### PR TITLE
fix(tw4): repair max-w-{named} site-wide — migrate named spacing → v4 numeric

### DIFF
--- a/frontend/app/components/admin/DashboardDesignTab.tsx
+++ b/frontend/app/components/admin/DashboardDesignTab.tsx
@@ -208,7 +208,7 @@ export function DashboardDesignTab() {
             <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
               <p className="text-sm text-blue-800 font-medium mb-1">Astuce</p>
               <p className="text-xs text-blue-700">
-                Utilisez les tokens sémantiques (p-md, bg-primary-500) plutôt
+                Utilisez les tokens sémantiques (p-4, bg-primary-500) plutôt
                 que des valeurs hardcodées
               </p>
             </div>
@@ -295,43 +295,43 @@ export function DashboardDesignTab() {
             {
               name: "XS",
               value: "4px",
-              class: "p-xs",
+              class: "p-1",
               usage: "Micro-espaces (badges)",
             },
             {
               name: "SM",
               value: "8px",
-              class: "p-sm",
+              class: "p-2",
               usage: "Serré (label → input)",
             },
             {
               name: "MD",
               value: "16px",
-              class: "p-md",
+              class: "p-4",
               usage: "Standard (padding cartes)",
             },
             {
               name: "LG",
               value: "24px",
-              class: "p-lg",
+              class: "p-6",
               usage: "Sections/blocs",
             },
             {
               name: "XL",
               value: "32px",
-              class: "p-xl",
+              class: "p-8",
               usage: "Grilles/marges",
             },
             {
               name: "2XL",
               value: "40px",
-              class: "p-2xl",
+              class: "p-10",
               usage: "Large grilles",
             },
             {
               name: "3XL",
               value: "48px",
-              class: "p-3xl",
+              class: "p-12",
               usage: "Hero sections",
             },
           ].map((spacing, index) => (

--- a/frontend/app/components/ecommerce/AdvancedFilters.tsx
+++ b/frontend/app/components/ecommerce/AdvancedFilters.tsx
@@ -240,9 +240,9 @@ export function AdvancedFilters({
         HEADER (Titre + Toggle Mobile + Compteur)
         ═════════════════════════════════════════════════════════════════════
       */}
-      <div className="flex items-center justify-between p-md border-b border-neutral-200">
+      <div className="flex items-center justify-between p-4 border-b border-neutral-200">
         {/* Titre */}
-        <div className="flex items-center gap-sm">
+        <div className="flex items-center gap-2">
           <svg
             className="w-5 h-5 text-secondary-500"
             fill="none"
@@ -262,14 +262,14 @@ export function AdvancedFilters({
 
           {/* Badge compteur filtres actifs */}
           {hasActiveFilters && (
-            <span className="bg-primary-500 text-white px-sm py-xs rounded-full font-mono text-xs font-bold">
+            <span className="bg-primary-500 text-white px-2 py-1 rounded-full font-mono text-xs font-bold">
               {activeTags.length}
             </span>
           )}
         </div>
 
         {/* Actions */}
-        <div className="flex items-center gap-sm">
+        <div className="flex items-center gap-2">
           {/* Compteur résultats */}
           {resultCount > 0 && (
             <span className="font-sans text-sm text-neutral-600">
@@ -314,8 +314,8 @@ export function AdvancedFilters({
         • Toujours visible (même si collapsed)
       */}
       {hasActiveFilters && (
-        <div className="p-md border-b border-neutral-200 bg-neutral-50">
-          <div className="flex flex-wrap items-center gap-xs">
+        <div className="p-4 border-b border-neutral-200 bg-neutral-50">
+          <div className="flex flex-wrap items-center gap-1">
             <span className="font-sans text-xs text-neutral-600 font-semibold">
               Filtres actifs:
             </span>
@@ -325,10 +325,10 @@ export function AdvancedFilters({
                 <button
                   onClick={() => handleRemoveTag(tag.key)}
                   className="
-                    inline-flex items-center gap-xs
+                    inline-flex items-center gap-1
                     bg-primary-500 hover:bg-primary-600
                     text-white
-                    px-sm py-xs
+                    px-2 py-1
                     font-sans text-xs font-semibold
                     rounded
                     transition-colors
@@ -351,7 +351,7 @@ export function AdvancedFilters({
                   </svg>
                 </button>
                 {index < activeTags.length - 1 && (
-                  <span className="mx-xs text-neutral-400">•</span>
+                  <span className="mx-1 text-neutral-400">•</span>
                 )}
               </span>
             ))}
@@ -365,7 +365,7 @@ export function AdvancedFilters({
         ═════════════════════════════════════════════════════════════════════
       */}
       <div className={`${isCollapsed ? "hidden lg:block" : "block"}`}>
-        <div className="p-md space-y-lg">
+        <div className="p-4 space-y-6">
           {/* 
             ─────────────────────────────────────────────────────────────────
             Section: Véhicule
@@ -373,7 +373,7 @@ export function AdvancedFilters({
           */}
           {showVehicleFilters && (
             <section>
-              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-sm flex items-center gap-xs">
+              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-2 flex items-center gap-1">
                 <svg
                   className="w-4 h-4 text-secondary-500"
                   fill="none"
@@ -390,10 +390,10 @@ export function AdvancedFilters({
                 Véhicule
               </h3>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-sm">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                 {/* Marque */}
                 <div>
-                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                     Marque
                   </label>
                   <Select
@@ -413,7 +413,7 @@ export function AdvancedFilters({
 
                 {/* Modèle */}
                 <div>
-                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                     Modèle
                   </label>
                   <Input
@@ -428,7 +428,7 @@ export function AdvancedFilters({
 
                 {/* Année */}
                 <div>
-                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                     Année
                   </label>
                   <Input
@@ -449,7 +449,7 @@ export function AdvancedFilters({
 
                 {/* Moteur */}
                 <div>
-                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                     Moteur
                   </label>
                   <Input
@@ -472,7 +472,7 @@ export function AdvancedFilters({
             ─────────────────────────────────────────────────────────────────
           */}
           <section>
-            <h3 className="font-heading text-sm font-bold text-neutral-900 mb-sm flex items-center gap-xs">
+            <h3 className="font-heading text-sm font-bold text-neutral-900 mb-2 flex items-center gap-1">
               <svg
                 className="w-4 h-4 text-secondary-500"
                 fill="none"
@@ -489,10 +489,10 @@ export function AdvancedFilters({
               Produit
             </h3>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-sm">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
               {/* Catégorie */}
               <div>
-                <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                   Catégorie
                 </label>
                 <Select
@@ -512,7 +512,7 @@ export function AdvancedFilters({
 
               {/* Référence OEM */}
               <div>
-                <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                   Référence OEM
                 </label>
                 <Input
@@ -535,7 +535,7 @@ export function AdvancedFilters({
           */}
           {showPriceFilter && (
             <section>
-              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-sm flex items-center gap-xs">
+              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-2 flex items-center gap-1">
                 <svg
                   className="w-4 h-4 text-secondary-500"
                   fill="none"
@@ -552,10 +552,10 @@ export function AdvancedFilters({
                 Prix (€)
               </h3>
 
-              <div className="grid grid-cols-2 gap-sm">
+              <div className="grid grid-cols-2 gap-2">
                 {/* Prix min */}
                 <div>
-                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                     Minimum
                   </label>
                   <Input
@@ -576,7 +576,7 @@ export function AdvancedFilters({
 
                 {/* Prix max */}
                 <div>
-                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-xs">
+                  <label className="block font-sans text-xs font-semibold text-neutral-700 mb-1">
                     Maximum
                   </label>
                   <Input
@@ -605,11 +605,11 @@ export function AdvancedFilters({
           */}
           {showStockFilter && (
             <section>
-              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-sm">
+              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-2">
                 Options
               </h3>
 
-              <div className="space-y-sm">
+              <div className="space-y-2">
                 {/* Stock uniquement */}
                 <Checkbox
                   checked={localValues.inStockOnly || false}
@@ -639,10 +639,10 @@ export function AdvancedFilters({
           FOOTER (Boutons Appliquer + Reset)
           ═════════════════════════════════════════════════════════════════
         */}
-        <div className="border-t border-neutral-200 p-md bg-neutral-50">
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-sm">
+        <div className="border-t border-neutral-200 p-4 bg-neutral-50">
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
             {/* Bouton Appliquer (Primary) */}
-            <Button onClick={handleApply} className="flex-1 gap-sm">
+            <Button onClick={handleApply} className="flex-1 gap-2">
               <svg
                 className="w-5 h-5"
                 fill="none"
@@ -658,7 +658,7 @@ export function AdvancedFilters({
               </svg>
               <span>Appliquer les filtres</span>
               {hasActiveFilters && (
-                <span className="bg-primary-foreground/20 px-xs py-xs rounded-full font-mono text-xs">
+                <span className="bg-primary-foreground/20 px-1 py-1 rounded-full font-mono text-xs">
                   {activeTags.length}
                 </span>
               )}
@@ -669,7 +669,7 @@ export function AdvancedFilters({
               <Button
                 variant="outline"
                 onClick={handleReset}
-                className="gap-sm"
+                className="gap-2"
               >
                 <svg
                   className="w-5 h-5"

--- a/frontend/app/components/ecommerce/ProductCard.tsx
+++ b/frontend/app/components/ecommerce/ProductCard.tsx
@@ -146,7 +146,7 @@ export const ProductCard = memo(function ProductCard({
         bg-white rounded-lg shadow-md border border-neutral-200
         hover:shadow-xl hover:border-neutral-300
         transition-all duration-300
-        ${compactMode ? "p-sm" : "p-md"}
+        ${compactMode ? "p-2" : "p-4"}
         relative
         group
       `}
@@ -163,7 +163,7 @@ export const ProductCard = memo(function ProductCard({
       <div
         className={`
           relative 
-          ${compactMode ? "aspect-square mb-sm" : "aspect-[4/3] mb-md"}
+          ${compactMode ? "aspect-square mb-2" : "aspect-[4/3] mb-4"}
           overflow-hidden rounded-lg
           bg-neutral-50
           cursor-pointer
@@ -194,11 +194,11 @@ export const ProductCard = memo(function ProductCard({
           • font-heading → Impact
         */}
         {calculatedDiscount > 0 && (
-          <div className="absolute top-xs left-xs">
+          <div className="absolute top-1 left-1">
             <span
               className="
               bg-error-500 text-white
-              px-sm py-xs
+              px-2 py-1
               font-heading text-sm font-bold
               rounded
               shadow-md
@@ -214,15 +214,15 @@ export const ProductCard = memo(function ProductCard({
           • Position: top-right
           • Couleur dynamique selon status
         */}
-        <div className="absolute top-xs right-xs">
+        <div className="absolute top-1 right-1">
           <span
             className={`
             ${stockBadge.color} ${stockBadge.textColor}
-            px-sm py-xs
+            px-2 py-1
             font-sans text-xs font-semibold
             rounded
             shadow-md
-            flex items-center gap-xs
+            flex items-center gap-1
           `}
           >
             <span>{stockBadge.icon}</span>
@@ -236,12 +236,12 @@ export const ProductCard = memo(function ProductCard({
           • Success = compatible, Error = incompatible
         */}
         {showCompatibility && isCompatible !== undefined && (
-          <div className="absolute bottom-xs left-xs">
+          <div className="absolute bottom-1 left-1">
             <span
               className={`
               ${isCompatible ? "bg-success-500" : "bg-error-500"}
               text-white
-              px-sm py-xs
+              px-2 py-1
               font-sans text-xs font-semibold
               rounded
               shadow-md
@@ -268,7 +268,7 @@ export const ProductCard = memo(function ProductCard({
         CONTENT SECTION
         ═════════════════════════════════════════════════════════════════════
       */}
-      <div className={compactMode ? "space-y-xs" : "space-y-sm"}>
+      <div className={compactMode ? "space-y-1" : "space-y-2"}>
         {/* 
           Référence OEM (Roboto Mono)
           • font-mono → Précision technique
@@ -280,7 +280,7 @@ export const ProductCard = memo(function ProductCard({
             className="
             font-mono text-xs text-neutral-600
             bg-neutral-100
-            px-xs py-xs
+            px-1 py-1
             rounded
             inline-block
           "
@@ -345,10 +345,10 @@ export const ProductCard = memo(function ProductCard({
           • Prix original barré si remise
           • Économie calculée affichée
         */}
-        <div className={compactMode ? "mt-sm" : "mt-md"}>
+        <div className={compactMode ? "mt-2" : "mt-4"}>
           {/* Prix barré (si remise) */}
           {originalPrice && originalPrice > price && (
-            <div className="flex items-center gap-xs mb-xs">
+            <div className="flex items-center gap-1 mb-1">
               <span
                 className="
                 font-mono text-sm text-neutral-400
@@ -378,7 +378,7 @@ export const ProductCard = memo(function ProductCard({
           </div>
 
           {/* TVA indication */}
-          <p className="font-sans text-xs text-neutral-500 mt-xs">
+          <p className="font-sans text-xs text-neutral-500 mt-1">
             TTC • Livraison gratuite dès 50€
           </p>
         </div>
@@ -398,7 +398,7 @@ export const ProductCard = memo(function ProductCard({
           disabled={stockStatus === "out-of-stock" || isAddingToCart}
           className={`
             w-full
-            ${compactMode ? "py-sm px-md" : "py-md px-lg"}
+            ${compactMode ? "py-2 px-4" : "py-4 px-6"}
             ${
               stockStatus === "out-of-stock"
                 ? "bg-neutral-300 cursor-not-allowed"
@@ -412,7 +412,7 @@ export const ProductCard = memo(function ProductCard({
             rounded-lg
             shadow-md hover:shadow-lg
             transition-all duration-200
-            flex items-center justify-center gap-sm
+            flex items-center justify-center gap-2
           `}
         >
           {isAddingToCart ? (
@@ -473,10 +473,10 @@ export const ProductCard = memo(function ProductCard({
             font-sans text-xs text-warning-700
             bg-warning-50
             border border-warning-200
-            px-sm py-xs
+            px-2 py-1
             rounded
             text-center
-            mt-xs
+            mt-1
           "
           >
             ⚠ Dernières pièces disponibles

--- a/frontend/app/components/ecommerce/QuickCartDrawer.tsx
+++ b/frontend/app/components/ecommerce/QuickCartDrawer.tsx
@@ -231,7 +231,7 @@ export function QuickCartDrawer({
         aria-labelledby="cart-drawer-title"
       >
         {/* Header */}
-        <div className="bg-neutral-900 text-white px-md py-md flex items-center justify-between">
+        <div className="bg-neutral-900 text-white px-4 py-4 flex items-center justify-between">
           <div>
             <h2
               id="cart-drawer-title"
@@ -239,14 +239,14 @@ export function QuickCartDrawer({
             >
               Mon Panier
             </h2>
-            <p className="font-sans text-sm text-neutral-300 mt-xs">
+            <p className="font-sans text-sm text-neutral-300 mt-1">
               {itemCount} {itemCount > 1 ? "articles" : "article"}
             </p>
           </div>
 
           <button
             onClick={handleClose}
-            className="p-sm hover:bg-neutral-800 rounded-lg transition-colors"
+            className="p-2 hover:bg-neutral-800 rounded-lg transition-colors"
             aria-label="Fermer le panier"
           >
             <svg
@@ -267,7 +267,7 @@ export function QuickCartDrawer({
 
         {/* Alerte véhicule configuré */}
         {savedVehicle && (
-          <div className="bg-success-50 border-b border-success-200 px-md py-sm">
+          <div className="bg-success-50 border-b border-success-200 px-4 py-2">
             <p className="font-sans text-xs text-success-800">
               <strong className="font-heading">✓ Véhicule:</strong>{" "}
               {savedVehicle.brand} {savedVehicle.model} {savedVehicle.engine} (
@@ -278,7 +278,7 @@ export function QuickCartDrawer({
 
         {/* Alerte incompatibilités */}
         {hasIncompatibleItems && (
-          <div className="bg-error-50 border-b border-error-200 px-md py-sm">
+          <div className="bg-error-50 border-b border-error-200 px-4 py-2">
             <p className="font-sans text-xs text-error-800">
               <strong className="font-heading">⚠ Attention:</strong>{" "}
               {incompatibleCount}{" "}
@@ -291,11 +291,11 @@ export function QuickCartDrawer({
         )}
 
         {/* Liste produits (scrollable) */}
-        <div className="flex-1 overflow-y-auto px-md py-md">
+        <div className="flex-1 overflow-y-auto px-4 py-4">
           {items.length === 0 ? (
-            <div className="text-center py-2xl">
-              <div className="text-6xl mb-md">🛒</div>
-              <p className="font-heading text-lg font-bold text-neutral-900 mb-sm">
+            <div className="text-center py-10">
+              <div className="text-6xl mb-4">🛒</div>
+              <p className="font-heading text-lg font-bold text-neutral-900 mb-2">
                 Votre panier est vide
               </p>
               <p className="font-sans text-sm text-neutral-600">
@@ -303,16 +303,16 @@ export function QuickCartDrawer({
               </p>
             </div>
           ) : (
-            <div className="space-y-md">
+            <div className="space-y-4">
               {items.map((item) => (
                 <div
                   key={item.id}
                   className={`
-                    bg-neutral-50 rounded-lg p-sm border-2 transition-colors
+                    bg-neutral-50 rounded-lg p-2 border-2 transition-colors
                     ${item.isCompatible ? "border-success-200" : "border-error-200"}
                   `}
                 >
-                  <div className="flex gap-sm">
+                  <div className="flex gap-2">
                     {/* Image */}
                     <img
                       src={item.imageUrl}
@@ -323,31 +323,31 @@ export function QuickCartDrawer({
                     {/* Infos */}
                     <div className="flex-1 min-w-0">
                       {/* Nom + Badge compatibilité */}
-                      <div className="flex items-start justify-between gap-xs mb-xs">
+                      <div className="flex items-start justify-between gap-1 mb-1">
                         <h3 className="font-heading text-sm font-bold text-neutral-900 line-clamp-2">
                           {item.name}
                         </h3>
 
                         {item.isCompatible ? (
-                          <span className="px-xs py-xs bg-success-500 text-white text-xs font-heading font-semibold rounded whitespace-nowrap">
+                          <span className="px-1 py-1 bg-success-500 text-white text-xs font-heading font-semibold rounded whitespace-nowrap">
                             ✓ OK
                           </span>
                         ) : (
-                          <span className="px-xs py-xs bg-error-500 text-white text-xs font-heading font-semibold rounded whitespace-nowrap">
+                          <span className="px-1 py-1 bg-error-500 text-white text-xs font-heading font-semibold rounded whitespace-nowrap">
                             ⚠ Non
                           </span>
                         )}
                       </div>
 
                       {/* Réf OEM */}
-                      <p className="font-mono text-xs text-neutral-600 mb-sm">
+                      <p className="font-mono text-xs text-neutral-600 mb-2">
                         Réf. {item.oemRef}
                       </p>
 
                       {/* Prix + Quantité */}
                       <div className="flex items-center justify-between">
                         {/* Quantité */}
-                        <div className="flex items-center gap-xs">
+                        <div className="flex items-center gap-1">
                           <button
                             onClick={() =>
                               handleDecrement(item.id, item.quantity)
@@ -393,7 +393,7 @@ export function QuickCartDrawer({
                   {/* Bouton supprimer */}
                   <button
                     onClick={() => onRemoveItem(item.id)}
-                    className="w-full mt-sm px-sm py-xs bg-neutral-200 hover:bg-error-100 text-neutral-700 hover:text-error-700 rounded-lg font-sans text-xs font-semibold transition-colors"
+                    className="w-full mt-2 px-2 py-1 bg-neutral-200 hover:bg-error-100 text-neutral-700 hover:text-error-700 rounded-lg font-sans text-xs font-semibold transition-colors"
                   >
                     Supprimer
                   </button>
@@ -405,10 +405,10 @@ export function QuickCartDrawer({
 
         {/* Footer (toujours visible) */}
         {items.length > 0 && (
-          <div className="border-t border-neutral-200 bg-white px-md py-md space-y-md">
+          <div className="border-t border-neutral-200 bg-white px-4 py-4 space-y-4">
             {/* 🚚 Barre de progression livraison gratuite */}
             {!isFreeShipping && (
-              <div className="bg-secondary-50 rounded-lg p-sm space-y-xs">
+              <div className="bg-secondary-50 rounded-lg p-2 space-y-1">
                 <div className="flex items-center justify-between text-xs">
                   <span className="font-heading font-bold text-secondary-700">
                     🚚 Livraison gratuite dès 50€
@@ -427,7 +427,7 @@ export function QuickCartDrawer({
             )}
 
             {isFreeShipping && selectedDeliveryId === "standard" && (
-              <div className="bg-success-50 border-2 border-success-500 rounded-lg p-sm">
+              <div className="bg-success-50 border-2 border-success-500 rounded-lg p-2">
                 <p className="font-heading text-sm font-bold text-success-700 text-center">
                   ✅ Livraison gratuite débloquée !
                 </p>
@@ -436,15 +436,15 @@ export function QuickCartDrawer({
 
             {/* Options livraison */}
             <div>
-              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-sm">
+              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-2">
                 Livraison
               </h3>
-              <div className="space-y-xs">
+              <div className="space-y-1">
                 {deliveryOptions.map((option) => (
                   <label
                     key={option.id}
                     className={`
-                      flex items-center justify-between p-sm rounded-lg cursor-pointer transition-colors
+                      flex items-center justify-between p-2 rounded-lg cursor-pointer transition-colors
                       ${
                         selectedDeliveryId === option.id
                           ? "bg-secondary-50 border-2 border-secondary-500"
@@ -452,7 +452,7 @@ export function QuickCartDrawer({
                       }
                     `}
                   >
-                    <div className="flex items-center gap-sm">
+                    <div className="flex items-center gap-2">
                       <input
                         type="radio"
                         name="delivery"
@@ -491,7 +491,7 @@ export function QuickCartDrawer({
             </div>
 
             {/* Résumé prix */}
-            <div className="space-y-xs">
+            <div className="space-y-1">
               {/* Sous-total */}
               <div className="flex items-center justify-between font-sans text-sm">
                 <span className="text-neutral-600">
@@ -513,7 +513,7 @@ export function QuickCartDrawer({
               </div>
 
               {/* Total */}
-              <div className="flex items-center justify-between pt-sm border-t border-neutral-300">
+              <div className="flex items-center justify-between pt-2 border-t border-neutral-300">
                 <span className="font-heading text-lg font-bold text-neutral-900">
                   Total
                 </span>
@@ -524,19 +524,19 @@ export function QuickCartDrawer({
             </div>
 
             {/* 🎁 Produits recommandés */}
-            <div className="mt-md">
-              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-sm">
+            <div className="mt-4">
+              <h3 className="font-heading text-sm font-bold text-neutral-900 mb-2">
                 Vous aimerez aussi
               </h3>
-              <div className="grid grid-cols-3 gap-xs">
+              <div className="grid grid-cols-3 gap-1">
                 {/* Placeholder - Les vraies données viennent de l'API */}
                 {[1, 2, 3].map((i) => (
                   <div
                     key={i}
-                    className="bg-neutral-50 rounded p-xs border border-neutral-200 hover:border-primary-300 cursor-pointer transition-colors"
+                    className="bg-neutral-50 rounded p-1 border border-neutral-200 hover:border-primary-300 cursor-pointer transition-colors"
                   >
-                    <div className="aspect-square bg-neutral-200 rounded mb-xs" />
-                    <p className="text-xs font-semibold text-neutral-900 line-clamp-2 mb-xs">
+                    <div className="aspect-square bg-neutral-200 rounded mb-1" />
+                    <p className="text-xs font-semibold text-neutral-900 line-clamp-2 mb-1">
                       Produit {i}
                     </p>
                     <p className="text-xs font-mono font-bold text-primary-600">
@@ -550,7 +550,7 @@ export function QuickCartDrawer({
             {/* CTA Commander */}
             <button
               onClick={handleCheckout}
-              className="w-full py-md bg-primary-500 hover:bg-primary-600 text-white rounded-lg font-heading text-base font-bold transition-colors shadow-lg hover:shadow-xl"
+              className="w-full py-4 bg-primary-500 hover:bg-primary-600 text-white rounded-lg font-heading text-base font-bold transition-colors shadow-lg hover:shadow-xl"
             >
               Commander
             </button>
@@ -558,7 +558,7 @@ export function QuickCartDrawer({
             {/* Continuer shopping */}
             <button
               onClick={handleClose}
-              className="w-full py-sm text-neutral-600 hover:text-neutral-900 font-sans text-sm font-semibold transition-colors"
+              className="w-full py-2 text-neutral-600 hover:text-neutral-900 font-sans text-sm font-semibold transition-colors"
             >
               Continuer mes achats
             </button>

--- a/frontend/app/components/ecommerce/SmartHeader.tsx
+++ b/frontend/app/components/ecommerce/SmartHeader.tsx
@@ -81,30 +81,30 @@ export function SmartHeader({
         ═════════════════════════════════════════════════════════════════════
         • bg-secondary-500 → Navigation (Bleu acier)
         • Sticky avec shadow au scroll
-        • py-sm/md → Espacement vertical adaptatif
+        • py-2/md → Espacement vertical adaptatif
       */}
       <header
         className={`
           fixed top-0 left-0 right-0 z-50
           bg-secondary-500 text-white
           transition-all duration-300
-          ${isSticky ? "shadow-lg py-sm" : "py-md"}
+          ${isSticky ? "shadow-lg py-2" : "py-4"}
         `}
       >
-        <div className="max-w-7xl mx-auto px-md">
+        <div className="max-w-7xl mx-auto px-4">
           {/* 
             ─────────────────────────────────────────────────────────────────
             Top Bar - Desktop
             ─────────────────────────────────────────────────────────────────
           */}
-          <div className="hidden lg:flex items-center justify-between gap-lg">
+          <div className="hidden lg:flex items-center justify-between gap-6">
             {/* 
               Logo + Nom (font-heading)
-              • gap-sm → Espacement serré entre logo et texte
+              • gap-2 → Espacement serré entre logo et texte
             */}
             <a
               href="/"
-              className="flex items-center gap-sm hover:opacity-90 transition-opacity"
+              className="flex items-center gap-2 hover:opacity-90 transition-opacity"
             >
               <BrandLogo src={logoUrl} alt={companyName} className="h-8 w-8" />
               <span className="font-heading text-xl font-bold">
@@ -116,7 +116,7 @@ export function SmartHeader({
               Recherche Centrale Intelligente
               • Largeur maximale pour visibilité
               • border-secondary-400 → Contraste subtil
-              • p-sm → Padding serré input
+              • p-2 → Padding serré input
             */}
             <form onSubmit={handleSearch} className="flex-1 max-w-2xl">
               <div className="relative">
@@ -126,7 +126,7 @@ export function SmartHeader({
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Recherche par marque, modèle, moteur, référence..."
                   className="
-                    w-full py-sm px-md
+                    w-full py-2 px-4
                     bg-secondary-600 border border-secondary-400
                     text-white placeholder-secondary-200
                     font-sans text-sm
@@ -140,8 +140,8 @@ export function SmartHeader({
                 <button
                   type="submit"
                   className="
-                    absolute right-xs top-1/2 -translate-y-1/2
-                    p-sm
+                    absolute right-1 top-1/2 -translate-y-1/2
+                    p-2
                     text-secondary-200 hover:text-white
                     transition-colors
                   "
@@ -165,9 +165,9 @@ export function SmartHeader({
 
               {/* 
                 Suggestions rapides
-                • gap-xs → Micro-espacement entre badges
+                • gap-1 → Micro-espacement entre badges
               */}
-              <div className="flex items-center gap-xs mt-xs">
+              <div className="flex items-center gap-1 mt-1">
                 <span className="font-sans text-xs text-secondary-200">
                   Recherches fréquentes:
                 </span>
@@ -181,7 +181,7 @@ export function SmartHeader({
                         onSearch?.(term);
                       }}
                       className="
-                      px-xs py-xs
+                      px-1 py-1
                       bg-secondary-600 hover:bg-secondary-500
                       text-secondary-100 hover:text-white
                       font-sans text-xs
@@ -202,14 +202,14 @@ export function SmartHeader({
               ═════════════════════════════════════════════════════════════
               • bg-primary-500 → CTA Action
               • font-heading → Outfit (robustesse)
-              • p-sm → Padding compact pour header
+              • p-2 → Padding compact pour header
               • Affiche véhicule mémorisé si présent
             */}
             <button
               onClick={() => setIsVehicleModalOpen(true)}
               className="
-                flex items-center gap-sm
-                px-md py-sm
+                flex items-center gap-2
+                px-4 py-2
                 bg-primary-500 hover:bg-primary-600
                 text-white
                 font-heading font-semibold text-sm
@@ -251,14 +251,14 @@ export function SmartHeader({
 
             {/* 
               Actions secondaires
-              • gap-sm → Espacement serré entre icônes
+              • gap-2 → Espacement serré entre icônes
             */}
-            <div className="flex items-center gap-sm">
+            <div className="flex items-center gap-2">
               {/* Compte */}
               <a
                 href="/account"
                 className="
-                  p-sm
+                  p-2
                   text-secondary-100 hover:text-white
                   transition-colors
                 "
@@ -284,7 +284,7 @@ export function SmartHeader({
                 href="/cart"
                 className="
                   relative
-                  p-sm
+                  p-2
                   text-secondary-100 hover:text-white
                   transition-colors
                 "
@@ -308,8 +308,8 @@ export function SmartHeader({
                 {cartItemCount > 0 && (
                   <span
                     className="
-                    absolute -top-xs -right-xs
-                    px-xs py-xs
+                    absolute -top-1 -right-1
+                    px-1 py-1
                     min-w-[20px]
                     bg-primary-500
                     text-white
@@ -334,7 +334,7 @@ export function SmartHeader({
             {/* Menu burger */}
             <button
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="p-sm text-white"
+              className="p-2 text-white"
               aria-label="Menu"
             >
               <svg
@@ -353,7 +353,7 @@ export function SmartHeader({
             </button>
 
             {/* Logo mobile */}
-            <a href="/" className="flex items-center gap-xs">
+            <a href="/" className="flex items-center gap-1">
               <BrandLogo src={logoUrl} alt={companyName} className="h-6 w-6" />
               <span className="font-heading text-lg font-bold">
                 {companyName}
@@ -361,10 +361,10 @@ export function SmartHeader({
             </a>
 
             {/* Actions mobile */}
-            <div className="flex items-center gap-xs">
+            <div className="flex items-center gap-1">
               <button
                 onClick={() => setIsVehicleModalOpen(true)}
-                className="p-sm text-white"
+                className="p-2 text-white"
                 aria-label="Mon véhicule"
               >
                 <svg
@@ -382,7 +382,7 @@ export function SmartHeader({
                 </svg>
               </button>
 
-              <a href="/cart" className="relative p-sm text-white">
+              <a href="/cart" className="relative p-2 text-white">
                 <svg
                   className="w-6 h-6"
                   fill="none"
@@ -397,7 +397,7 @@ export function SmartHeader({
                   />
                 </svg>
                 {cartItemCount > 0 && (
-                  <span className="absolute -top-xs -right-xs px-xs min-w-[16px] bg-primary-500 text-white font-mono text-xs rounded-full flex items-center justify-center">
+                  <span className="absolute -top-1 -right-1 px-1 min-w-[16px] bg-primary-500 text-white font-mono text-xs rounded-full flex items-center justify-center">
                     {cartItemCount}
                   </span>
                 )}
@@ -406,14 +406,14 @@ export function SmartHeader({
           </div>
 
           {/* Recherche mobile (sous le header) */}
-          <form onSubmit={handleSearch} className="lg:hidden mt-sm">
+          <form onSubmit={handleSearch} className="lg:hidden mt-2">
             <input
               type="search"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Recherche..."
               className="
-                w-full py-sm px-sm
+                w-full py-2 px-2
                 bg-secondary-600 border border-secondary-400
                 text-white placeholder-secondary-200
                 font-sans text-sm
@@ -428,12 +428,12 @@ export function SmartHeader({
           Navigation Secondaire (Categories)
           ═════════════════════════════════════════════════════════════════
           • bg-secondary-600 → Nuance plus foncée
-          • gap-lg → Espacement sections
+          • gap-6 → Espacement sections
         */}
         {!isSticky && (
-          <nav className="hidden lg:block bg-secondary-600 mt-sm">
-            <div className="max-w-7xl mx-auto px-md py-sm">
-              <ul className="flex items-center gap-lg font-sans text-sm">
+          <nav className="hidden lg:block bg-secondary-600 mt-2">
+            <div className="max-w-7xl mx-auto px-4 py-2">
+              <ul className="flex items-center gap-6 font-sans text-sm">
                 {[
                   "Freinage",
                   "Filtration",
@@ -472,16 +472,16 @@ export function SmartHeader({
           onClick={() => setIsMobileMenuOpen(false)}
         >
           <div
-            className="absolute left-0 top-0 bottom-0 w-80 bg-white p-lg"
+            className="absolute left-0 top-0 bottom-0 w-80 bg-white p-6"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center justify-between mb-lg">
+            <div className="flex items-center justify-between mb-6">
               <h2 className="font-heading text-xl font-bold text-neutral-900">
                 Menu
               </h2>
               <button
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="p-sm"
+                className="p-2"
               >
                 <svg
                   className="w-6 h-6"
@@ -500,7 +500,7 @@ export function SmartHeader({
             </div>
 
             <nav>
-              <ul className="space-y-sm font-sans">
+              <ul className="space-y-2 font-sans">
                 {[
                   "Freinage",
                   "Filtration",
@@ -513,7 +513,7 @@ export function SmartHeader({
                   <li key={category}>
                     <a
                       href={`/category/${category.toLowerCase()}`}
-                      className="block py-sm px-md text-neutral-700 hover:bg-neutral-100 rounded-md transition-colors"
+                      className="block py-2 px-4 text-neutral-700 hover:bg-neutral-100 rounded-md transition-colors"
                     >
                       {category}
                     </a>
@@ -533,22 +533,22 @@ export function SmartHeader({
       */}
       {isVehicleModalOpen && (
         <div
-          className="fixed inset-0 z-50 bg-neutral-900/50 flex items-center justify-center p-md"
+          className="fixed inset-0 z-50 bg-neutral-900/50 flex items-center justify-center p-4"
           onClick={() => setIsVehicleModalOpen(false)}
         >
           <div
-            className="bg-white rounded-lg p-xl max-w-2xl w-full"
+            className="bg-white rounded-lg p-8 max-w-2xl w-full"
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="font-heading text-2xl font-bold text-neutral-900 mb-lg">
+            <h2 className="font-heading text-2xl font-bold text-neutral-900 mb-6">
               Sélectionnez votre véhicule
             </h2>
-            <p className="font-sans text-neutral-600 mb-lg">
+            <p className="font-sans text-neutral-600 mb-6">
               Formulaire à implémenter : Marque → Modèle → Moteur → Année
             </p>
             <button
               onClick={() => setIsVehicleModalOpen(false)}
-              className="px-lg py-sm bg-neutral-200 hover:bg-neutral-300 rounded-lg font-heading transition-colors"
+              className="px-6 py-2 bg-neutral-200 hover:bg-neutral-300 rounded-lg font-heading transition-colors"
             >
               Fermer
             </button>

--- a/frontend/app/components/ecommerce/TrustPage.tsx
+++ b/frontend/app/components/ecommerce/TrustPage.tsx
@@ -8,7 +8,7 @@
  * 
  * Design System: Primary (CTA), Success (badges verts), Secondary (liens), Neutral (backgrounds)
  * Typographie: font-heading (titres), font-sans (body), font-mono (dates/refs)
- * Espacement: 8px grid (gap-md sections, p-lg cards)
+ * Espacement: 8px grid (gap-4 sections, p-6 cards)
  */
 
 import React from 'react';
@@ -262,28 +262,28 @@ export const TrustPage: React.FC<TrustPageProps> = ({
   onViewAllReviews,
 }) => {
   return (
-    <div className="w-full space-y-2xl">
+    <div className="w-full space-y-10">
       {/* Section Logos Équipementiers */}
       {showSections.partners && (
-        <section className="w-full bg-neutral-50 py-2xl">
-          <div className="container mx-auto px-md">
-            <h2 className="font-heading text-3xl text-neutral-900 text-center mb-xl">
+        <section className="w-full bg-neutral-50 py-10">
+          <div className="container mx-auto px-4">
+            <h2 className="font-heading text-3xl text-neutral-900 text-center mb-8">
               {partnersTitle}
             </h2>
-            <p className="font-sans text-neutral-600 text-center mb-2xl max-w-2xl mx-auto">
+            <p className="font-sans text-neutral-600 text-center mb-10 max-w-2xl mx-auto">
               Nous travaillons avec les plus grands équipementiers automobiles pour vous garantir
               des pièces de qualité d'origine constructeur.
             </p>
 
             {/* Grid logos */}
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-lg">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-6">
               {partnerBrands.map((brand) => (
                 <div
                   key={brand.id}
-                  className="bg-white p-lg rounded-lg border border-neutral-200 hover:border-secondary-500 hover:shadow-md transition-all duration-300 flex flex-col items-center justify-center group"
+                  className="bg-white p-6 rounded-lg border border-neutral-200 hover:border-secondary-500 hover:shadow-md transition-all duration-300 flex flex-col items-center justify-center group"
                 >
                   {/* Placeholder logo (à remplacer par une vraie image en production) */}
-                  <div className="w-full h-20 flex items-center justify-center mb-sm">
+                  <div className="w-full h-20 flex items-center justify-center mb-2">
                     <div className="font-heading text-xl text-neutral-700 group-hover:text-secondary-500 transition-colors">
                       {brand.name}
                     </div>
@@ -302,14 +302,14 @@ export const TrustPage: React.FC<TrustPageProps> = ({
 
       {/* Section Badges Sécurité */}
       {showSections.security && (
-        <section className="w-full py-2xl">
-          <div className="container mx-auto px-md">
-            <h2 className="font-heading text-3xl text-neutral-900 text-center mb-xl">
+        <section className="w-full py-10">
+          <div className="container mx-auto px-4">
+            <h2 className="font-heading text-3xl text-neutral-900 text-center mb-8">
               {securityTitle}
             </h2>
 
             {/* Grid badges */}
-            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-lg">
+            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-6">
               {securityBadges.map((badge) => {
                 const bgColorClass =
                   badge.variant === 'success'
@@ -328,13 +328,13 @@ export const TrustPage: React.FC<TrustPageProps> = ({
                 return (
                   <div
                     key={badge.id}
-                    className={`${bgColorClass} border-2 rounded-lg p-lg flex flex-col items-center text-center hover:shadow-lg transition-shadow duration-300`}
+                    className={`${bgColorClass} border-2 rounded-lg p-6 flex flex-col items-center text-center hover:shadow-lg transition-shadow duration-300`}
                   >
                     {/* Icône */}
-                    <div className={`text-4xl mb-sm ${iconColorClass}`}>{badge.icon}</div>
+                    <div className={`text-4xl mb-2 ${iconColorClass}`}>{badge.icon}</div>
 
                     {/* Titre */}
-                    <h3 className="font-heading text-lg text-neutral-900 mb-xs">
+                    <h3 className="font-heading text-lg text-neutral-900 mb-1">
                       {badge.title}
                     </h3>
 
@@ -350,17 +350,17 @@ export const TrustPage: React.FC<TrustPageProps> = ({
 
       {/* Section Avis Clients avec Véhicule */}
       {showSections.reviews && (
-        <section className="w-full bg-neutral-50 py-2xl">
-          <div className="container mx-auto px-md">
-            <h2 className="font-heading text-3xl text-neutral-900 text-center mb-xl">
+        <section className="w-full bg-neutral-50 py-10">
+          <div className="container mx-auto px-4">
+            <h2 className="font-heading text-3xl text-neutral-900 text-center mb-8">
               {reviewsTitle}
             </h2>
-            <p className="font-sans text-neutral-600 text-center mb-2xl max-w-2xl mx-auto">
+            <p className="font-sans text-neutral-600 text-center mb-10 max-w-2xl mx-auto">
               Découvrez les retours d'expérience de nos clients sur leurs véhicules.
             </p>
 
             {/* Grid avis */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-lg mb-xl">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
               {customerReviews.map((review) => (
                 <CustomerReviewCard key={review.id} review={review} />
               ))}
@@ -371,7 +371,7 @@ export const TrustPage: React.FC<TrustPageProps> = ({
               <div className="text-center">
                 <button
                   onClick={onViewAllReviews}
-                  className="bg-secondary-500 hover:bg-secondary-600 text-white font-heading px-xl py-md rounded-lg transition-colors duration-200"
+                  className="bg-secondary-500 hover:bg-secondary-600 text-white font-heading px-8 py-4 rounded-lg transition-colors duration-200"
                 >
                   Voir tous les avis clients
                 </button>
@@ -393,9 +393,9 @@ export const TrustPage: React.FC<TrustPageProps> = ({
  */
 const CustomerReviewCard: React.FC<{ review: CustomerReview }> = ({ review }) => {
   return (
-    <div className="bg-white rounded-lg border border-neutral-200 p-lg hover:shadow-lg transition-shadow duration-300">
+    <div className="bg-white rounded-lg border border-neutral-200 p-6 hover:shadow-lg transition-shadow duration-300">
       {/* Header: Avatar + Nom + Date */}
-      <div className="flex items-start gap-sm mb-md">
+      <div className="flex items-start gap-2 mb-4">
         {/* Avatar */}
         <div className="w-12 h-12 rounded-full bg-neutral-200 flex items-center justify-center shrink-0 overflow-hidden">
           {review.customerPhoto ? (
@@ -413,10 +413,10 @@ const CustomerReviewCard: React.FC<{ review: CustomerReview }> = ({ review }) =>
 
         {/* Nom + Date */}
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-xs">
+          <div className="flex items-center gap-1">
             <h4 className="font-heading text-neutral-900">{review.customerName}</h4>
             {review.isVerified && (
-              <span className="bg-success-500 text-white text-xs px-xs py-0.5 rounded">
+              <span className="bg-success-500 text-white text-xs px-1 py-0.5 rounded">
                 ✓ Vérifié
               </span>
             )}
@@ -432,7 +432,7 @@ const CustomerReviewCard: React.FC<{ review: CustomerReview }> = ({ review }) =>
       </div>
 
       {/* Note étoiles */}
-      <div className="flex items-center gap-xs mb-md">
+      <div className="flex items-center gap-1 mb-4">
         {[1, 2, 3, 4, 5].map((star) => (
           <span
             key={star}
@@ -444,18 +444,18 @@ const CustomerReviewCard: React.FC<{ review: CustomerReview }> = ({ review }) =>
       </div>
 
       {/* Commentaire */}
-      <p className="font-sans text-neutral-700 mb-md leading-relaxed">{review.comment}</p>
+      <p className="font-sans text-neutral-700 mb-4 leading-relaxed">{review.comment}</p>
 
       {/* Véhicule */}
-      <div className="bg-secondary-50 border border-secondary-200 rounded-md p-sm">
-        <div className="flex items-center gap-xs mb-xs">
+      <div className="bg-secondary-50 border border-secondary-200 rounded-md p-2">
+        <div className="flex items-center gap-1 mb-1">
           <span className="text-secondary-500">🚗</span>
           <span className="font-heading text-sm text-secondary-700">Véhicule du client</span>
         </div>
         <p className="font-sans text-sm text-neutral-900">
           {review.vehicle.brand} {review.vehicle.model} ({review.vehicle.year})
           {review.vehicle.engine && (
-            <span className="font-mono text-xs text-neutral-600 ml-xs">
+            <span className="font-mono text-xs text-neutral-600 ml-1">
               · {review.vehicle.engine}
             </span>
           )}
@@ -464,7 +464,7 @@ const CustomerReviewCard: React.FC<{ review: CustomerReview }> = ({ review }) =>
 
       {/* Produit acheté (optionnel) */}
       {review.productName && (
-        <p className="font-sans text-xs text-neutral-500 mt-sm">
+        <p className="font-sans text-xs text-neutral-500 mt-2">
           Produit : <span className="text-neutral-700">{review.productName}</span>
         </p>
       )}

--- a/frontend/app/components/ecommerce/VehicleCompatibilityBanner.tsx
+++ b/frontend/app/components/ecommerce/VehicleCompatibilityBanner.tsx
@@ -12,7 +12,7 @@
  * 
  * Design System: Success (compatible), Error (incompatible), Secondary (boutons), Neutral (backgrounds)
  * Typographie: font-heading (véhicule), font-sans (message), font-mono (specs techniques)
- * Espacement: 8px grid (p-md, gap-sm)
+ * Espacement: 8px grid (p-4, gap-2)
  */
 
 import React from 'react';
@@ -80,7 +80,7 @@ export const VehicleCompatibilityBanner: React.FC<VehicleCompatibilityBannerProp
   const containerClasses = `
     w-full ${bgColorClass} text-white
     ${isSticky ? 'sticky z-40' : 'relative'}
-    ${compact ? 'py-sm px-md' : 'py-md px-md md:px-lg'}
+    ${compact ? 'py-2 px-4' : 'py-4 px-4 md:px-6'}
     transition-all duration-300 shadow-md
     ${className}
   `.trim();
@@ -90,9 +90,9 @@ export const VehicleCompatibilityBanner: React.FC<VehicleCompatibilityBannerProp
   return (
     <div className={containerClasses} style={stickyStyle}>
       <div className="max-w-7xl mx-auto">
-        <div className="flex items-center justify-between gap-md flex-wrap">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
           {/* Message principal */}
-          <div className="flex items-center gap-sm flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
             {/* Icône */}
             <span className="text-2xl shrink-0" aria-hidden="true">
               {iconEmoji}
@@ -108,7 +108,7 @@ export const VehicleCompatibilityBanner: React.FC<VehicleCompatibilityBannerProp
               ) : (
                 // Mode normal: multi-lignes
                 <>
-                  <p className="font-heading text-base md:text-lg mb-xs">
+                  <p className="font-heading text-base md:text-lg mb-1">
                     {isCompatible ? '✓ Pièce compatible' : '✕ Pièce incompatible'}
                   </p>
                   <p className="font-sans text-sm md:text-base opacity-90">
@@ -127,7 +127,7 @@ export const VehicleCompatibilityBanner: React.FC<VehicleCompatibilityBannerProp
                 bg-white hover:bg-neutral-100
                 text-neutral-900
                 font-heading text-sm
-                px-md py-sm rounded-md
+                px-4 py-2 rounded-md
                 transition-colors duration-200
                 shrink-0
                 border border-transparent hover:border-neutral-300

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -135,7 +135,19 @@ module.exports = {
         }
       },
       spacing: {
-        ...tokens.spacing,
+        // Échelle spacing v4 : clés NUMÉRIQUES (0,1,2,4,6,8,10,12,16,20,24) +
+        // fluid (section-*/gap-*). Les clés NOMMÉES nues (xs..6xl) sont retirées :
+        // en Tailwind v4 l'échelle `maxWidth` v3 a fusionné dans le namespace sizing
+        // partagé, donc `spacing.{xs..6xl}` shadowait `max-w-{nommé}` (max-w-2xl=40px
+        // au lieu de 672px, régression site-wide). Sans elles, `max-w-{nommé}`
+        // repointe sur `--container-*` (correct), et les usages spacing nommés ont été
+        // migrés vers le numérique v4 équivalent pixel-identique (md=16px=4, lg=24px=6…).
+        // Tokens nommés sémantiques toujours dispo programmatiquement via @fafa/design-tokens.
+        ...Object.fromEntries(
+          Object.entries(tokens.spacing).filter(
+            ([k]) => !['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl'].includes(k)
+          )
+        ),
         // Fluid spacing tokens (use clamp for responsive)
         ...tokens.spacingFluid
       },


### PR DESCRIPTION
## Régression (TW-2 #1181, LIVE sur PREPROD ; PROD non affecté)
En Tailwind v4, **`max-w-{nommé}` compilait vers des largeurs minuscules** :
`max-w-2xl`=**40px** au lieu de 672px, `max-w-md`=16px, `max-w-lg`=24px… →
conteneurs/colonnes/cartes capés à quelques pixels. **~334 usages / 177 fichiers.**

Repro : `/pieces/filtre-a-huile-7.html` — l'image « Emplacement sur le véhicule »
rendait à 40px de large (cadre `max-w-2xl` effondré).

## Cause racine
v4 a supprimé l'échelle `maxWidth` v3 dédiée ; `max-w-*` puise dans le namespace
sizing partagé. Le `@config` legacy projette `theme.spacing` avec des clés
**nommées** (`xs..6xl`) que v4 mappe en `--spacing-{nommé}` et lit **en priorité**
sur `--container-*`. Ces clés **shadowent** `max-w-{nommé}`. C'est précisément la
collision que le gate **DT-2 (reserved-namespace-zero)** devait empêcher avant TW-2.

Aucun correctif config/CSS propre (tous testés/réfutés) :
| Tentative | Résultat |
|---|---|
| `@utility max-w-* { … }` statique | 2 règles, le spacing 40px gagne la cascade |
| `@theme { --container-2xl: … }` | no-op (spacing prime) |
| `theme.maxWidth` via `@config` | ignoré par v4 |
| `@utility` fonctionnel `--value(--container-*)` | casse les valeurs arbitraires |

## Fix structurel — retire la collision à la racine, garde v4
1. **Spacing nommé → numérique v4**, pixel-identique (7 fichiers, 234 subs) :
   `xs=4px→1 · sm=8px→2 · md=16px→4 · lg=24px→6 · xl=32px→8 · 2xl=40px→10 · 3xl=48px→12`
   (ex. `gap-sm→gap-2`, `p-md→p-4`, `top-xs→top-1`, `space-y-xs→space-y-1`).
2. **Retrait des clés nommées nues** (`xs..6xl`) de l'échelle `spacing` du `@config`
   (numérique + fluid `section-*`/`gap-*` conservés ; tokens sémantiques toujours
   dispo programmatiquement via `@fafa/design-tokens`).

→ `max-w-{nommé}` repointe **automatiquement** sur `--container-*` (max-w-2xl=672px)
dans les **177 fichiers sans les toucher**. Arbitraires / responsive / `full` intacts.

## Vérification
- compile standalone v4.3.1 : `max-w-2xl`→`var(--container-2xl)`, `p-4`=1rem (=md),
  `md:max-w-4xl`→`var(--container-4xl)`, `p-md` nu = **ABSENT**
- `tsc --noEmit` exit 0 · `react-router build` exit 0 (CSS **49KB gzip** < 60KB)

Transitoire jusqu'à DT-2 complet. Frontend uniquement ; aucune URL/meta/H1/payment touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)