### PR TITLE
fix(gamme-r1): restore equipementier logos in top_brands fallback

### DIFF
--- a/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
+++ b/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
@@ -20,6 +20,7 @@ import {
   buildGammeImageUrl,
   buildModelImageUrl,
   buildProxyImageUrl,
+  buildEquipementierLogoUrl,
   IMAGE_CONFIG,
 } from '../../catalog/utils/image-urls.utils';
 import {
@@ -345,14 +346,22 @@ export class GammeResponseBuilderService {
     // If top_brands has more brands than __seo_equip_gamme, use top_brands instead
     const topBrands = gammeStats.top_brands || [];
     if (topBrands.length > equipementiers.length) {
-      equipementiers = topBrands
+      const selectedBrands = topBrands
         .filter((b) => b.name && b.count > 0)
-        .slice(0, 6)
-        .map((b) => ({
-          title: b.name,
-          description: `${b.count} références disponibles — équipementier ${b.top === '1' ? 'première monte (OE)' : 'qualité équivalente OE'}`,
-          image: null as string | null,
-        }));
+        .slice(0, 6);
+      // top_brands (gamme_stats) ne porte pas le logo → enrichissement depuis
+      // pieces_marque (logos réels) via buildEquipementierLogoUrl (DEFAULT_LOGO si
+      // absent). Sans ça l'image était `null` → <img> sans src → logo manquant.
+      const logoMap = await this.rpcService.getEquipementierLogos(
+        selectedBrands.map((b) => b.name),
+      );
+      equipementiers = selectedBrands.map((b) => ({
+        title: b.name,
+        description: `${b.count} références disponibles — équipementier ${b.top === '1' ? 'première monte (OE)' : 'qualité équivalente OE'}`,
+        image: buildEquipementierLogoUrl(
+          logoMap.get(b.name.toUpperCase()) ?? null,
+        ),
+      }));
     }
 
     // ✅ Utilise fonctions centralisées depuis image-urls.utils.ts

--- a/backend/src/modules/gamme-rest/services/gamme-rpc.service.ts
+++ b/backend/src/modules/gamme-rest/services/gamme-rpc.service.ts
@@ -335,6 +335,38 @@ export class GammeRpcService extends SupabaseBaseService {
   }
 
   /**
+   * Récupère les logos équipementiers (pieces_marque.pm_logo) pour une liste de
+   * noms de marques. Le fallback `top_brands` (gamme_stats) n'expose pas le logo ;
+   * cette lookup bornée (≤ quelques marques, sur cache-miss page uniquement) permet
+   * de l'enrichir avant buildEquipementierLogoUrl (qui gère le DEFAULT_LOGO si null).
+   * @returns Map clé = UPPER(pm_name), valeur = pm_logo (filename) | null
+   */
+  async getEquipementierLogos(
+    brandNames: string[],
+  ): Promise<Map<string, string | null>> {
+    const map = new Map<string, string | null>();
+    const names = [...new Set(brandNames.filter((n): n is string => !!n))];
+    if (names.length === 0) return map;
+
+    const { data, error } = await this.supabase
+      .from('pieces_marque')
+      .select('pm_name, pm_logo')
+      .in('pm_name', names);
+
+    if (error) {
+      this.logger.warn(`⚠️ getEquipementierLogos: ${error.message}`);
+      return map;
+    }
+
+    for (const row of data ?? []) {
+      if (row.pm_name) {
+        map.set(String(row.pm_name).toUpperCase(), row.pm_logo ?? null);
+      }
+    }
+    return map;
+  }
+
+  /**
    * Récupère les codes CNIT / Type Mine pour une liste de type_ids
    * Utilisé par le response builder pour la section "Fiche technique"
    */


### PR DESCRIPTION
## Problème

Sur les pages R1 (`/pieces/<gamme>-<id>.html`, ex. [/pieces/filtre-a-huile-7.html](https://www.automecanik.com/pieces/filtre-a-huile-7.html)), les logos équipementiers (BOSCH, DENSO, MANN FILTER…) **ne s'affichaient pas** — `<img>` rendu **sans `src`** → image cassée.

## Cause racine

`gamme-response-builder.service.ts` : quand `gamme_stats.top_brands` contient plus de marques que `__seo_equip_gamme`, le builder bascule sur le **fallback `top_brands`**. Ce fallback mappait `image: null` car `top_brands` n'expose que `name/count/top/stars` — **pas le logo**.

Côté frontend, `pieces.$slug.tsx` fait `pm_logo: e.image || ""` → `null` → React **omet l'attribut `src`** → et le handler `onError` **ne se déclenche pas** pour un `src` vide → logo manquant (pas même le fallback).

## Fix (structurel, périmètre minimal)

- **`GammeRpcService.getEquipementierLogos(names)`** — lookup borné de `pieces_marque.pm_logo` (≤ marques réellement affichées, uniquement sur cache-miss page).
- **Fallback `top_brands` enrichi** via `buildEquipementierLogoUrl(logo)` — la **fonction déjà utilisée** par le chemin nominal `processEquipementiers` (gère `DEFAULT_LOGO` si `null`).

→ `image` est désormais **toujours une URL valide** : logo réel, ou `default.svg`.

## Vérification

- `pieces_marque.pm_logo` confirmé (MCP) : `bosch.webp`, `denso.webp`, `mann-filter.webp`, `magneti-marelli.webp`, `knecht.webp` ; `WIX FILTERS` = `null` → DEFAULT_LOGO.
- URLs construites **toutes HTTP 200** :
  - `/img/uploads/equipementiers-automobiles/bosch.webp`
  - `/img/uploads/equipementiers-automobiles/mann-filter.webp`
  - `/img/uploads/equipementiers-automobiles/denso.webp`
  - `/images/categories/default.svg`
- `tsc --noEmit` **clean** sur les 2 fichiers.

## Portée / sûreté

- Aucune migration DB · aucun guessing de nom de fichier (réutilise les utils existants) · aucune route/URL/meta/H1 touchés.
- Module `gamme-rest` uniquement. Rétro-compatible (le chemin nominal `__seo_equip_gamme` est inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)