### PR TITLE
revert(seo-cp): restore synthetic-probe rate-limit exemption — egress floor was load-bearing (reverts #1164)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -87,6 +87,20 @@ jobs:
           # Optional override. If unset, the value already present in the PROD
           # .env is used (REQUIRED_VARS below guarantees it exists).
           JWT_SECRET_OVERRIDE: ${{ secrets.PROD_JWT_SECRET }}
+          # Optional. When set, activates the seo-control-plane synthetic-crawler
+          # rate-limit exemption on PROD (HMAC verifier side). Unset = stays OFF
+          # (probes throttled; in-app 429-rate alert fires). PR #1141 / #1142.
+          SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE: ${{ secrets.PROD_SEO_CP_SYNTHETIC_PROBE_SECRET }}
+          # Optional defense-in-depth FLOOR (synthetic-probe egress floor, 2026-06-26): comma-separated egress
+          # IP/CIDR(s) of the synthetic probe. cf-connecting-ip is always forwarded
+          # by Cloudflare (unlike the HMAC header, which the CDN can strip — root
+          # cause of the 2026-06-25 self-throttle), so this keeps the exemption
+          # working even if the header never reaches origin. Unset = floor stays
+          # OFF (fail-closed; HMAC path only). The value is a public egress IP, NOT a
+          # credential — so it lives as a GitHub Actions *variable* (vars), which is
+          # readable/verifiable (`gh variable list`), unlike the write-only HMAC secret
+          # above. cf-connecting-ip is anti-spoofed at origin, so exposing the IP is safe.
+          SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE: ${{ vars.PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:production
 
@@ -142,6 +156,46 @@ jobs:
               echo "JWT_SECRET=${JWT_SECRET_OVERRIDE}" >> .env
             fi
             echo "✅ JWT_SECRET updated from GitHub Secrets"
+          fi
+          # Inject the seo-control-plane synthetic-crawler probe HMAC secret and
+          # ATOMICALLY enable its rate-limit exemption (BotGuardMiddleware is the
+          # verifier — PR #1141). The enable flag is flipped to true ONLY when the
+          # secret is actually provided, so a half-config ("enabled but no secret")
+          # never reaches PROD; the app would fail-closed + log loudly anyway, but
+          # we avoid the state entirely. When PROD_SEO_CP_SYNTHETIC_PROBE_SECRET is
+          # unset the exemption stays OFF: probes get throttled and the in-app
+          # 429-rate alert fires (no silent degradation). Mirrors the JWT pattern.
+          # `|` sed delimiter is safe — the value is hex (openssl rand -hex 32).
+          if [ -n "$SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE" ]; then
+            if grep -q '^SEO_CP_SYNTHETIC_PROBE_SECRET=' .env; then
+              sed -i "s|^SEO_CP_SYNTHETIC_PROBE_SECRET=.*|SEO_CP_SYNTHETIC_PROBE_SECRET=${SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE}|" .env
+            else
+              echo "SEO_CP_SYNTHETIC_PROBE_SECRET=${SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE}" >> .env
+            fi
+            if grep -q '^SEO_CP_SYNTHETIC_PROBE_ENABLED=' .env; then
+              sed -i "s|^SEO_CP_SYNTHETIC_PROBE_ENABLED=.*|SEO_CP_SYNTHETIC_PROBE_ENABLED=true|" .env
+            else
+              echo "SEO_CP_SYNTHETIC_PROBE_ENABLED=true" >> .env
+            fi
+            echo "✅ SEO_CP synthetic-probe exemption secret injected + enabled from GitHub Secrets"
+          else
+            echo "ℹ️ PROD_SEO_CP_SYNTHETIC_PROBE_SECRET unset — synthetic-crawler exemption stays OFF (probes throttled; in-app 429 alert will fire)"
+          fi
+          # Inject the synthetic-probe egress allowlist (defense-in-depth FLOOR,
+          # synthetic-probe egress floor, 2026-06-26). Independent of the HMAC secret above: this floor recognizes
+          # the probe by its anti-spoofed cf-connecting-ip, so the exemption keeps
+          # working even when Cloudflare strips the x-synthetic-probe header (root
+          # cause of the 2026-06-25 self-throttle). Unset = floor OFF (fail-closed;
+          # HMAC path only). `|` sed delimiter is safe — IP/CIDR values use :, /, ,.
+          if [ -n "$SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE" ]; then
+            if grep -q '^SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=' .env; then
+              sed -i "s|^SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=.*|SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=${SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE}|" .env
+            else
+              echo "SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=${SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE}" >> .env
+            fi
+            echo "✅ SEO_CP synthetic-probe egress floor configured from GitHub Variables"
+          else
+            echo "ℹ️ PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS unset — egress floor OFF (HMAC path only)"
           fi
 
           docker network create automecanik-prod 2>/dev/null || true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -187,13 +187,22 @@ SEO_CP_CONCURRENCY=10
 SEO_CP_TIMEOUT_MS=15000
 SEO_CP_PROD_BASE=https://www.automecanik.com
 
-# Cadence de la sonde synthétique (self-pacing, PR #1161) — garde le crawler sous
-# le rate-limiter PROD sans exemption serveur. Défauts : 12 rps / 90 rpm (le cap
-# rpm domine = ~667 ms entre sondes). Laisser vide = défauts. Le crawler ne porte
-# plus d'en-tête d'exemption (l'ancien HMAC x-synthetic-probe + plancher egress
-# ont été retirés : CDN-fragiles et superflus face au pacer).
-SEO_CP_MAX_RPS=
-SEO_CP_MAX_RPM=
+# Exemption rate-limit du crawler synthétique (incident 2026-06-25). Le crawler
+# sonde ses pages publiques via Cloudflare ; sans exemption il est 429 par le
+# throttler (mono-IP en rafale) → 89,7 % de sondes throttlées, monitoring L1
+# aveugle. Le crawler signe un HMAC (header x-synthetic-probe) vérifié par
+# BotGuardMiddleware ; l'exemption est scopée GET + catalogue public (least-priv).
+# DÉFAUT = OFF.
+#
+# Provisioning PROD (gouverné — parité JWT_SECRET) : créer le GitHub Actions secret
+# `PROD_SEO_CP_SYNTHETIC_PROBE_SECRET` (valeur `openssl rand -hex 32`, ≠ INTERNAL_API_KEY,
+# compartimenté). deploy-prod.yml l'injecte dans le .env PROD et passe ENABLED=true
+# atomiquement. Ne JAMAIS coller le secret ici ni dans le .env PROD à la main.
+#   - PREPROD : non requis (READ_ONLY → le processor skip la sonde, ne sonde jamais).
+#   - DEV     : laisser vide ; le crawler y est désactivé (SEO_CP_SYNTHETIC_ENABLED=false)
+#               pour ne pas sonder PROD depuis le poste DEV.
+SEO_CP_SYNTHETIC_PROBE_ENABLED=
+SEO_CP_SYNTHETIC_PROBE_SECRET=
 
 # PR-2A-2 — L1 Cloudflare Analytics Collector (q5min GraphQL ingest)
 # Réutilise CLOUDFLARE_API_TOKEN + CLOUDFLARE_ZONE_ID déjà câblés pour

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,8 @@ import { FeatureFlagsModule } from './config/feature-flags.module'; // 🎛️ N
 import { WriteGuardModule } from './config/write-guard.module'; // 🛡️ P1.5 - Write Ownership & Collision Guard
 import { RpcGateModule } from './security/rpc-gate/rpc-gate.module'; // 🛡️ NOUVEAU - RPC Safety Gate pour gouvernance Supabase !
 import { BotGuardModule } from './modules/bot-guard/bot-guard.module'; // 🛡️ Bot protection (geo-block, IP block, behavioral scoring)
+import { SyntheticProbeCredentialModule } from './modules/seo-control-plane/synthetic-probe-credential.module'; // 🛡️ HMAC credential du crawler synthétique (exemption rate-limit scopée)
+import { isSyntheticExemptPath } from './modules/seo-control-plane/types';
 import { DatabaseModule } from './database/database.module';
 import { OrdersModule } from './modules/orders/orders.module';
 import { HealthModule } from './modules/health/health.module';
@@ -136,12 +138,19 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
           return true;
         }
 
-        // NOTE: the internal synthetic crawler (seo-control-plane L1) is NOT
-        // exempted here. It self-paces (SEO_CP_MAX_RPM ≈ 90/min, structural fix
-        // PR #1161) to stay under the throttler tiers — verified live 2026-06-26
-        // (~90% 429 → 0%). The old HMAC/egress-IP exemption was retired (PR2): a
-        // server-side exemption is fragile (CDN strips the header; IP allowlists
-        // weaken a security control) and the pacer fixes the cause at the source.
+        // Skip the internal synthetic crawler (seo-control-plane L1) — but ONLY
+        // for public-catalogue GETs (least-privilege). The flag is set upstream
+        // by BotGuardMiddleware after verifying an HMAC credential (NOT the UA),
+        // and isSyntheticExemptPath() blocks /api, /auth, /cart, /checkout,
+        // /admin and every non-GET, so even a leaked credential cannot relax
+        // rate-limiting beyond already-public, already-CDN-cached reads.
+        // Incident 2026-06-25 (crawler 89.7% 429 → L1 monitoring blind).
+        if (
+          request.isVerifiedSyntheticProbe === true &&
+          isSyntheticExemptPath(request.method, request.path || '')
+        ) {
+          return true;
+        }
 
         // Skip for admin users (level >= 7)
         if (user?.isAdmin === true || parseInt(user?.level) >= 7) {
@@ -181,6 +190,11 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
 
     // 🛡️ Bot protection - geo-block, IP block, behavioral scoring (must be before other modules)
     BotGuardModule,
+
+    // 🛡️ Credential HMAC du crawler synthétique (@Global) — injecté par
+    // BotGuardMiddleware (verify) + SyntheticCrawlerService (sign). Posé avant les
+    // modules consommateurs pour disponibilité DI app-wide. Incident 2026-06-25.
+    SyntheticProbeCredentialModule,
 
     // 🎛️ Feature flags centralisés (Global)
     FeatureFlagsModule,

--- a/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
@@ -2,7 +2,11 @@ import { BotGuardMiddleware } from './bot-guard.middleware';
 
 type ServiceMock = Record<string, jest.Mock | (() => boolean)>;
 
-function makeMiddleware(overrides: ServiceMock = {}) {
+function makeMiddleware(
+  overrides: ServiceMock = {},
+  probeVerify: () => boolean = () => false,
+  probeEgress: (ip?: string) => boolean = () => false,
+) {
   const service = {
     isEnabled: () => true,
     isIpBlocked: jest.fn(async () => false),
@@ -13,8 +17,17 @@ function makeMiddleware(overrides: ServiceMock = {}) {
     trackAllowed: jest.fn(async () => undefined),
     ...overrides,
   };
-  const middleware = new BotGuardMiddleware(service as never);
-  return { middleware, service };
+  // Synthetic-probe credential: par défaut verify=false ET egress=false (chemin
+  // synthétique jamais pris → comportement existant inchangé).
+  const syntheticProbe = {
+    verify: jest.fn(probeVerify),
+    isExemptEgressIp: jest.fn(probeEgress),
+  };
+  const middleware = new BotGuardMiddleware(
+    service as never,
+    syntheticProbe as never,
+  );
+  return { middleware, service, syntheticProbe };
 }
 
 function makeReqRes(
@@ -63,15 +76,36 @@ describe('BotGuardMiddleware ordering', () => {
     expect(service.isCountryBlocked).not.toHaveBeenCalled();
   });
 
-  it('no longer exempts the synthetic crawler — geo + behavioral now apply (PR2: exemption retired, crawler self-paces instead)', async () => {
-    // Former synthetic-probe bypass (HMAC header / egress-IP floor) is gone. A
-    // probe-like request (identifiable UA, public client IP) must now flow through
-    // geo + behavioral like any other client. Empirically the crawler passes both
-    // (0 × 403 across all runs); the rate limiter is handled by self-pacing, not a
-    // server-side exemption.
-    const { middleware, service } = makeMiddleware({
-      isVerifiedSearchEngine: jest.fn(async () => false), // NOT a search engine
+  it('lets a verified synthetic probe through (dedicated flag) and bypasses geo + behavioral', async () => {
+    const { middleware, service, syntheticProbe } = makeMiddleware(
+      {
+        isVerifiedSearchEngine: jest.fn(async () => false), // NOT a search engine
+        isCountryBlocked: jest.fn(async () => true), // would block if consulted
+        calculateSuspicionScore: jest.fn(() => 100), // would block if consulted
+      },
+      () => true, // valid HMAC credential
+    );
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'DE',
+      'cf-connecting-ip': '203.0.113.7', // public client IP → reaches the probe check
     });
+
+    await middleware.use(req, res, next);
+
+    expect(syntheticProbe.verify).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
+    ).toBe(true);
+    // distinct from the search-engine flag (least-privilege; skipIf scopes it)
+    expect((req as { isVerifiedBot?: boolean }).isVerifiedBot).toBeUndefined();
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(service.isCountryBlocked).not.toHaveBeenCalled();
+    expect(service.calculateSuspicionScore).not.toHaveBeenCalled();
+  });
+
+  it('does NOT set the synthetic flag without a valid credential (verify=false → normal flow)', async () => {
+    const { middleware, syntheticProbe } = makeMiddleware(); // default verify=false
     const { req, res, next } = makeReqRes({
       'cf-ipcountry': 'DE',
       'cf-connecting-ip': '203.0.113.7',
@@ -79,14 +113,41 @@ describe('BotGuardMiddleware ordering', () => {
 
     await middleware.use(req, res, next);
 
+    expect(syntheticProbe.verify).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
-    // No dedicated synthetic flag is ever set anymore.
     expect(
       (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
     ).toBeUndefined();
-    // geo + behavioral are consulted (the bypass that skipped them is gone).
-    expect(service.isCountryBlocked).toHaveBeenCalled();
-    expect(service.calculateSuspicionScore).toHaveBeenCalled();
+  });
+
+  it('recognizes the synthetic probe by its egress IP when the HMAC header is absent (defense-in-depth floor)', async () => {
+    // verify=false (en-tête HMAC retiré par le CDN) MAIS isExemptEgressIp=true
+    // (cf-connecting-ip de la sonde dans l'allowlist) → exemption maintenue.
+    const { middleware, service, syntheticProbe } = makeMiddleware(
+      {
+        isCountryBlocked: jest.fn(async () => true), // would block if consulted
+        calculateSuspicionScore: jest.fn(() => 100), // would block if consulted
+      },
+      () => false, // HMAC absent / stripped
+      () => true, // egress IP recognized
+    );
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'DE',
+      'cf-connecting-ip': '203.0.113.7',
+    });
+
+    await middleware.use(req, res, next);
+
+    expect(syntheticProbe.verify).toHaveBeenCalledTimes(1);
+    // getClientIp's anti-spoofed IP is passed to the egress check
+    expect(syntheticProbe.isExemptEgressIp).toHaveBeenCalledWith('203.0.113.7');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
+    ).toBe(true);
+    expect((req as { isVerifiedBot?: boolean }).isVerifiedBot).toBeUndefined();
+    expect(service.isCountryBlocked).not.toHaveBeenCalled();
+    expect(service.calculateSuspicionScore).not.toHaveBeenCalled();
   });
 
   it('still honors an explicit operator IP block even for a would-be verified crawler (ip_block wins, no DNS work)', async () => {

--- a/backend/src/modules/bot-guard/bot-guard.middleware.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.ts
@@ -1,12 +1,16 @@
 import { HttpStatus, Injectable, Logger, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { BotGuardService } from './bot-guard.service';
+import { SyntheticProbeCredentialService } from '../seo-control-plane/synthetic-probe-credential.service';
 
 @Injectable()
 export class BotGuardMiddleware implements NestMiddleware {
   private readonly logger = new Logger(BotGuardMiddleware.name);
 
-  constructor(private readonly botGuardService: BotGuardService) {}
+  constructor(
+    private readonly botGuardService: BotGuardService,
+    private readonly syntheticProbe: SyntheticProbeCredentialService,
+  ) {}
 
   async use(req: Request, res: Response, next: NextFunction) {
     // 1. Skip health checks and static assets
@@ -64,14 +68,27 @@ export class BotGuardMiddleware implements NestMiddleware {
         return next();
       }
 
-      // NOTE: the internal synthetic crawler (seo-control-plane L1) is no longer
-      // given a dedicated bypass here. It carries an identifiable UA
-      // (AutoMecanikSyntheticBot) and passes geo + behavioral scoring on its own
-      // (empirically 0 × 403 across all runs, even before any exemption existed);
-      // it self-paces (PR #1161) to stay under the rate limiter. The old HMAC /
-      // egress-IP exemption was retired (PR2) — header-survival was CDN-fragile and
-      // an IP allowlist weakens a security control for no benefit the pacer doesn't
-      // already provide.
+      // 6b. Verified internal synthetic probe (seo-control-plane L1). Identity is
+      // proven by EITHER an HMAC credential header (primary) OR the probe's own
+      // egress IP (defense-in-depth floor) — NEVER the User-Agent. The HMAC header
+      // can be stripped in transit by the CDN (Cloudflare did not forward
+      // x-synthetic-probe → probe self-throttled ~90%); cf-connecting-ip is always
+      // forwarded and anti-spoofed in getClientIp, so the egress floor keeps the
+      // exemption working regardless. Like a verified crawler it bypasses geo +
+      // behavioral; the rate-limit exemption is further scoped to public-catalogue
+      // GETs in app.module.ts skipIf. The explicit IP blocklist above still wins.
+      // Both paths fail-closed (verify() false on any error; egress allowlist empty
+      // → false). `ip` is the anti-spoofed client IP from getClientIp (line 32).
+      if (
+        this.syntheticProbe.verify(req) ||
+        this.syntheticProbe.isExemptEgressIp(ip)
+      ) {
+        (
+          req as Request & { isVerifiedSyntheticProbe?: boolean }
+        ).isVerifiedSyntheticProbe = true;
+        this.botGuardService.trackAllowed(country).catch(() => {});
+        return next();
+      }
 
       // 7. Geo block (Cloudflare CF-IPCountry header).
       if (country && (await this.botGuardService.isCountryBlocked(country))) {

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.test.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.test.ts
@@ -108,7 +108,9 @@ function buildSvc(
     logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
     criticality: crit,
     cfg,
-    // buildProbeHeaders() returns only the identifiable UA (no exemption header).
+    // Exemption inactive en test → buildProbeHeaders n'ajoute que l'UA (comportement
+    // identique à l'existant ; pas de header HMAC).
+    probeCredential: { isActive: () => false, sign: jest.fn() },
     supabase: {
       from: (_table: string) => ({ insert: spyInsert }),
     },

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.ts
@@ -30,8 +30,11 @@ import { randomUUID } from 'node:crypto';
 import type { TierId } from '@repo/registry';
 import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
 import { CriticalityLoaderService } from '../../services/criticality-loader.service';
+import { SyntheticProbeCredentialService } from '../../synthetic-probe-credential.service';
 import {
   SYNTHETIC_USER_AGENT,
+  SYNTHETIC_PROBE_HEADER,
+  SYNTHETIC_PROBE_ENABLED_KEY,
   type SyntheticCrawlJobData,
   type SyntheticRunResult,
   type SyntheticSnapshot,
@@ -62,18 +65,34 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
   constructor(
     private readonly criticality: CriticalityLoaderService,
     configService: ConfigService,
+    private readonly probeCredential: SyntheticProbeCredentialService,
   ) {
     super(configService);
     this.cfg = configService;
   }
 
   /**
-   * En-têtes de sonde : UA identifiable obligatoire (JAMAIS spoof Googlebot). La
-   * sonde ne porte plus d'en-tête d'exemption — elle s'auto-cadence (pacer,
-   * SEO_CP_MAX_RPM) pour rester sous le rate-limiter PROD (PR #1161 + PR2).
+   * En-têtes de sonde : UA identifiable + (si le credential est actif) un HMAC
+   * `x-synthetic-probe` signé sur (GET|pathname|fenêtre) pour être exempté du
+   * rate-limiter sans usurper d'UA. Si l'exemption est OFF/non provisionnée, le
+   * header est omis (la sonde sera throttlée — surfacé par l'alerte 429 du run).
    */
-  private buildProbeHeaders(): Record<string, string> {
-    return { 'User-Agent': SYNTHETIC_USER_AGENT };
+  private buildProbeHeaders(url: string): Record<string, string> {
+    const headers: Record<string, string> = {
+      'User-Agent': SYNTHETIC_USER_AGENT,
+    };
+    if (this.probeCredential.isActive()) {
+      try {
+        const { pathname } = new URL(url);
+        headers[SYNTHETIC_PROBE_HEADER] = this.probeCredential.sign(
+          'GET',
+          pathname,
+        );
+      } catch {
+        // URL malformée — pas de header ; la sonde sera throttlée (observable).
+      }
+    }
+    return headers;
   }
 
   /**
@@ -163,19 +182,19 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
       if (s.http_code >= 500) t.fail_5xx++;
     }
 
-    // 🚨 Observabilité anti silent-fallback : la sonde s'auto-cadence (pacer,
-    // SEO_CP_MAX_RPM ≈ 90/min) pour rester sous le rate-limiter PROD. Un taux de
-    // 429 anormal signale une dérive (pacer mal configuré, paliers throttler
-    // modifiés, ou sitemap gonflé) → le monitoring L1 redevient AVEUGLE. On le rend
-    // BRUYANT (log.error, visible Sentry) plutôt que de dégrader en silence
-    // (incident 2026-06-25 : 89,7 % de 429 jamais alertés).
+    // 🚨 Observabilité anti silent-fallback : si une part anormale des sondes est
+    // throttlée (429), l'exemption rate-limit est probablement inactive (flag OFF,
+    // secret non provisionné) ou a dérivé → le monitoring L1 redevient AVEUGLE.
+    // On le rend BRUYANT (log.error, visible Sentry) plutôt que de dégrader en
+    // silence (incident 2026-06-25 : 89,7 % de 429 jamais alertés).
     if (snapshots.length > 0) {
       const rate429 = http429 / snapshots.length;
       if (rate429 > 0.2) {
         this.logger.error(
           `🚨 synthetic-crawler: ${(rate429 * 100).toFixed(1)}% des sondes throttlées ` +
-            `(${http429}/${snapshots.length} en 429). Le self-pacing (SEO_CP_MAX_RPM) ` +
-            `ne tient plus la sonde sous le rate-limiter PROD — monitoring L1 dégradé.`,
+            `(${http429}/${snapshots.length} en 429). L'exemption rate-limit est ` +
+            `probablement inactive (${SYNTHETIC_PROBE_ENABLED_KEY}/secret) ou a dérivé — ` +
+            `monitoring L1 dégradé.`,
         );
       }
     }
@@ -370,7 +389,7 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
     try {
       const res = await fetch(cand.url, {
         signal: ctrl.signal,
-        headers: this.buildProbeHeaders(),
+        headers: this.buildProbeHeaders(cand.url),
         redirect: 'manual',
       });
       const ttfb = Date.now() - t0;
@@ -525,7 +544,7 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
     try {
       const res = await fetch(url, {
         signal: ctrl.signal,
-        headers: this.buildProbeHeaders(),
+        headers: this.buildProbeHeaders(url),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status} on ${url}`);
       return await res.text();

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.module.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.module.ts
@@ -1,0 +1,17 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SyntheticProbeCredentialService } from './synthetic-probe-credential.service';
+
+/**
+ * @Global — le credential synthétique est injecté par DEUX modules distincts :
+ * BotGuardModule (verify, côté origine) et SeoControlPlaneModule (sign, côté
+ * crawler). Le rendre global évite une dépendance circulaire
+ * bot-guard ↔ seo-control-plane et ne duplique aucun provider.
+ */
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [SyntheticProbeCredentialService],
+  exports: [SyntheticProbeCredentialService],
+})
+export class SyntheticProbeCredentialModule {}

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.test.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.test.ts
@@ -1,0 +1,232 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  SyntheticProbeCredentialService,
+  type SyntheticVerifiableRequest,
+} from './synthetic-probe-credential.service';
+import {
+  SYNTHETIC_PROBE_HEADER,
+  SYNTHETIC_PROBE_SECRET_KEY,
+  SYNTHETIC_PROBE_ENABLED_KEY,
+  SYNTHETIC_PROBE_WINDOW_MS,
+  SYNTHETIC_PROBE_EGRESS_IPS_KEY,
+  isSyntheticExemptPath,
+} from './types';
+
+/** Secret fixture — JAMAIS une vraie valeur. */
+const SECRET = 'a'.repeat(64);
+const OTHER_SECRET = 'b'.repeat(64);
+const ENABLED: Record<string, string> = {
+  [SYNTHETIC_PROBE_ENABLED_KEY]: 'true',
+  [SYNTHETIC_PROBE_SECRET_KEY]: SECRET,
+};
+
+function makeService(
+  env: Record<string, string | undefined>,
+): SyntheticProbeCredentialService {
+  const config = {
+    get: (k: string, d?: string) => env[k] ?? d ?? '',
+  } as unknown as ConfigService;
+  return new SyntheticProbeCredentialService(config);
+}
+
+function reqWith(
+  mac: string | undefined,
+  method = 'GET',
+  path = '/pieces/x.html',
+): SyntheticVerifiableRequest {
+  return {
+    method,
+    path,
+    headers: mac === undefined ? {} : { [SYNTHETIC_PROBE_HEADER]: mac },
+  };
+}
+
+describe('SyntheticProbeCredentialService', () => {
+  const T0 = 1_700_000_000_000; // epoch ms fixe
+  let nowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('signe et vérifie dans la même fenêtre', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    expect(s.verify(reqWith(mac))).toBe(true);
+  });
+
+  it('accepte la fenêtre précédente (t-1, tolérance de skew)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    nowSpy.mockReturnValue(T0 + SYNTHETIC_PROBE_WINDOW_MS);
+    expect(s.verify(reqWith(mac))).toBe(true);
+  });
+
+  it('rejette une signature expirée (> 2 fenêtres)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    nowSpy.mockReturnValue(T0 + 2 * SYNTHETIC_PROBE_WINDOW_MS + 1000);
+    expect(s.verify(reqWith(mac))).toBe(false);
+  });
+
+  it('rejette une signature faite avec un autre secret', () => {
+    const signer = makeService(ENABLED);
+    const verifier = makeService({
+      ...ENABLED,
+      [SYNTHETIC_PROBE_SECRET_KEY]: OTHER_SECRET,
+    });
+    const mac = signer.sign('GET', '/pieces/x.html');
+    expect(verifier.verify(reqWith(mac))).toBe(false);
+  });
+
+  it('rejette le rejeu sur un autre chemin (binding chemin)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/a.html');
+    expect(s.verify(reqWith(mac, 'GET', '/pieces/b.html'))).toBe(false);
+  });
+
+  it('rejette le rejeu avec une autre méthode (binding méthode)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    expect(s.verify(reqWith(mac, 'POST', '/pieces/x.html'))).toBe(false);
+  });
+
+  it('rejette quand le header est absent (spoof UA-seul = sans effet)', () => {
+    const s = makeService(ENABLED);
+    expect(s.verify(reqWith(undefined))).toBe(false);
+  });
+
+  it('rejette (fail-closed) quand le kill-switch est OFF', () => {
+    const off = makeService({ [SYNTHETIC_PROBE_SECRET_KEY]: SECRET }); // enabled non posé
+    const mac = makeService(ENABLED).sign('GET', '/pieces/x.html');
+    expect(off.isActive()).toBe(false);
+    expect(off.verify(reqWith(mac))).toBe(false);
+  });
+
+  it('rejette (fail-closed) quand activé mais secret absent', () => {
+    const noSecret = makeService({ [SYNTHETIC_PROBE_ENABLED_KEY]: 'true' });
+    expect(noSecret.isActive()).toBe(false);
+    expect(noSecret.verify(reqWith('anything'))).toBe(false);
+  });
+
+  it('isActive() = vrai seulement si activé ET secret présent', () => {
+    expect(makeService(ENABLED).isActive()).toBe(true);
+    expect(
+      makeService({ [SYNTHETIC_PROBE_ENABLED_KEY]: 'true' }).isActive(),
+    ).toBe(false);
+    expect(
+      makeService({ [SYNTHETIC_PROBE_SECRET_KEY]: SECRET }).isActive(),
+    ).toBe(false);
+  });
+});
+
+describe('SyntheticProbeCredentialService.isExemptEgressIp (plancher défense-en-profondeur)', () => {
+  // IP d'egress observée de la sonde PROD (incident 2026-06-25). Fixture de test.
+  const PROBE_V6 = '2a01:4f8:1c1b:5e4e::1';
+
+  it('exempte une IPv6 exacte présente dans l’allowlist', () => {
+    const s = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(s.isExemptEgressIp(PROBE_V6)).toBe(true);
+  });
+
+  it('exempte via un CIDR IPv6', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '2a01:4f8:1c1b:5e4e::/64',
+    });
+    expect(s.isExemptEgressIp(PROBE_V6)).toBe(true);
+    expect(s.isExemptEgressIp('2a01:4f8:1c1b:5e4e:abcd::9')).toBe(true);
+  });
+
+  it('exempte une IPv4 exacte et via CIDR', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '203.0.113.7, 198.51.100.0/24',
+    });
+    expect(s.isExemptEgressIp('203.0.113.7')).toBe(true);
+    expect(s.isExemptEgressIp('198.51.100.42')).toBe(true);
+  });
+
+  it('normalise un IPv4-mapped IPv6 (::ffff:) vers IPv4', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '203.0.113.0/24',
+    });
+    expect(s.isExemptEgressIp('::ffff:203.0.113.7')).toBe(true);
+  });
+
+  it('REFUSE une IP hors allowlist', () => {
+    const s = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(s.isExemptEgressIp('8.8.8.8')).toBe(false);
+    expect(s.isExemptEgressIp('2a01:4f8:1c1b:5e4f::1')).toBe(false);
+  });
+
+  it('fail-closed : allowlist vide → toujours false', () => {
+    expect(makeService({}).isExemptEgressIp(PROBE_V6)).toBe(false);
+    expect(
+      makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '' }).isExemptEgressIp(
+        PROBE_V6,
+      ),
+    ).toBe(false);
+  });
+
+  it('REFUSE une IP absente/illisible (fail-closed, pas de crash)', () => {
+    const s = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(s.isExemptEgressIp(undefined)).toBe(false);
+    expect(s.isExemptEgressIp('')).toBe(false);
+    expect(s.isExemptEgressIp('pas-une-ip')).toBe(false);
+    expect(s.isExemptEgressIp('unknown')).toBe(false);
+  });
+
+  it('ignore les entrées invalides mais garde les valides (parse résilient)', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: `garbage, ${PROBE_V6}, 999.999.0.0/8`,
+    });
+    expect(s.isExemptEgressIp(PROBE_V6)).toBe(true);
+    expect(s.isExemptEgressIp('8.8.8.8')).toBe(false);
+  });
+
+  it('ne confond pas les familles (IPv4 vs plage IPv6 et inversement)', () => {
+    const v6only = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(v6only.isExemptEgressIp('203.0.113.7')).toBe(false);
+    const v4only = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '203.0.113.0/24',
+    });
+    expect(v4only.isExemptEgressIp(PROBE_V6)).toBe(false);
+  });
+});
+
+describe('isSyntheticExemptPath (least-privilege scope)', () => {
+  it('exempte les GET catalogue publics + accueil', () => {
+    expect(isSyntheticExemptPath('GET', '/')).toBe(true);
+    expect(isSyntheticExemptPath('GET', '/pieces/barre-274.html')).toBe(true);
+    expect(isSyntheticExemptPath('GET', '/pieces')).toBe(true);
+    expect(
+      isSyntheticExemptPath('GET', '/constructeurs/audi/a4/2-0.html'),
+    ).toBe(true);
+    expect(isSyntheticExemptPath('GET', '/blog/guide')).toBe(true);
+  });
+
+  it('ne couvre PAS les sitemaps (servis statiquement par Caddy, hors throttler)', () => {
+    expect(isSyntheticExemptPath('GET', '/sitemap-pieces-1.xml')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/sitemap.xml')).toBe(false);
+  });
+
+  it('REFUSE toute méthode non-GET (même chemin public)', () => {
+    expect(isSyntheticExemptPath('POST', '/pieces/x.html')).toBe(false);
+    expect(isSyntheticExemptPath('HEAD', '/pieces/x.html')).toBe(false);
+    expect(isSyntheticExemptPath('PUT', '/')).toBe(false);
+  });
+
+  it('REFUSE les chemins sensibles/non-publics (blast radius borné)', () => {
+    expect(isSyntheticExemptPath('GET', '/api/auth/login')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/cart')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/checkout')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/admin')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/account/orders')).toBe(false);
+  });
+
+  it('ne matche pas un préfixe partiel trompeur', () => {
+    // '/piecesXYZ' ne doit PAS matcher le préfixe '/pieces'
+    expect(isSyntheticExemptPath('GET', '/pieces-fake/x')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/blogger')).toBe(false);
+  });
+});

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { BlockList, isIP } from 'node:net';
+import {
+  SYNTHETIC_PROBE_HEADER,
+  SYNTHETIC_PROBE_SECRET_KEY,
+  SYNTHETIC_PROBE_ENABLED_KEY,
+  SYNTHETIC_PROBE_WINDOW_MS,
+  SYNTHETIC_PROBE_EGRESS_IPS_KEY,
+} from './types';
+
+/** Requête minimale lisible par {@link SyntheticProbeCredentialService.verify}. */
+export interface SyntheticVerifiableRequest {
+  method?: string;
+  path?: string;
+  headers?: Record<string, unknown>;
+}
+
+/**
+ * SyntheticProbeCredentialService — credential vérifiable (HMAC) prouvant qu'une
+ * requête provient du crawler synthétique interne (seo-control-plane L1), SANS
+ * faire confiance à l'User-Agent (spoofable).
+ *
+ * Pourquoi (incident 2026-06-25) : le crawler L1 sonde ses propres pages publiques
+ * via Cloudflare pour mesurer la santé edge+page, mais le ThrottlerGuard global
+ * (clé par IP) le 429 à 89,7 % car c'est une source mono-IP en rafale → le
+ * monitoring L1 devient AVEUGLE. Ce credential permet à BotGuardMiddleware de poser
+ * `req.isVerifiedSyntheticProbe`, lu par une branche `skipIf` SCOPÉE (GET + préfixes
+ * catalogue publics uniquement, cf. {@link isSyntheticExemptPath}) dans app.module.
+ *
+ * Sécurité (issue d'un panel de conception adverse, 2026-06-25) :
+ *   - HMAC-SHA256(`${method}|${pathname}|${windowCounter}`) avec un secret DÉDIÉ
+ *     (≠ INTERNAL_API_KEY : compartimentation — une fuite ne touche pas les
+ *     endpoints internes admin). Le SECRET ne transite JAMAIS sur le fil ; seule
+ *     une signature (liée méthode+chemin+fenêtre 60 s) circule.
+ *   - `timingSafeEqual` length-guardé (même primitive qu'InternalApiKeyGuard).
+ *   - Fenêtre 60 s + acceptation `t` et `t-1` (skew d'horloge ; crawler et origine
+ *     co-localisés sur la même machine PROD → skew ~0).
+ *   - FAIL-CLOSED : kill-switch OFF, secret absent, header absent, parse error,
+ *     signature invalide ou fenêtre expirée → `false` → la requête retombe sur le
+ *     throttler normal. JAMAIS de fail-open vers « vérifié ».
+ *   - Le least-privilege (scope GET + catalogue) est appliqué dans `skipIf`, pas ici.
+ *
+ * Défense en profondeur ({@link isExemptEgressIp}, ajout 2026-06-26) : le HMAC
+ * voyage dans un en-tête custom qu'un CDN peut retirer en transit (Cloudflare ne
+ * l'a PAS transmis → sonde auto-throttlée). Un PLANCHER par IP d'egress
+ * (`cf-connecting-ip`, toujours transmis + anti-spoofé) rend l'exemption robuste
+ * indépendamment du CDN. Même scope least-privilege, env-gated, fail-closed.
+ *
+ * Stateless. Dépend uniquement de ConfigService. Fourni par un module @Global pour
+ * être injecté à la fois par BotGuardMiddleware (verify) et SyntheticCrawlerService
+ * (sign) sans dépendance circulaire.
+ */
+@Injectable()
+export class SyntheticProbeCredentialService {
+  private readonly logger = new Logger(SyntheticProbeCredentialService.name);
+  private readonly secret: string;
+  private readonly enabled: boolean;
+  /** Plancher défense-en-profondeur : allowlist d'egress de la sonde (cf. types). */
+  private readonly egressAllowlist: BlockList;
+  /** Nombre de règles d'egress chargées (0 → plancher inactif, fail-closed). */
+  private readonly egressRuleCount: number;
+  private warnedSecretMissing = false;
+
+  constructor(private readonly config: ConfigService) {
+    this.secret = this.config.get<string>(SYNTHETIC_PROBE_SECRET_KEY, '');
+    this.enabled =
+      this.config.get<string>(SYNTHETIC_PROBE_ENABLED_KEY, '') === 'true';
+    if (this.enabled && !this.secret) {
+      // Erreur de config explicite (no silent enable) : flag ON mais secret absent.
+      this.logger.error(
+        `${SYNTHETIC_PROBE_ENABLED_KEY}=true mais ${SYNTHETIC_PROBE_SECRET_KEY} absent — ` +
+          'exemption synthétique DÉSACTIVÉE (fail-closed).',
+      );
+    }
+
+    const egress = this.buildEgressAllowlist(
+      this.config.get<string>(SYNTHETIC_PROBE_EGRESS_IPS_KEY, ''),
+    );
+    this.egressAllowlist = egress.list;
+    this.egressRuleCount = egress.count;
+    if (this.egressRuleCount > 0) {
+      this.logger.log(
+        `Plancher egress sonde synthétique actif (${this.egressRuleCount} entrée(s) ${SYNTHETIC_PROBE_EGRESS_IPS_KEY}).`,
+      );
+    }
+  }
+
+  /**
+   * Construit l'allowlist d'egress (IP simples ou CIDR, v4/v6) depuis une liste
+   * séparée par des virgules, via `net.BlockList` (primitive stdlib Node : aucune
+   * dépendance tierce, et `check()` normalise nativement les IPv4-mapped-IPv6).
+   * Chaque entrée invalide est ignorée + warn (no silent fail-open). `count` =
+   * nombre d'entrées valides chargées (0 → plancher OFF / fail-closed).
+   */
+  private buildEgressAllowlist(raw: string): {
+    list: BlockList;
+    count: number;
+  } {
+    const list = new BlockList();
+    let count = 0;
+    for (const entry of raw.split(',')) {
+      const trimmed = entry.trim();
+      if (trimmed && this.addEgressEntry(list, trimmed)) count += 1;
+    }
+    return { list, count };
+  }
+
+  /**
+   * Ajoute une entrée (IP simple ou CIDR, v4/v6) à la BlockList. Retourne `false`
+   * si l'entrée est invalide (ignorée + warn) — `isIP` rejette une IP malformée et
+   * `addSubnet`/`addAddress` lèvent sur un préfixe hors-domaine, capté ici.
+   */
+  private addEgressEntry(list: BlockList, entry: string): boolean {
+    try {
+      if (entry.includes('/')) {
+        const [net, prefixRaw] = entry.split('/');
+        const family = isIP(net);
+        const prefix = Number(prefixRaw);
+        if (family === 0 || !Number.isInteger(prefix)) {
+          throw new Error('CIDR invalide');
+        }
+        list.addSubnet(net, prefix, family === 6 ? 'ipv6' : 'ipv4');
+        return true;
+      }
+      const family = isIP(entry);
+      if (family === 0) throw new Error('IP invalide');
+      list.addAddress(entry, family === 6 ? 'ipv6' : 'ipv4');
+      return true;
+    } catch {
+      this.logger.warn(
+        `Entrée ${SYNTHETIC_PROBE_EGRESS_IPS_KEY} invalide ignorée: "${entry}".`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Plancher défense-en-profondeur : `true` si l'IP cliente (déjà anti-spoofée par
+   * BotGuard.getClientIp = `cf-connecting-ip` cru uniquement derrière le proxy
+   * interne) appartient à l'allowlist d'egress de la sonde. Allowlist vide → `false`
+   * (fail-closed). Le scope least-privilege (GET + catalogue public) reste appliqué
+   * en aval dans `skipIf` — cette méthode ne décide QUE de l'identité, pas du scope.
+   */
+  isExemptEgressIp(ip: string | undefined): boolean {
+    if (this.egressRuleCount === 0 || !ip) return false;
+    const family = isIP(ip);
+    if (family === 0) return false; // IP illisible → fail-closed
+    try {
+      // `BlockList.check` normalise un IPv4-mapped IPv6 (`::ffff:1.2.3.4`) et
+      // n'inter-matche jamais deux familles distinctes (enforce family equality).
+      return this.egressAllowlist.check(ip, family === 6 ? 'ipv6' : 'ipv4');
+    } catch {
+      return false;
+    }
+  }
+
+  /** Le credential est-il opérationnel (flag ON + secret présent) ? */
+  isActive(): boolean {
+    return this.enabled && this.secret.length > 0;
+  }
+
+  /** Signe une requête sortante du crawler (côté émetteur). */
+  sign(method: string, pathname: string): string {
+    return this.computeMac(method, pathname, this.windowCounter());
+  }
+
+  /**
+   * Vérifie l'en-tête `x-synthetic-probe` d'une requête entrante (côté origine).
+   * Retourne `true` SEULEMENT si la signature est valide pour la fenêtre courante
+   * ou précédente. Fail-closed sur toute condition d'erreur.
+   */
+  verify(req: SyntheticVerifiableRequest): boolean {
+    if (!this.enabled) return false;
+    if (!this.secret) {
+      if (!this.warnedSecretMissing) {
+        this.warnedSecretMissing = true;
+        this.logger.warn(
+          `${SYNTHETIC_PROBE_SECRET_KEY} absent — exemption synthétique inactive (fail-closed).`,
+        );
+      }
+      return false;
+    }
+
+    const provided = req.headers?.[SYNTHETIC_PROBE_HEADER];
+    if (typeof provided !== 'string' || provided.length === 0) return false;
+
+    const method = (req.method ?? '').toUpperCase();
+    const pathname = req.path ?? '';
+    const w = this.windowCounter();
+    // Accepte la fenêtre courante ET la précédente (tolérance de skew d'horloge).
+    return (
+      this.safeEqual(provided, this.computeMac(method, pathname, w)) ||
+      this.safeEqual(provided, this.computeMac(method, pathname, w - 1))
+    );
+  }
+
+  private windowCounter(): number {
+    return Math.floor(Date.now() / SYNTHETIC_PROBE_WINDOW_MS);
+  }
+
+  private computeMac(method: string, pathname: string, window: number): string {
+    return createHmac('sha256', this.secret)
+      .update(`${method.toUpperCase()}|${pathname}|${window}`)
+      .digest('hex');
+  }
+
+  private safeEqual(a: string, b: string): boolean {
+    const bufA = Buffer.from(a, 'utf8');
+    const bufB = Buffer.from(b, 'utf8');
+    return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+  }
+}

--- a/backend/src/modules/seo-control-plane/types.ts
+++ b/backend/src/modules/seo-control-plane/types.ts
@@ -17,11 +17,76 @@ export type SyntheticRunTrigger = 'scheduler' | 'manual' | 'test';
 export const SYNTHETIC_USER_AGENT =
   'AutoMecanikSyntheticBot/1.0 (+https://www.automecanik.com/bots/synthetic)';
 
-// NOTE: the synthetic crawler no longer carries a rate-limit exemption. The
-// former HMAC header (x-synthetic-probe) + egress-IP floor + isSyntheticExemptPath
-// scope were retired (PR2): the CDN strips the custom header, an IP allowlist
-// weakens a security control, and the crawler now self-paces (PR #1161,
-// SEO_CP_MAX_RPM) to stay under the throttler — the structural fix at the source.
+/**
+ * Identité du crawler synthétique vis-à-vis du rate-limiter (incident 2026-06-25).
+ *
+ * En-tête CUSTOM (PAS `Authorization` — vérifié empiriquement : n'entre pas dans la
+ * cache-key Cloudflare, préserve donc `cf_cache_status`) portant un HMAC signé par
+ * le crawler et vérifié par BotGuardMiddleware. On n'expose ici que les NOMS d'env
+ * et le nom du header — AUCUNE valeur (IP/secret) en dur.
+ */
+export const SYNTHETIC_PROBE_HEADER = 'x-synthetic-probe';
+export const SYNTHETIC_PROBE_SECRET_KEY = 'SEO_CP_SYNTHETIC_PROBE_SECRET';
+export const SYNTHETIC_PROBE_ENABLED_KEY = 'SEO_CP_SYNTHETIC_PROBE_ENABLED';
+export const SYNTHETIC_PROBE_WINDOW_MS = 60_000;
+
+/**
+ * Allowlist d'IP/CIDR d'egress de la sonde synthétique — PLANCHER de défense en
+ * profondeur du rate-limit, EN PLUS du HMAC. Liste séparée par virgules d'IP ou
+ * CIDR (IPv4 ou IPv6).
+ *
+ * Pourquoi (incident 2026-06-25) : le HMAC voyage dans un en-tête custom
+ * (`x-synthetic-probe`) que le CDN peut retirer en transit (Cloudflare ne l'a PAS
+ * transmis à l'origine → sonde auto-throttlée ~90 %, monitoring L1 aveugle). Or
+ * `cf-connecting-ip` est TOUJOURS transmis par Cloudflare et anti-spoofé à
+ * l'origine (cf. BotGuard.getClientIp : la valeur n'est crue QUE si le pair TCP
+ * est le reverse-proxy interne). Reconnaître l'IP d'egress de NOTRE propre sonde
+ * rend l'exemption robuste, que l'en-tête survive ou non au CDN.
+ *
+ * Vide = plancher OFF (fail-closed) → seule la voie HMAC s'applique. Le même
+ * périmètre least-privilege (GET + catalogue public, {@link isSyntheticExemptPath})
+ * est appliqué en aval dans `skipIf` : même blast-radius que la voie HMAC.
+ */
+export const SYNTHETIC_PROBE_EGRESS_IPS_KEY =
+  'SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS';
+
+/**
+ * Préfixes de chemins PUBLICS en lecture sur lesquels l'exemption rate-limit du
+ * crawler synthétique peut s'appliquer (least-privilege). Aligné sur la surface
+ * publique cacheable (Caddyfile @products/@content). Une fuite éventuelle du
+ * credential ne peut donc relâcher le rate-limit QUE sur des GET de pages
+ * publiques déjà CDN-cachées — jamais /api, /auth, /cart, /checkout, /admin, ni
+ * aucune méthode non-GET.
+ *
+ * NB : les sitemaps (`/sitemap*.xml`) ne figurent PAS ici — Caddy les sert en
+ * statique (`@sitemaps → file_server`), ils n'atteignent jamais le throttler NestJS.
+ */
+export const SYNTHETIC_PROBE_PUBLIC_PREFIXES = [
+  '/pieces',
+  '/products',
+  '/catalog',
+  '/vehicule',
+  '/constructeurs',
+  '/blog',
+  '/blog-pieces-auto',
+] as const;
+
+/**
+ * Scope (pur, testable) de l'exemption rate-limit synthétique : `true` uniquement
+ * pour un GET vers la page d'accueil ou un préfixe catalogue public. Toute autre
+ * méthode ou chemin (API/auth/panier/admin/…) renvoie `false` même avec un flag
+ * `isVerifiedSyntheticProbe` vrai — borne le rayon d'explosion d'un secret fuité.
+ */
+export function isSyntheticExemptPath(method: string, path: string): boolean {
+  if (method !== 'GET') return false;
+  if (path === '/') return true;
+  return SYNTHETIC_PROBE_PUBLIC_PREFIXES.some(
+    (prefix) =>
+      path === prefix ||
+      path.startsWith(`${prefix}/`) ||
+      path.startsWith(`${prefix}.`),
+  );
+}
 
 /**
  * Entrée de seed-list pour un crawl R8/R2 ciblé (D-0 baseline).


### PR DESCRIPTION
## Quoi

Revert de #1164 (`15e493dcb` *"retire synthetic-probe rate-limit exemption — self-pacing supersedes it"*) → restaure le mécanisme d'exemption rate-limit du crawler synthétique L1 (HMAC + **plancher egress** #1158 + scope least-privilege).

## Pourquoi — preuve A/B de la PROD elle-même

Le crawler synthétique (seo-control-plane L1) sonde PROD depuis l'IP egress DEV et est **throttlé par le NestJS `@nestjs/throttler` d'origine** (palier `long` 2000/h par-IP, budget partagé). Données live `__seo_snapshot_synthetic` :

| Heure UTC | 429/h | État PROD |
|---|---|---|
| 06-26 14h → 06-27 **11h** | **0,0-0,7 %** | plancher egress LIVE (`v2026.06.26-synthetic-probe-egress-floor`), 23 h |
| 06-27 12h05 | → 16,9 % puis **70,4 %** | tag `v2026.06.27-tw4-cwv-exemption-removal` (#1164) déployé |
| 06-27 17h | **69,7 %** | état actuel |

Step net à **12h05 UTC**, exactement le déploiement du retrait. **AVEC** exemption = ~0 % ; **SANS** = 70 %. La prémisse de #1164 (« self-pacing → 0 % ») est **falsifiée** : le 0 % venait du plancher egress, pas du pacer. Le pacer seul = 70 %. Le retrait est une **régression pure** → monitoring L1 aveugle (violation no-silent-fallback).

Diagnostic fingerprint : 429 = 100 % throttler d'origine (corps 2065 o `global-error.filter` + `X-Robots-Tag: noindex`, `cf=MISS`). La sonde se cadence **correctement** (90/min, 300 sondes/198 s, sans overlap) — elle ne peut PAS échapper au budget par-IP partagé en ralentissant.

## Détail technique

#1164 a retiré **deux** mécanismes sur **une** prémisse :
- **#1141 en-tête HMAC** (`x-synthetic-probe`) : ne traverse jamais Cloudflare (CF le strip) — mort à l'arrivée, correctement identifié.
- **#1158 plancher egress** (`cf-connecting-ip` via stdlib `net.BlockList`) : le seul signal que Cloudflare transmet TOUJOURS, anti-spoofé par `getClientIp`, fail-closed, least-privilege (GET + catalogue public). **C'est lui qui faisait le ~0 %.** Retiré à tort.

Ce revert restaure le mécanisme complet revu (HMAC + plancher egress + scope + 32 tests). Le plancher egress porte l'exemption quel que soit le strip CDN ; la voie HMAC est inerte-mais-inoffensive tant que Cloudflare n'est pas configuré pour transmettre l'en-tête (suivi owner).

## Vérification

- ✅ Coexiste **proprement** avec #1180 (D-0 balise/seed-list) — régions disjointes, **0 conflit**
- ✅ `backend tsc --noEmit` = **0**
- ✅ Suites credential + bot-guard + crawler = **40/40 vertes**

## Activation (owner-gated)

1. **Merge + tag `v*`** (déploiement PROD) → retour à ~0 % 429.
2. Vérifier que le secret `SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS` est toujours provisionné en PROD (il l'était le 26 juin ; le cleanup post-#1164 a pu le supprimer → re-poser à l'identique) + `SEO_CP_SYNTHETIC_PROBE_ENABLED=true`.
3. **Fail-closed** : allowlist vide = plancher OFF → le merge est **inerte** tant que le secret n'est pas posé (zéro blast radius sur merge seul).

## Secondaire (suivi owner, hors-PR)

Cloudflare cache les 429 d'origine avec `max-age=7200` (réécriture Browser-Cache-TTL) par-dessus le `no-store` de #1140 → sans objet dès que les 429 cessent, mais une règle de cache CF sur les 4xx mériterait un examen. Fix « primaire » long terme (#1158) = configurer CF pour transmettre `x-synthetic-probe` (la voie HMAC redevient alors un 2ᵉ facteur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
