### PR TITLE
fix(home): translate="no" sur widgets interactifs — stoppe le crash removeChild (traduction navigateur)

### DIFF
--- a/frontend/app/components/home/CatalogueSection.tsx
+++ b/frontend/app/components/home/CatalogueSection.tsx
@@ -219,7 +219,16 @@ export default function CatalogueSection({
         sub={`Pièces neuves pour toutes marques — ${families.length} familles techniques`}
       />
 
+      {/* translate="no" — neutralise la cause racine du crash NotFoundError
+          "removeChild ... not a child" (Sentry PROD, page /, fragment #catalogue).
+          La traduction navigateur (Chrome / Google Translate) re-parente les nœuds
+          texte de ce widget dans des <font> ; un re-render React (frappe dans la
+          recherche, changement d'onglet, expand/collapse) appelle ensuite removeChild
+          sur un nœud déplacé → DOMException. Marquer ce sous-arbre interactif comme
+          non-traduisible empêche le traducteur d'y toucher. Le <SectionHeader>
+          ci-dessus reste hors de ce sous-arbre, donc traduisible. Cf. React #11538. */}
       <Tabs
+        translate="no"
         defaultValue="Tout"
         className="w-full"
         aria-label="Catalogue par domaine technique"

--- a/frontend/app/components/home/HeroSection.tsx
+++ b/frontend/app/components/home/HeroSection.tsx
@@ -67,7 +67,12 @@ export default function HeroSection() {
             Recherche par véhicule, référence OE, Type Mine ou immatriculation.
           </p>
           {/* ====== SELECTOR ====== */}
-          <div className="mx-auto mt-5 max-w-[960px] lg:mt-8">
+          {/* translate="no" — même protection que CatalogueSection : ce sélecteur
+              (onglets Véhicule/Type Mine/Référence + formulaires) re-render au clic et
+              à la frappe. La traduction navigateur re-parente ses nœuds texte → React
+              removeChild NotFoundError. Le H1 / sous-titre / trust strip restent hors
+              de ce <div>, donc traduisibles. Cf. React #11538. */}
+          <div translate="no" className="mx-auto mt-5 max-w-[960px] lg:mt-8">
             {/* ── MOBILE SELECTOR ── */}
             <div className="relative lg:hidden">
               <div className="absolute inset-x-3 top-0 h-24 rounded-[28px] bg-white/8 blur-2xl" />

--- a/log.md
+++ b/log.md
@@ -483,3 +483,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tw2-tailwind4-engine`
 - **Décision** : feat(tw-2): install Tailwind CSS v4.3.1 (engine swap, @config bridge, @tailwindcss/vite)
 - **Sortie** : PR #1181 | commits fe3aef3b8
+
+## 2026-06-27 — fix/home-translate-no-removechild (auto)
+
+- **Branche** : `fix/home-translate-no-removechild`
+- **Décision** : fix(home): translate="no" sur widgets interactifs — stoppe le crash removeChild dû à la traduction navigateur
+- **Sortie** : PR aucune | commits bda4ee6d5


### PR DESCRIPTION
## Incident (Sentry PROD)

`NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.` (DOMException code 8) — projet `automecanik-frontend-prod`, `transaction=/`, fragment `#catalogue`, Chrome 149 / Windows. Déclenché par l'alerte « first canonical PROD error ».

## Cause racine (confirmée)

La **traduction automatique du navigateur** (Chrome / Google Translate) ré-emballe les nœuds texte de la page `<html lang="fr">` dans des `<font>` et les re-parente. Sur les widgets home qui re-render à l'interaction, React appelle ensuite `removeChild` sur un nœud texte que le traducteur a déplacé → `NotFoundError`.

Preuves :
- pile d'erreur = **100 % reconciler React** (`fl`↔`dl`, ~45 frames, zéro frame applicative) → mutation DOM externe, pas un bug logique ;
- `root.tsx` = `<html lang="fr">` hydraté en entier, **aucun** `translate="no"` nulle part ;
- `#catalogue` = `CatalogueSection`, la surface la plus dense en texte + interactions (recherche live, onglets, expand) ;
- alternatives écartées par vérification directe : Radix Tabs rendu **inline** (pas de portal), framer-motion **absent**, hydration mismatch ne correspond pas à la signature.

C'est l'incompatibilité connue React + traduction navigateur (la team React ne corrige pas côté React — [facebook/react#11538](https://github.com/facebook/react/issues/11538)).

## Correctif

`translate="no"` (attribut HTML standard, **coût runtime nul**) sur les **2 sous-arbres interactifs** de la home :
- `CatalogueSection` → sur `<Tabs>` (couvre recherche, onglets, cartes, état vide) ;
- `HeroSection` → sur le conteneur du sélecteur (onglets + formulaires).

Le traducteur n'y touche plus → plus de désync DOM. Les titres / prose restent **traduisibles** (hors de ces sous-arbres).

### Pourquoi cette approche (et pas les autres)

- ❌ **monkeypatch `Node.prototype.removeChild`** : dégrade une primitive DOM globale, masque de vrais bugs → bricolage rejeté ;
- ❌ **span-wrapping** : incomplet (rate les ternaires à nombre de nœuds variable + `insertBefore`), whack-a-mole sur 16 sites ;
- ❌ **`notranslate` document-wide** : casse la traduction pour tous les visiteurs non-francophones.

## Vérification

- `npm run typecheck` (react-router typegen + tsc) → ✅ exit 0
- ESLint sur les fichiers modifiés → ✅ exit 0
- Diff : 2 fichiers, +15/−1

**Repro comportementale (manuelle — impossible en CI headless)** : ouvrir `/` dans Chrome → clic droit → « Traduire en anglais » → taper dans la recherche catalogue / changer d'onglet → ne doit plus planter ; le reste de la page doit toujours se traduire.

## Déploiement / rollback

- Frontend-only, **aucun** changement d'URL / meta / H1 / paiement / DB.
- Merge `main` → container **PREPROD** (E2E Smoke + Lighthouse). **PROD** uniquement via tag `v*` (décision owner).
- Rollback = revert de cette PR (1 commit, 2 attributs).

## Follow-ups (hors scope, à décider)

1. Élargir `translate="no"` aux blocs below-fold (Marques / Blog / FAQ) si du résiduel apparaît (risque plus faible : révélés une fois, pas à chaque frappe).
2. **Anomalie observabilité** : la valeur `react.error_channel` du rapport (`intercepté`) ne correspond à aucune valeur émise par le code (`recoverable|caught|uncaught`) — très probablement Gmail ayant traduit « caught » ; un diff du bundle PROD `react-vendor-CacC8Fry.js` le confirmerait.
3. Filtre Sentry `ignoreErrors` pour le bruit résiduel d'autres extensions — *après* mesure, pour ne pas s'aveugler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)