### PR TITLE
feat(seo-balise): rendre les builders H1 partagés R8/R2 au frontend (PR-D2)

### DIFF
--- a/frontend/app/components/pieces/PiecesHeader.tsx
+++ b/frontend/app/components/pieces/PiecesHeader.tsx
@@ -5,15 +5,10 @@
  * ⚠️ URLS PRÉSERVÉES - Breadcrumb et navigation inchangés
  */
 
-import {
-  enrichTypeNameForHeadings,
-  pickH1Suffix,
-  SEO_PRICE_VARIATIONS,
-} from "@repo/seo-types";
+import { buildR2H1Emitted } from "@repo/seo-types";
 import { Car } from "lucide-react";
 import React, { useState, memo } from "react";
 
-import { PiecesHeroTrustStrip } from "./hero";
 import { brandColorsService } from "../../services/brand-colors.service";
 import {
   type GammeData,
@@ -21,6 +16,7 @@ import {
   type VehicleData,
 } from "../../types/pieces-route.types";
 import { ImageOptimizer, isValidImagePath } from "../../utils/image-optimizer";
+import { PiecesHeroTrustStrip } from "./hero";
 
 interface PiecesHeaderProps {
   vehicle: VehicleData;
@@ -51,28 +47,12 @@ export const PiecesHeader = memo(function PiecesHeader({
 }: PiecesHeaderProps) {
   const [imageError, setImageError] = useState(false);
 
-  // Suffix H1 R2 rotation : compSwitch2 per-gamme primary (pattern legacy PHP
-  // #CompSwitch_2#), fallback SEO_PRICE_VARIATIONS 7 variantes prix, fallback
-  // ultime literal "au meilleur prix" (compatibilité legacy prixPasCherText).
-  // Cause : audit 2026-05-26 montre `au meilleur prix` figé 4/4 fixtures car
-  // prop n'était jamais passée. Restauration pattern legacy via #763 follow-up.
-  const finalText = pickH1Suffix({
-    compSwitch2,
-    priceVariations: SEO_PRICE_VARIATIONS,
-    ctx: { typeId: vehicle.typeId, pgId: gamme.id },
-    literalFallback: prixPasCherText ?? "au meilleur prix",
-  });
-
-  // R2 H1/title disambiguation : enrichir `typeName` avec `powerPs`/`fuel`
-  // quand le type_name est ambigu (ex. "2.0 HDi" partagé par 140/163 ch).
-  // No-op si non-ambigu → byte-identique à l'actuel. Cause empirique :
-  // audit/seo-h1-meta-empirical-verification-2026-05-26.md (3 H1 + 1 title
-  // EXACT duplicates sur 100 paires LIVE PROD).
-  const enrichedTypeLabel = enrichTypeNameForHeadings({
-    typeName: vehicle.typeName || vehicle.type,
-    powerPs: vehicle.typePowerPs?.toString(),
-    fuel: vehicle.typeFuel,
-  }).value;
+  // H1 R2 = builder partagé @repo/seo-types `buildR2H1Emitted` (PR-D2). L'assemblage
+  // (rotation suffixe compSwitch2 → SEO_PRICE_VARIATIONS → "au meilleur prix" legacy
+  // #763 ; enrichissement type powerPs/fuel anti-collision ambiguïté, audit 2026-05-26)
+  // vit désormais DANS le builder, rendu ici ET hashé par le fingerprint anti-duplicate
+  // → divergence impossible. Byte-identique au JSX précédent (golden #1178 +
+  // pieces-header-h1-parity.test.tsx).
 
   // Récupérer le gradient de la marque du véhicule
   const brandGradient = vehicle.marqueAlias
@@ -114,9 +94,17 @@ export const PiecesHeader = memo(function PiecesHeader({
               <header>
                 <h1 className="text-2xl sm:text-3xl lg:text-4xl font-black leading-tight mb-3 tracking-tight">
                   <span className="text-foreground from-white via-white to-white/90 drop-shadow-[0_8px_32px_rgba(0,0,0,0.5)]">
-                    {gamme.name} {vehicle.marque?.toUpperCase()}{" "}
-                    {vehicle.modele?.toUpperCase()} {enrichedTypeLabel}{" "}
-                    {finalText}
+                    {buildR2H1Emitted({
+                      gammeName: gamme.name,
+                      marque: vehicle.marque,
+                      modele: vehicle.modele,
+                      typeName: vehicle.typeName || vehicle.type,
+                      typePowerPs: vehicle.typePowerPs,
+                      typeFuel: vehicle.typeFuel,
+                      ctx: { typeId: vehicle.typeId, pgId: gamme.id },
+                      compSwitch2,
+                      literalFallback: prixPasCherText,
+                    })}
                   </span>
                 </h1>
               </header>

--- a/frontend/app/components/vehicle/r8/sections/HeroSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/HeroSection.tsx
@@ -1,6 +1,8 @@
 // 🎯 R8 Vehicle — S_HERO
 // H1 unique (image-matrix-v1 §7, gradient-only)
 
+import { buildR8H1Emitted } from "@repo/seo-types";
+
 import { resolveSlogan } from "~/config/visual-intent";
 import { HeroSelection } from "../../../heroes";
 import { type LoaderData } from "../r8.types";
@@ -13,7 +15,18 @@ export function HeroSection({ vehicle }: Props) {
   return (
     <div data-section="S_HERO">
       <HeroSelection
-        title={`${vehicle.marque_name} ${vehicle.modele_name} ${vehicle.type_name} ${vehicle.type_power_ps} ch de ${vehicle.type_year_from} à ${vehicle.type_year_to || "aujourd'hui"}`}
+        // H1 R8 = builder partagé @repo/seo-types (PR-D2). Le frontend REND le
+        // builder ; le fingerprint anti-duplicate hashe la même fonction →
+        // divergence impossible. Byte-identique au template inline précédent
+        // (parité prouvée, golden #1178 + r8-hero-h1-parity.test.tsx).
+        title={buildR8H1Emitted({
+          marqueName: vehicle.marque_name,
+          modeleName: vehicle.modele_name,
+          typeName: vehicle.type_name,
+          typePowerPs: vehicle.type_power_ps,
+          typeYearFrom: vehicle.type_year_from,
+          typeYearTo: vehicle.type_year_to,
+        })}
         subtitle={`${vehicle.type_fuel} · ${vehicle.type_body} · ${vehicle.type_year_from}–${vehicle.type_year_to || "Auj."}`}
         slogan={resolveSlogan("selection")}
       />

--- a/frontend/tests/unit/pieces-header-h1-parity.test.tsx
+++ b/frontend/tests/unit/pieces-header-h1-parity.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests de PARITÉ H1 R2 — `PiecesHeader` (route `pieces.$gamme.$marque.$modele.$type`).
+ *
+ * Objectif (plan rév.9, Track A, PR-D2) : prouver que le `<h1>` RÉELLEMENT RENDU par
+ * le composant égale `buildR2H1Emitted(...)` au byte près. Les golden tests de #1178
+ * vérifient le builder *isolé* ; ce fichier ferme le trou non couvert = le rendu réel
+ * (assemblage JSX `{a} {b}{" "}{c}…` avec `undefined→""`) == builder. Tant que c'est
+ * vert, brancher le frontend sur le builder ne change AUCUN byte ; toute dérive du JSX
+ * casse ce test.
+ *
+ * Verification-first : ces tests passent contre le JSX inline ACTUEL (pré-rewire).
+ */
+
+import { buildR2H1Emitted } from "@repo/seo-types";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PiecesHeader } from "~/components/pieces/PiecesHeader";
+import {
+  type GammeData,
+  type VehicleData,
+} from "~/types/pieces-route.types";
+
+function makeR2Vehicle(overrides: Partial<VehicleData> = {}): VehicleData {
+  return {
+    marque: "renault",
+    modele: "clio iii",
+    type: "1.5 dCi 90",
+    typeName: "1.5 dCi 90",
+    typeId: 34189,
+    marqueId: 7,
+    modeleId: 140004,
+    typePowerPs: 90,
+    typeFuel: "Diesel",
+    ...overrides,
+  };
+}
+
+function makeGamme(overrides: Partial<GammeData> = {}): GammeData {
+  return {
+    id: 307,
+    name: "Kit de distribution",
+    alias: "kit-distribution",
+    description: "",
+    ...overrides,
+  };
+}
+
+/** Reproduit le mapping du call-site `PiecesHeader.tsx` vers le builder. */
+function expectedH1(opts: {
+  vehicle: VehicleData;
+  gamme: GammeData;
+  compSwitch2?: readonly string[];
+  prixPasCherText?: string;
+}): string {
+  const { vehicle, gamme, compSwitch2, prixPasCherText } = opts;
+  return buildR2H1Emitted({
+    gammeName: gamme.name,
+    marque: vehicle.marque,
+    modele: vehicle.modele,
+    typeName: vehicle.typeName || vehicle.type,
+    typePowerPs: vehicle.typePowerPs,
+    typeFuel: vehicle.typeFuel,
+    ctx: { typeId: vehicle.typeId, pgId: gamme.id },
+    compSwitch2,
+    literalFallback: prixPasCherText,
+  });
+}
+
+describe("PiecesHeader R2 — parité <h1> rendu == buildR2H1Emitted", () => {
+  it("rend exactement le builder — pool compSwitch2 (rotation déterministe)", () => {
+    const vehicle = makeR2Vehicle();
+    const gamme = makeGamme();
+    const compSwitch2 = ["monter le kit de distribution"] as const;
+    const { container } = render(
+      <PiecesHeader
+        vehicle={vehicle}
+        gamme={gamme}
+        count={24}
+        compSwitch2={compSwitch2}
+      />,
+    );
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toBe(expectedH1({ vehicle, gamme, compSwitch2 }));
+    // sanity : fragments stables présents (gamme + marque/modele uppercase + suffixe pool)
+    expect(h1?.textContent).toContain("Kit de distribution");
+    expect(h1?.textContent).toContain("RENAULT");
+    expect(h1?.textContent).toContain("CLIO III");
+    expect(h1?.textContent).toContain("monter le kit de distribution");
+  });
+
+  it("rend exactement le builder — fallback SEO_PRICE_VARIATIONS (compSwitch2 absent)", () => {
+    const vehicle = makeR2Vehicle({ typeId: 70, modeleId: 11387 });
+    const gamme = makeGamme({ id: 402, name: "Plaquette de frein" });
+    const { container } = render(
+      <PiecesHeader vehicle={vehicle} gamme={gamme} count={5} />,
+    );
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toBe(expectedH1({ vehicle, gamme }));
+  });
+
+  it("rend exactement le builder — prixPasCherText legacy override", () => {
+    const vehicle = makeR2Vehicle();
+    const gamme = makeGamme();
+    const prixPasCherText = "à prix discount";
+    const { container } = render(
+      <PiecesHeader
+        vehicle={vehicle}
+        gamme={gamme}
+        count={3}
+        prixPasCherText={prixPasCherText}
+      />,
+    );
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toBe(expectedH1({ vehicle, gamme, prixPasCherText }));
+  });
+
+  it("minPrice (PriceCard) n'altère pas le <h1>", () => {
+    const vehicle = makeR2Vehicle();
+    const gamme = makeGamme();
+    const compSwitch2 = ["monter le kit de distribution"] as const;
+    const { container } = render(
+      <PiecesHeader
+        vehicle={vehicle}
+        gamme={gamme}
+        count={24}
+        minPrice={49.9}
+        compSwitch2={compSwitch2}
+      />,
+    );
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toBe(expectedH1({ vehicle, gamme, compSwitch2 }));
+  });
+
+  it("un seul <h1> émis", () => {
+    const { container } = render(
+      <PiecesHeader vehicle={makeR2Vehicle()} gamme={makeGamme()} count={1} />,
+    );
+    expect(container.querySelectorAll("h1")).toHaveLength(1);
+  });
+});

--- a/frontend/tests/unit/r8-hero-h1-parity.test.tsx
+++ b/frontend/tests/unit/r8-hero-h1-parity.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests de PARITÉ H1 R8 — `HeroSection` (route `constructeurs.$brand.$model.$type`).
+ *
+ * Objectif (plan rév.9, Track A, PR-D2) : prouver que le `<h1>` RÉELLEMENT RENDU par
+ * le composant égale `buildR8H1Emitted(...)` au byte près. Les golden tests de #1178
+ * vérifient le builder *isolé* ; ce fichier ferme le trou non couvert = le rendu réel
+ * du composant == builder. Tant que c'est vert, brancher le frontend sur le builder
+ * (rewire) ne change AUCUN byte émis ; et toute dérive future du JSX casse ce test.
+ *
+ * Verification-first : ces tests passent contre le JSX inline ACTUEL (pré-rewire) — si
+ * l'un échoue, c'est que la byte-parité affirmée par #1178 ne tient pas dans le vrai
+ * rendu, à corriger AVANT tout rewire.
+ */
+
+import { buildR8H1Emitted } from "@repo/seo-types";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { type VehicleData } from "~/components/vehicle/r8/r8.types";
+import { HeroSection } from "~/components/vehicle/r8/sections/HeroSection";
+
+/** Fixture R8 complète (tous les champs requis de `VehicleData`), surchargeable. */
+function makeR8Vehicle(overrides: Partial<VehicleData> = {}): VehicleData {
+  return {
+    marque_id: 7,
+    marque_alias: "renault",
+    marque_name: "RENAULT",
+    marque_name_meta: "Renault",
+    marque_name_meta_title: "Renault",
+    marque_logo: "renault.webp",
+    marque_relfollow: 1,
+    modele_id: 140004,
+    modele_alias: "clio-iii",
+    modele_name: "Clio III",
+    modele_name_meta: "Clio III",
+    modele_relfollow: 1,
+    type_id: 34189,
+    type_alias: "1-5-dci-90",
+    type_name: "1.5 dCi 90",
+    type_name_meta: "1.5 dCi 90",
+    type_power_ps: "90",
+    type_body: "Berline",
+    type_fuel: "Diesel",
+    type_month_from: "06",
+    type_year_from: "2005",
+    type_month_to: null,
+    type_year_to: null,
+    type_relfollow: 1,
+    power: "90",
+    date: "2005",
+    ...overrides,
+  };
+}
+
+/** Reproduit le mapping du call-site `HeroSection.tsx` vers le builder. */
+function expectedH1(v: VehicleData): string {
+  return buildR8H1Emitted({
+    marqueName: v.marque_name,
+    modeleName: v.modele_name,
+    typeName: v.type_name,
+    typePowerPs: v.type_power_ps,
+    typeYearFrom: v.type_year_from,
+    typeYearTo: v.type_year_to,
+  });
+}
+
+describe("HeroSection R8 — parité <h1> rendu == buildR8H1Emitted", () => {
+  it("rend exactement le builder (type_year_to null → « aujourd'hui »)", () => {
+    const v = makeR8Vehicle({ type_year_to: null });
+    const { container } = render(<HeroSection vehicle={v} />);
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toBe(expectedH1(v));
+    // double-verrou : bytes concrets attendus
+    expect(h1?.textContent).toBe(
+      "RENAULT Clio III 1.5 dCi 90 90 ch de 2005 à aujourd'hui",
+    );
+  });
+
+  it("rend exactement le builder (type_year_to défini)", () => {
+    const v = makeR8Vehicle({ type_year_to: "2012" });
+    const { container } = render(<HeroSection vehicle={v} />);
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toBe(expectedH1(v));
+    expect(h1?.textContent).toBe(
+      "RENAULT Clio III 1.5 dCi 90 90 ch de 2005 à 2012",
+    );
+  });
+
+  it("un seul <h1> émis", () => {
+    const { container } = render(
+      <HeroSection vehicle={makeR8Vehicle()} />,
+    );
+    expect(container.querySelectorAll("h1")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Rewire frontend : HeroSection R8 + PiecesHeader R2 rendent buildR*H1Emitted (single source = fingerprint). Byte-identique prouvé (8 tests parité composant verts avant/après rewire ; typecheck+lint+344/344). Zéro changement balise/URL/canonical/robots. Suite PR-D1 #1178.