### PR TITLE
feat(seo-balise): reason SOFT_404_EMPTY_CONTENT — cascade indexabilité (D-3 Slice 2a, ADR-095 §1)

### DIFF
--- a/backend/src/modules/seo/services/policies/seo-indexability-policy.service.ts
+++ b/backend/src/modules/seo/services/policies/seo-indexability-policy.service.ts
@@ -49,6 +49,8 @@ export interface IndexabilityVerdict {
  *   3. R2 gate fail ⇒ noindex,nofollow + R2_GATE_FAIL
  *   4. availableFamilies < min_families ⇒ noindex,follow + FAMILIES_BELOW_THRESHOLD
  *   5. availableGammes < min_gammes ⇒ noindex,follow + GAMMES_BELOW_THRESHOLD
+ *   5b. Soft-404 (ADR-095 §1) ⇒ noindex,follow + SOFT_404_EMPTY_CONTENT
+ *      (exposé uniquement aux loaders via composer direct, comme tecdoc)
  *   6. Fingerprint match (PR-9) ⇒ noindex,follow + FINGERPRINT_DUPLICATE
  *   7. TecDoc release gate ⇒ noindex,nofollow + TECDOC_RELEASE_GATE
  *      (exposé uniquement aux loaders R8 via composer direct)
@@ -123,6 +125,8 @@ export class SeoIndexabilityPolicyService {
           `gammes_below_threshold(${input.availableGammes}<${thresholds.min_gammes})`,
         ];
       }
+      case ReasonCode.SOFT_404_EMPTY_CONTENT:
+        return ['soft_404_empty_content'];
       case ReasonCode.FINGERPRINT_DUPLICATE:
         return ['fingerprint_duplicate_match'];
       case ReasonCode.TECDOC_RELEASE_GATE:

--- a/packages/seo-role-contracts/src/__fixtures__/indexability-snapshot.json
+++ b/packages/seo-role-contracts/src/__fixtures__/indexability-snapshot.json
@@ -225,6 +225,39 @@
     "expectedReasonCodes": ["CANONICAL_MISMATCH"]
   },
   {
+    "stratum": "R8_VEHICLE_soft_404",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/foo-bar-29404.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/foo-bar-29404.html",
+      "availableGammes": 10,
+      "soft404": true
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["SOFT_404_EMPTY_CONTENT"]
+  },
+  {
+    "stratum": "R2_PRODUCT_soft_404",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-99404.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-99404.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      },
+      "soft404": true
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["SOFT_404_EMPTY_CONTENT"]
+  },
+  {
     "stratum": "R8_VEHICLE_fingerprint",
     "input": {
       "surfaceKey": "R8_VEHICLE",

--- a/packages/seo-role-contracts/src/__tests__/compose-indexability.test.ts
+++ b/packages/seo-role-contracts/src/__tests__/compose-indexability.test.ts
@@ -283,6 +283,67 @@ describe("@repo/seo-role-contracts — computeIndexabilityVerdict — cascade", 
   });
 
   // ───────────────────────────────────────────────────────────────────────────
+  // 5b. SOFT_404_EMPTY_CONTENT (caller flag — ADR-095 §1, après gammes/avant fingerprint)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 5b — soft-404 empty content", () => {
+    it("soft404=true → NOINDEX_FOLLOW + [SOFT_404_EMPTY_CONTENT]", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        soft404: true,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_FOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.SOFT_404_EMPTY_CONTENT]);
+    });
+
+    it("soft404=false explicite ne déclenche pas", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        soft404: false,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("soft404 undefined ne déclenche pas (behaviour-preserving — callers existants)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("gammes<threshold court-circuite AVANT soft-404 (ordre cascade : 5 avant 5b)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 4, // < 5 → GAMMES_BELOW_THRESHOLD doit gagner
+        soft404: true,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.GAMMES_BELOW_THRESHOLD]);
+    });
+
+    it("soft-404 court-circuite AVANT fingerprint (ordre cascade : 5b avant 6)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        soft404: true,
+        fingerprintMatch: true, // serait FINGERPRINT_DUPLICATE si pas court-circuité
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.SOFT_404_EMPTY_CONTENT]);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
   // 6. FINGERPRINT_DUPLICATE
   // ───────────────────────────────────────────────────────────────────────────
   describe("step 6 — fingerprint duplicate", () => {
@@ -396,6 +457,7 @@ describe("@repo/seo-role-contracts — computeIndexabilityVerdict — cascade", 
       { surfaceKey: "R2_PRODUCT", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, r2Conditions: R2_FAIL_NO_IMAGE },
       { surfaceKey: "R1_GAMME_ROUTER", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableFamilies: 0 },
       { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 1 },
+      { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 10, soft404: true },
       { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 10, fingerprintMatch: true },
       { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 10, tecdocReleaseGateOpen: true },
     ];

--- a/packages/seo-role-contracts/src/compose-indexability.ts
+++ b/packages/seo-role-contracts/src/compose-indexability.ts
@@ -15,6 +15,8 @@
  *      ⇒ NOINDEX_FOLLOW + reasonCodes:[FAMILIES_BELOW_THRESHOLD]
  *   5. availableGammes < min_gammes
  *      ⇒ NOINDEX_FOLLOW + reasonCodes:[GAMMES_BELOW_THRESHOLD]
+ *   5b. Soft-404 (caller flag `soft404` — ADR-095 §1, après gammes/avant fingerprint)
+ *      ⇒ NOINDEX_FOLLOW + reasonCodes:[SOFT_404_EMPTY_CONTENT]
  *   6. Fingerprint match (PR-9)
  *      ⇒ NOINDEX_FOLLOW + reasonCodes:[FINGERPRINT_DUPLICATE]
  *   7. TecDoc release gate ouverte (caller flag)
@@ -115,6 +117,19 @@ export function computeIndexabilityVerdict(
     return {
       kind: RobotsVerdictKind.NOINDEX_FOLLOW,
       reasonCodes: [ReasonCode.GAMMES_BELOW_THRESHOLD],
+      context: baseContext,
+    };
+  }
+
+  // 5b. soft-404 — page sans contenu réel (caller flag, ADR-095 §1).
+  //     NOINDEX_FOLLOW : on n'indexe pas une page vide, mais les liens (vers
+  //     alternatives/related) restent suivables. Le composer ne décide JAMAIS
+  //     du soft-404 lui-même (zéro I/O) — il consomme le booléen calculé par le
+  //     caller via le proxy `get_soft_404_alternatives`.
+  if (input.soft404 === true) {
+    return {
+      kind: RobotsVerdictKind.NOINDEX_FOLLOW,
+      reasonCodes: [ReasonCode.SOFT_404_EMPTY_CONTENT],
       context: baseContext,
     };
   }

--- a/packages/seo-role-contracts/src/robots-verdict.ts
+++ b/packages/seo-role-contracts/src/robots-verdict.ts
@@ -56,6 +56,8 @@ export enum ReasonCode {
   FAMILIES_BELOW_THRESHOLD = "FAMILIES_BELOW_THRESHOLD",
   /** availableGammes < threshold (R1/R8). */
   GAMMES_BELOW_THRESHOLD = "GAMMES_BELOW_THRESHOLD",
+  /** Soft-404 — page sans contenu réel (caller flag `soft404`). ADR-095 §1. */
+  SOFT_404_EMPTY_CONTENT = "SOFT_404_EMPTY_CONTENT",
   /** Fingerprint match (PR-9 SEO) — page duplicate variant. */
   FINGERPRINT_DUPLICATE = "FINGERPRINT_DUPLICATE",
   /** TecDoc release gate ouverte ([60000, 83456]) — noindex jusqu'à validation. */
@@ -108,6 +110,12 @@ export const IndexabilityInputSchema = z.object({
   availableFamilies: z.number().int().nonnegative().optional(),
   availableGammes: z.number().int().nonnegative().optional(),
   r2Conditions: R2IndexabilityConditionsSchema.optional(),
+  /**
+   * Soft-404 — caller-computed proxy (`get_soft_404_alternatives` : vehicles+gammes+
+   * related vides ET availableGammes=0). undefined/false = check inactif sur cette
+   * surface. Le composer ne fait que consommer le booléen (zéro I/O). ADR-095 §1.
+   */
+  soft404: z.boolean().optional(),
   /** PR-9 fingerprint match — undefined = check inactif sur cette surface. */
   fingerprintMatch: z.boolean().optional(),
   /** Caller-computed (ex. R8 : `type_id >= 60000 && type_id <= 83456`). */


### PR DESCRIPTION
## Quoi

Ajoute la reason **`SOFT_404_EMPTY_CONTENT`** à la cascade d'indexabilité pure `computeIndexabilityVerdict()` (`@repo/seo-role-contracts`). C'est le **seul check manquant** de `indexable_effective` selon **ADR-095 §1** (200 ∧ index ∧ canonical cohérent ∧ **¬soft-404** ∧ ¬noindex).

D-3 **Slice 2a** = la moitié *pure / testable* de l'input-assembler indexabilité. **Zéro I/O, zéro DB, zéro câblage runtime.**

## Changements (additifs, backward-compatible)

- `ReasonCode.SOFT_404_EMPTY_CONTENT` (nouveau membre enum)
- `IndexabilityInputSchema.soft404?: boolean` (input optionnel)
- Étape cascade **5b** (après `gammes`, avant `fingerprint`) → `NOINDEX_FOLLOW` :
  on n'indexe pas une page vide, mais les liens (vers alternatives/related) restent suivables.
- Wrapper legacy `SeoIndexabilityPolicyService` : `case` d'exhaustivité ajouté
  (même traitement que `TECDOC_RELEASE_GATE`) → string legacy `soft_404_empty_content`.

## Pourquoi pur (pas de détection ici)

Le composer **ne décide jamais** du soft-404 lui-même — il **consomme** un booléen calculé
par le caller via le proxy `get_soft_404_alternatives` (vehicles+gammes+related vides ET
`availableGammes=0`). Cette détection I/O est une **slice séparée** (Slice 2b), pas dans cette PR.

## Backward-compat

- `soft404` **undefined** ⇒ comportement **strictement identique** pour tous les callers existants
  (golden-master behaviour-preserving — aucune entrée existante ne passe `soft404`).
- Le flag n'est **pas** exposé à l'input legacy déprécié (`SeoIndexabilityPolicyService`,
  retrait V1.5) — précédent `tecdocReleaseGateOpen` : les loaders consomment le composer direct.

## Vérification (PRE-PR, runtime)

- `@repo/seo-role-contracts` : `tsc --noEmit` ✓ + **140 tests** verts (`tsx --test`), dont :
  - 5 cas cascade soft-404 (`true`/`false`/`undefined` + ordre `gammes` avant `5b`, `5b` avant `fingerprint`)
  - 2 entrées golden master (`R8_VEHICLE_soft_404`, `R2_PRODUCT_soft_404` post-gate)
- Backend : **8/8** tests `seo-indexability-policy.service` verts (switch compile contre le nouvel enum).

## Hors-scope (slices suivantes)

- **2b** : détection I/O DB→`IndexabilityInput.soft404` via `RmAlternativesService`/`get_soft_404_alternatives`, câblage shadow gated `SEO_CHAIN_DUPLICATE_GATE_MODE`.
- **3** : enforce per-surface (owner-gated).

Réf. plan balises rév.9 §D-3 · ADR-095 (vault, mergé #331).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
