### PR TITLE
fix(command-center): executor Phase 2b — NODE_PATH pour résoudre js-yaml en worktree isolé

### DIFF
--- a/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.executor.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.executor.ts
@@ -15,12 +15,15 @@ const execFileAsync = promisify(execFile);
 export type CommandRunner = (
   cmd: string,
   args: string[],
-  cwd?: string,
+  opts?: { cwd?: string; env?: NodeJS.ProcessEnv },
 ) => Promise<{ stdout: string }>;
 
-const defaultRunner: CommandRunner = async (cmd, args, cwd) => {
+const defaultRunner: CommandRunner = async (cmd, args, opts) => {
   const { stdout } = await execFileAsync(cmd, args, {
-    cwd,
+    cwd: opts?.cwd,
+    // env absent ⇒ execFile hérite de process.env (git/gh conservent leur auth).
+    // Fourni ⇒ REMPLACE process.env : l'appelant doit passer un env complet mergé.
+    env: opts?.env,
     timeout: 120_000,
     maxBuffer: 16 * 1024 * 1024,
   });
@@ -117,21 +120,36 @@ export class RegenArtifactExecutor {
         wt,
         'origin/main',
       ]);
-      // régénère l'artefact (le générateur écrit DANS le worktree temporaire).
-      await this.run('node', [join(wt, target.generatorRel)], wt);
-      await this.run('git', ['-C', wt, 'add', target.committedRel]);
-      await this.run('git', [
-        '-C',
-        wt,
-        '-c',
-        `user.name=${RegenArtifactExecutor.GIT_NAME}`,
-        '-c',
-        `user.email=${RegenArtifactExecutor.GIT_EMAIL}`,
-        'commit',
-        '-m',
-        target.commitMessage,
-      ]);
-      await this.run('git', ['-C', wt, 'push', '-u', 'origin', branch]);
+      // Régénère l'artefact (le générateur écrit DANS le worktree temporaire).
+      // Le worktree (sous os.tmpdir()) n'a PAS de node_modules (gitignoré) → le
+      // générateur `require('js-yaml')` échouerait (MODULE_NOT_FOUND) sur toute
+      // machine propre (CI/PROD/fresh dev). NODE_PATH pointe la résolution des
+      // modules bare vers les deps du checkout runtime — sans jamais salir ce dernier.
+      await this.run('node', [join(wt, target.generatorRel)], {
+        cwd: wt,
+        env: { ...process.env, NODE_PATH: join(repoRoot, 'node_modules') },
+      });
+      await this.run('git', ['-C', wt, 'add', target.committedRel], {
+        cwd: wt,
+      });
+      await this.run(
+        'git',
+        [
+          '-C',
+          wt,
+          '-c',
+          `user.name=${RegenArtifactExecutor.GIT_NAME}`,
+          '-c',
+          `user.email=${RegenArtifactExecutor.GIT_EMAIL}`,
+          'commit',
+          '-m',
+          target.commitMessage,
+        ],
+        { cwd: wt },
+      );
+      await this.run('git', ['-C', wt, 'push', '-u', 'origin', branch], {
+        cwd: wt,
+      });
       const { stdout } = await this.run(
         'gh',
         [
@@ -147,7 +165,7 @@ export class RegenArtifactExecutor {
           '--body',
           `Régénération approuvée (HITL, ADR-087 Phase 2). plan_hash=${planHash}. À relire + merger humainement.`,
         ],
-        wt,
+        { cwd: wt },
       );
       const prUrl = stdout.trim();
       this.logger.warn(`PR d'exécution ouverte (draft) : ${prUrl} [${branch}]`);
@@ -175,6 +193,15 @@ export class RegenArtifactExecutor {
         ]);
       } catch {
         /* worktree déjà absent / non créé */
+      }
+      // Supprime la branche LOCALE créée par `worktree add -b` (après remove, elle
+      // n'est plus checked-out). Sinon un re-run du même plan (planHash → même nom)
+      // collisionnerait « branch already exists ». La branche distante + la PR (si
+      // push a réussi) subsistent : `git branch -D` ne touche que le ref local.
+      try {
+        await this.run('git', ['-C', repoRoot, 'branch', '-D', branch]);
+      } catch {
+        /* branche jamais créée / déjà supprimée */
       }
       try {
         rmSync(wt, { recursive: true, force: true });

--- a/backend/tests/unit/regen-artifact.executor.test.ts
+++ b/backend/tests/unit/regen-artifact.executor.test.ts
@@ -69,28 +69,44 @@ describe('RegenArtifactExecutor', () => {
       base: 'main',
     });
 
-    const calls = run.mock.calls as [string, string[], string?][];
+    const calls = run.mock.calls as [
+      string,
+      string[],
+      { cwd?: string; env?: NodeJS.ProcessEnv }?,
+    ][];
     // worktree isolé sur origin/main + branche dérivée du plan_hash
     const wtAdd = calls.find(
-      (c) => c[0] === 'git' && c[1].includes('worktree') && c[1].includes('add'),
+      (c) =>
+        c[0] === 'git' && c[1].includes('worktree') && c[1].includes('add'),
     );
     expect(wtAdd?.[1]).toEqual(expect.arrayContaining(['origin/main', '-b']));
     expect(wtAdd?.[1].some((a) => a.includes('abcdef012345'))).toBe(true);
+    // Générateur lancé avec NODE_PATH vers les deps du checkout (sinon require('js-yaml')
+    // → MODULE_NOT_FOUND dans le worktree tmpdir sans node_modules). Régression lockée.
+    const gen = calls.find((c) => c[0] === 'node');
+    expect(gen?.[2]?.env?.NODE_PATH).toBe('/repo/node_modules');
     // PR draft
     const gh = calls.find((c) => c[0] === 'gh');
     expect(gh?.[1]).toEqual(
       expect.arrayContaining(['pr', 'create', '--draft', '--base', 'main']),
     );
-    // worktree nettoyé (remove --force)
+    // worktree nettoyé (remove --force) + branche locale supprimée (re-run possible)
     const wtRemove = calls.find(
-      (c) => c[0] === 'git' && c[1].includes('worktree') && c[1].includes('remove'),
+      (c) =>
+        c[0] === 'git' && c[1].includes('worktree') && c[1].includes('remove'),
     );
     expect(wtRemove).toBeDefined();
+    const branchDel = calls.find(
+      (c) => c[0] === 'git' && c[1].includes('branch') && c[1].includes('-D'),
+    );
+    expect(branchDel).toBeDefined();
   });
 
   it('git/gh échoue → ExecutorUnavailableError (pas de succès fictif)', async () => {
     env.COMMAND_CENTER_EXECUTOR = 'pr';
-    const run = jest.fn().mockRejectedValue(new Error('git: command not found'));
+    const run = jest
+      .fn()
+      .mockRejectedValue(new Error('git: command not found'));
     const ex = new RegenArtifactExecutor(run);
     await expect(ex.execute(target, '/repo', 'h')).rejects.toBeInstanceOf(
       ExecutorUnavailableError,


### PR DESCRIPTION
## Contexte

Review post-merge de la stack orchestration Command Center (ADR-087, Phase 1/2a/2b + cockpit + catalogue + dropdown, tous mergés). Ce PR corrige **un bug latent trouvé dans le code Phase 2b** — l'executor mutation-capable (#1022).

## Bug (latent, non-live)

`RegenArtifactExecutor.execute()` régénère l'artefact via `node build-command-center-snapshot.js` **dans un worktree git sous `os.tmpdir()`**. Ce worktree n'a pas de `node_modules` (gitignoré). Le générateur fait `require('js-yaml')` (dép externe) → **`MODULE_NOT_FOUND` sur toute machine propre** (CI / container PROD / fresh dev / après nettoyage `/tmp`) → capté → `ExecutorUnavailableError` → **503, jamais de PR ouverte**. L'executor est donc **non-fonctionnel dès activation**.

⚠️ **Pas de casse live** : Phase 2b est double-flag-gated OFF (`COMMAND_CENTER_ORCHESTRATION=approved` **ET** `COMMAND_CENTER_EXECUTOR=pr`), jamais activé. Mais c'est le pire type de bug latent : **il « marche » en test DEV** (masqué ici par un `/tmp/node_modules/js-yaml` parasite) **et casse partout ailleurs**.

## Preuve empirique

Worktree créé dans `/var/tmp` (ancêtre sans `node_modules`, simule CI/PROD/fresh) :

```
sans NODE_PATH → Error: Cannot find module 'js-yaml'
avec NODE_PATH → wrote audit/registry/command-center-snapshot.json (sha256:3615f94d…)
```

Sortie identique (déterministe) à celle du shadow planner qui, lui, tourne depuis le checkout runtime (où `node_modules` existe) — d'où l'asymétrie masquée.

## Fix (robuste, pas de bricolage)

- `CommandRunner` : 3ᵉ arg `cwd?` → sac d'options `{ cwd?, env? }` (signature propre).
- Le **seul** appel `node` (générateur) reçoit `env: { ...process.env, NODE_PATH: <repoRoot>/node_modules }` — résout les modules bare vers les deps du checkout runtime **sans jamais salir ce dernier** (le worktree reste sous `tmpdir`, invariant « 0 working tree sali » préservé). git/gh gardent `env` hérité → auth intacte.
- Robustesse `finally` : `git branch -D <branch>` best-effort après `worktree remove` — sinon un re-run du même plan (`planHash` → même nom de branche) collisionnerait « branch already exists ». La branche distante + PR (si push réussi) subsistent : `-D` ne touche que le ref local.

## Vérification

- ✅ 60/60 tests unit orchestration verts (avec assertion de régression `NODE_PATH=/repo/node_modules` + suppression branche locale)
- ✅ tsc / eslint / prettier OK
- ✅ repro empirique before/after ci-dessus

🤖 Generated with [Claude Code](https://claude.com/claude-code)