### PR TITLE
feat(command-center): cockpit — flux HITL approve (preview → approuver + exécuter), inerte par défaut

### DIFF
--- a/backend/src/modules/admin/controllers/command-center.controller.ts
+++ b/backend/src/modules/admin/controllers/command-center.controller.ts
@@ -38,10 +38,18 @@ import {
 } from '../services/command-center-orchestrator/regen-artifact.executor';
 import { UnknownPrPropositionError } from '../services/command-center-orchestrator/pr-proposition.planner';
 import {
+  computePlanHash,
   type ExecutionPlan,
   type ExecutionReceipt,
   type OrchestrationMode,
 } from '../services/command-center-orchestrator/executable-action.contract';
+
+/**
+ * Preview shadow renvoyé à l'UI : le plan *would-be* + son `plan_hash` déterministe.
+ * Le hash voyage AVEC le plan pour que l'étape approve (HITL) porte exactement le plan
+ * prévisualisé (garde TOCTOU) — l'UI ne recalcule jamais le hash (pas de logique dupliquée).
+ */
+type ShadowPlanPreview = ExecutionPlan & { plan_hash: string };
 
 /** Corps validé du preview shadow (kind aligné sur ExecutableActionKind). */
 const ShadowPlanRequestSchema = z
@@ -131,7 +139,7 @@ export class CommandCenterController {
   async previewShadowPlan(
     @Body() body: unknown,
     @User('email') actorEmail?: string,
-  ): Promise<ExecutionPlan> {
+  ): Promise<ShadowPlanPreview> {
     this.assertExposed();
 
     let parsed: z.infer<typeof ShadowPlanRequestSchema>;
@@ -147,9 +155,13 @@ export class CommandCenterController {
     }
 
     try {
-      return await this.orchestrator.planShadow(parsed.kind, parsed.action_id, {
-        actor: actorEmail ?? 'admin',
-      });
+      const plan = await this.orchestrator.planShadow(
+        parsed.kind,
+        parsed.action_id,
+        { actor: actorEmail ?? 'admin' },
+      );
+      // Le hash déterministe accompagne le plan → l'UI le renvoie tel quel à approve.
+      return { ...plan, plan_hash: computePlanHash(plan) };
     } catch (e) {
       // Mapping HTTP explicite — jamais de 500 opaque sur un cas attendu.
       if (e instanceof OrchestrationDisabledError) {

--- a/backend/tests/unit/command-center.controller.test.ts
+++ b/backend/tests/unit/command-center.controller.test.ts
@@ -112,7 +112,9 @@ describe('CommandCenterController — orchestration', () => {
     const c1 = make({
       planShadow: jest
         .fn()
-        .mockRejectedValue(new UnsupportedExecutableActionError('regen-artifact')),
+        .mockRejectedValue(
+          new UnsupportedExecutableActionError('regen-artifact'),
+        ),
     });
     await expect(
       c1.previewShadowPlan({ kind: 'regen-artifact', action_id: 'x' }),
@@ -136,14 +138,16 @@ describe('CommandCenterController — orchestration', () => {
     ).rejects.toBeInstanceOf(UnprocessableEntityException);
   });
 
-  it('succès → renvoie le plan + propage actor (email)', async () => {
+  it('succès → renvoie le plan + plan_hash déterministe + propage actor (email)', async () => {
     const planShadow = jest.fn().mockResolvedValue(plan);
     const c = make({ orchMode: 'shadow', planShadow });
     const res = await c.previewShadowPlan(
       { kind: 'regen-artifact', action_id: 'regen:command-center-snapshot' },
       'fafa@automecanik.com',
     );
-    expect(res).toEqual(plan);
+    // Le plan est renvoyé tel quel, AUGMENTÉ d'un plan_hash sha256 pour le flux HITL.
+    expect(res).toMatchObject(plan);
+    expect(res.plan_hash).toMatch(/^[a-f0-9]{64}$/);
     expect(planShadow).toHaveBeenCalledWith(
       'regen-artifact',
       'regen:command-center-snapshot',

--- a/frontend/app/components/command-center/OrchestrationPanel.tsx
+++ b/frontend/app/components/command-center/OrchestrationPanel.tsx
@@ -1,18 +1,21 @@
 /**
- * OrchestrationPanel — onglet « Orchestration » du Command Center (ADR-087, shadow).
+ * OrchestrationPanel — onglet « Orchestration » du Command Center (ADR-087).
  *
- * Read-only + preview. Affiche le mode d'orchestration courant (off|shadow|…) et les
- * kinds supportés, et permet de PRÉVISUALISER un plan *would-be* (POST .../shadow) —
- * 0 mutation d'artefact. Le backend reste la source de vérité : l'action_id se choisit
- * dans le catalogue `available_actions` exposé par l'API (#1019), filtré par kind ;
- * fallback en saisie libre si le backend ne fournit pas (encore) le catalogue. Dans
- * tous les cas le serveur valide (400 si inconnu, 409 si mode ≠ shadow, 422 si dry-run KO).
+ * Deux étages HITL (Human-In-The-Loop), le backend restant seule autorité :
+ *  1. PRÉVISUALISER (POST .../shadow) — plan *would-be* + `plan_hash` déterministe,
+ *     0 mutation. L'action_id vient du catalogue `available_actions` (#1019), filtré
+ *     par kind ; fallback saisie libre. Le serveur valide (400/409/422).
+ *  2. APPROUVER + EXÉCUTER (POST .../approve) — visible UNIQUEMENT en mode `approved`,
+ *     renvoie le `plan_hash` du plan prévisualisé (garde TOCTOU). L'exécution réelle
+ *     ouvre une PR draft (réversible) et exige un 2ᵉ flag executor côté backend
+ *     (`COMMAND_CENTER_EXECUTOR=pr`) — sinon 409/501/503 surfacés. Inerte par défaut.
  */
 import {
   Activity,
   PlayCircle,
   AlertTriangle,
   CheckCircle2,
+  Rocket,
 } from "lucide-react";
 import { useState } from "react";
 import { Form, useNavigation } from "react-router";
@@ -42,16 +45,37 @@ export interface ShadowPlanView {
   would_change: boolean;
   reversible: boolean;
   details: Record<string, unknown>;
+  /** hash déterministe du plan — renvoyé tel quel à approve (garde TOCTOU, HITL). */
+  plan_hash: string;
+}
+
+/** Reçu d'une exécution approuvée (Phase 2) — ce qui A ÉTÉ fait + comment l'annuler. */
+export interface ExecutionReceiptView {
+  action_id: string;
+  kind: string;
+  applied: boolean;
+  plan_hash: string;
+  reverted_by: string | null;
+  details: Record<string, unknown>;
 }
 
 export type OrchestrationActionData =
-  | { ok: true; plan: ShadowPlanView }
+  | { ok: true; intent: "preview"; plan: ShadowPlanView }
+  | { ok: true; intent: "approve"; receipt: ExecutionReceiptView }
   | { ok: false; error: string };
 
 function modeBadgeVariant(
   mode: OrchestrationStatus["mode"],
-): "secondary" | "success" {
-  return mode === "shadow" ? "success" : "secondary";
+): "secondary" | "success" | "warning" {
+  if (mode === "shadow") return "success";
+  if (mode === "approved") return "warning"; // mode HITL : peut muter (double-flag)
+  return "secondary";
+}
+
+/** URL de PR éventuelle portée par le reçu d'exécution (details.pr_url). */
+function receiptPrUrl(receipt: ExecutionReceiptView): string | null {
+  const u = receipt.details?.pr_url;
+  return typeof u === "string" && u.length > 0 ? u : null;
 }
 
 export function OrchestrationPanel({
@@ -62,7 +86,13 @@ export function OrchestrationPanel({
   result?: OrchestrationActionData;
 }) {
   const navigation = useNavigation();
-  const submitting = navigation.state === "submitting";
+  // Intent en cours de soumission (pour désactiver le bon bouton uniquement).
+  const submittingIntent =
+    navigation.state === "submitting"
+      ? String(navigation.formData?.get("intent") ?? "preview")
+      : null;
+  const previewing = submittingIntent === "preview";
+  const approving = submittingIntent === "approve";
   // Hook AVANT tout early-return (rules of hooks). Vide → défaut dérivé du statut.
   const [kind, setKind] = useState("");
 
@@ -100,10 +130,16 @@ export function OrchestrationPanel({
           <div className="flex flex-wrap items-center gap-2 text-sm">
             <span className="text-muted-foreground">Mode :</span>
             <Badge variant={modeBadgeVariant(status.mode)}>{status.mode}</Badge>
-            {status.shadow_enabled ? (
+            {status.mode === "shadow" ? (
               <span className="text-muted-foreground">
                 — calcul <em>would-be</em> uniquement, 0 mutation
                 d&apos;artefact.
+              </span>
+            ) : status.mode === "approved" ? (
+              <span className="text-muted-foreground">
+                — HITL : prévisualise puis <strong>approuve</strong> pour
+                exécuter (ouvre une PR draft ; requiert aussi{" "}
+                <code className="text-xs">COMMAND_CENTER_EXECUTOR=pr</code>).
               </span>
             ) : (
               <span className="text-muted-foreground">
@@ -143,6 +179,7 @@ export function OrchestrationPanel({
             method="post"
             className="flex flex-col gap-3 sm:flex-row sm:items-end"
           >
+            <input type="hidden" name="intent" value="preview" />
             <div className="flex flex-col gap-1">
               <label htmlFor="orch-kind" className="text-sm font-medium">
                 Kind
@@ -190,8 +227,8 @@ export function OrchestrationPanel({
                 />
               )}
             </div>
-            <Button type="submit" disabled={submitting}>
-              {submitting ? "Calcul…" : "Prévisualiser"}
+            <Button type="submit" disabled={previewing}>
+              {previewing ? "Calcul…" : "Prévisualiser"}
             </Button>
           </Form>
           <p className="mt-2 text-xs text-muted-foreground">
@@ -202,37 +239,139 @@ export function OrchestrationPanel({
           </p>
 
           {result ? (
-            <div className="mt-4">
-              {result.ok ? (
+            <div className="mt-4 space-y-3">
+              {!result.ok ? (
                 <Alert
-                  variant={result.plan.would_change ? "warning" : "success"}
+                  variant="error"
+                  icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
+                >
+                  <AlertTitle>Action refusée</AlertTitle>
+                  <AlertDescription>{result.error}</AlertDescription>
+                </Alert>
+              ) : result.intent === "preview" ? (
+                <>
+                  <Alert
+                    variant={result.plan.would_change ? "warning" : "success"}
+                    icon={
+                      result.plan.would_change ? (
+                        <AlertTriangle className="h-5 w-5" aria-hidden />
+                      ) : (
+                        <CheckCircle2 className="h-5 w-5" aria-hidden />
+                      )
+                    }
+                  >
+                    <AlertTitle>
+                      {result.plan.would_change
+                        ? "Changement détecté (would-be)"
+                        : "Aucun changement (déjà à jour)"}
+                    </AlertTitle>
+                    <AlertDescription>
+                      <p className="mb-2">{result.plan.summary}</p>
+                      <pre className="max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs">
+                        {JSON.stringify(result.plan.details, null, 2)}
+                      </pre>
+                    </AlertDescription>
+                  </Alert>
+
+                  {/* Étape 2 HITL — n'apparaît que si le plan muterait ET mode approved. */}
+                  {result.plan.would_change &&
+                  result.plan.reversible &&
+                  status.mode === "approved" ? (
+                    <Form method="post" className="space-y-2">
+                      <input type="hidden" name="intent" value="approve" />
+                      <input
+                        type="hidden"
+                        name="kind"
+                        value={result.plan.kind}
+                      />
+                      <input
+                        type="hidden"
+                        name="action_id"
+                        value={result.plan.action_id}
+                      />
+                      <input
+                        type="hidden"
+                        name="plan_hash"
+                        value={result.plan.plan_hash}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        L&apos;approbation exécute réellement CE plan (hash{" "}
+                        <code className="text-xs">
+                          {result.plan.plan_hash.slice(0, 12)}
+                        </code>
+                        ) : elle <strong>ouvre une PR draft</strong> — rien
+                        n&apos;atterrit sur{" "}
+                        <code className="text-xs">main</code> sans review +
+                        merge humain. Réversible (fermer la PR).
+                      </p>
+                      <Button
+                        type="submit"
+                        variant="destructive"
+                        disabled={approving}
+                      >
+                        <Rocket className="mr-2 h-4 w-4" aria-hidden />
+                        {approving
+                          ? "Exécution…"
+                          : "Approuver + exécuter (PR draft)"}
+                      </Button>
+                    </Form>
+                  ) : result.plan.would_change && status.mode !== "approved" ? (
+                    <p className="text-xs text-muted-foreground">
+                      Pour exécuter ce plan : passe l&apos;orchestration en mode{" "}
+                      <code className="text-xs">
+                        COMMAND_CENTER_ORCHESTRATION=approved
+                      </code>{" "}
+                      et active l&apos;executor{" "}
+                      <code className="text-xs">
+                        COMMAND_CENTER_EXECUTOR=pr
+                      </code>{" "}
+                      (DEV/PREPROD ; PROD reste forcé <code>off</code>).
+                    </p>
+                  ) : null}
+                </>
+              ) : (
+                // intent === "approve" → reçu d'exécution.
+                <Alert
+                  variant={result.receipt.applied ? "success" : "info"}
                   icon={
-                    result.plan.would_change ? (
-                      <AlertTriangle className="h-5 w-5" aria-hidden />
+                    result.receipt.applied ? (
+                      <Rocket className="h-5 w-5" aria-hidden />
                     ) : (
                       <CheckCircle2 className="h-5 w-5" aria-hidden />
                     )
                   }
                 >
                   <AlertTitle>
-                    {result.plan.would_change
-                      ? "Changement détecté (would-be)"
-                      : "Aucun changement (déjà à jour)"}
+                    {result.receipt.applied
+                      ? "Exécuté — PR draft ouverte"
+                      : "Aucune exécution (no-op, déjà à jour)"}
                   </AlertTitle>
                   <AlertDescription>
-                    <p className="mb-2">{result.plan.summary}</p>
-                    <pre className="max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs">
-                      {JSON.stringify(result.plan.details, null, 2)}
+                    {receiptPrUrl(result.receipt) ? (
+                      <p className="mb-2">
+                        PR :{" "}
+                        <a
+                          href={receiptPrUrl(result.receipt) as string}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-medium underline"
+                        >
+                          {receiptPrUrl(result.receipt)}
+                        </a>
+                      </p>
+                    ) : null}
+                    {result.receipt.reverted_by ? (
+                      <p className="text-xs">
+                        Annuler :{" "}
+                        <code className="text-xs">
+                          {result.receipt.reverted_by}
+                        </code>
+                      </p>
+                    ) : null}
+                    <pre className="mt-2 max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs">
+                      {JSON.stringify(result.receipt.details, null, 2)}
                     </pre>
                   </AlertDescription>
-                </Alert>
-              ) : (
-                <Alert
-                  variant="error"
-                  icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
-                >
-                  <AlertTitle>Prévisualisation refusée</AlertTitle>
-                  <AlertDescription>{result.error}</AlertDescription>
                 </Alert>
               )}
             </div>

--- a/frontend/app/routes/admin.command-center.tsx
+++ b/frontend/app/routes/admin.command-center.tsx
@@ -32,6 +32,7 @@ import { GlobalHealthBar } from "~/components/command-center/GlobalHealthBar";
 import { ModuleGrid } from "~/components/command-center/ModuleGrid";
 import {
   OrchestrationPanel,
+  type ExecutionReceiptView,
   type OrchestrationActionData,
   type OrchestrationStatus,
   type ShadowPlanView,
@@ -166,12 +167,69 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
   }
 }
 
+/** Extrait un message d'erreur lisible du corps backend (AdminResponseInterceptor / Nest). */
+function backendError(
+  body: { message?: string | string[] },
+  status: number,
+): string {
+  return Array.isArray(body.message)
+    ? body.message.join(", ")
+    : (body.message ?? `Erreur backend ${status}`);
+}
+
+/**
+ * Deux intents (HITL preview → approve) vers le backend gouverné :
+ *  - `preview`  → POST /orchestration/shadow  : plan *would-be* + plan_hash (0 mutation).
+ *  - `approve`  → POST /orchestration/approve : exécution réelle du plan approuvé (mode
+ *    `approved` + double-flag executor requis côté backend, sinon 409/501/503 surfacés).
+ * Le backend reste la seule autorité : l'UI ne fait que router + afficher son verdict.
+ */
 export async function action({ request, context }: ActionFunctionArgs) {
   await requireAdmin({ context });
   const form = await request.formData();
+  const intent = String(form.get("intent") ?? "preview");
   const kind = String(form.get("kind") ?? "");
   const action_id = String(form.get("action_id") ?? "");
 
+  if (intent === "approve") {
+    const plan_hash = String(form.get("plan_hash") ?? "");
+    try {
+      const res = await fetch(
+        getInternalApiUrlFromRequest(
+          "/api/admin/command-center/orchestration/approve",
+          request,
+        ),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: request.headers.get("Cookie") || "",
+          },
+          body: JSON.stringify({ kind, action_id, plan_hash }),
+        },
+      );
+      const body = (await res.json().catch(() => ({}))) as {
+        data?: ExecutionReceiptView;
+        message?: string | string[];
+      } & ExecutionReceiptView;
+      if (!res.ok) {
+        return data(
+          { ok: false, error: backendError(body, res.status) },
+          { status: res.status },
+        );
+      }
+      const receipt = body.data ?? (body as ExecutionReceiptView);
+      return { ok: true, intent: "approve" as const, receipt };
+    } catch (e) {
+      logger.error(`[command-center] approve execution failed: ${e}`);
+      return data(
+        { ok: false, error: "Backend injoignable." },
+        { status: 502 },
+      );
+    }
+  }
+
+  // intent === "preview" (défaut)
   try {
     const res = await fetch(
       getInternalApiUrlFromRequest(
@@ -192,13 +250,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
       message?: string | string[];
     } & ShadowPlanView;
     if (!res.ok) {
-      const msg = Array.isArray(body.message)
-        ? body.message.join(", ")
-        : (body.message ?? `Erreur backend ${res.status}`);
-      return data({ ok: false, error: msg }, { status: res.status });
+      return data(
+        { ok: false, error: backendError(body, res.status) },
+        { status: res.status },
+      );
     }
     const plan = body.data ?? (body as ShadowPlanView);
-    return { ok: true, plan };
+    return { ok: true, intent: "preview" as const, plan };
   } catch (e) {
     logger.error(`[command-center] shadow preview failed: ${e}`);
     return data({ ok: false, error: "Backend injoignable." }, { status: 502 });


### PR DESCRIPTION
## Contexte

Complète l'arc **Phase 2 (ADR-087)** de l'orchestration Command Center. Le backend expose déjà : preview shadow (#1017/#1019), approve HITL (#1021 Phase 2a), executor PR-draft (#1022 Phase 2b, fix js-yaml #1198). Il manquait **la surface UI pour boucler `preview → approve`** — un admin ne pouvait approuver que par `curl`. Ce PR ajoute le bouton d'approbation dans le cockpit.

## Ce que ça fait

**Backend** (`command-center.controller.ts`) :
- `/orchestration/shadow` renvoie désormais le **`plan_hash` déterministe** (`computePlanHash`) avec le plan. L'UI le reporte tel quel à `/approve` (garde **TOCTOU**) — **jamais** de recalcul de hash côté client (pas de logique dupliquée ni de dérive).

**Frontend** (`admin.command-center.tsx` action) :
- multiplex `intent=preview|approve` : preview → `/shadow` ; approve → `/approve` avec `{kind, action_id, plan_hash}`. Le backend reste **seule autorité** ; l'UI route + affiche le verdict.

**Frontend** (`OrchestrationPanel.tsx`) :
- carte statut **mode-aware** (shadow / approved / off — corrige le « inactif » trompeur en mode approved) ;
- bouton **« Approuver + exécuter (PR draft) »** visible **uniquement si** `mode=approved` **ET** `would_change` **ET** `reversible` ; sinon un hint explique les 2 flags requis ;
- **warning explicite** : l'approbation ouvre une **PR draft** (rien sur `main` sans review + merge humain), réversible (fermer la PR) ;
- rendu du **reçu d'exécution** : lien PR + commande d'annulation (`reverted_by`).

## Sécurité / inertie (par défaut)

| Garde | Effet |
|---|---|
| admin-only | `requireAdmin` (route) + `AuthenticatedGuard`+`IsAdminGuard` (controller) |
| bouton conditionnel | ne s'affiche **qu'en mode `approved`** avec un plan mutant réversible |
| TOCTOU | approve porte le `plan_hash` prévisualisé ; backend re-hash + refuse si périmé (409) |
| double-flag executor | `COMMAND_CENTER_EXECUTOR=pr` requis, sinon 409 (surfacé) |
| PROD | orchestration forcée `off` → 409 ; `COMMAND_CENTER_MODE=disabled` → 404 |
| réversible | exécution = PR **draft** ; `reverted_by = gh pr close <url>` |

→ **0 mutation** tant que les 2 flags ne sont pas posés (DEV/PREPROD, décision owner).

## Vérification

- ✅ 60/60 tests unit orchestration verts (controller preview `plan_hash` mis à jour : `toMatchObject(plan)` + `plan_hash` sha256)
- ✅ tsc / eslint / prettier OK (backend + frontend)
- ⏳ Smoke live = post-merge (resync DEV) ; l'exécution réelle reste **owner-gated** par les 2 flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)