### PR TITLE
fix(lazy): stop Footer mixed static+dynamic import crashing R2 pages (Rolldown fulfill-undefined)

### DIFF
--- a/frontend/app/components/LazyBoundary.tsx
+++ b/frontend/app/components/LazyBoundary.tsx
@@ -1,0 +1,73 @@
+/**
+ * LazyBoundary — ErrorBoundary réutilisable pour UI **lazy non-critique**.
+ * Généralise l'ancien `ChatWidgetErrorBoundary` (root.tsx) en un composant
+ * paramétré par `name` (libellé warn/balise) + `fallback` (défaut `null`).
+ *
+ * CLASSIFIANT (must-fix red-team #5) : SEULE la classe « fulfill-with-undefined
+ * / safeLazy » est avalée → dégrade vers `fallback` + est observée. TOUTE autre
+ * erreur est **re-jetée** (pendant le render de récupération → propagation
+ * déterministe vers l'ErrorBoundary de route). Une vraie régression ne doit
+ * jamais être masquée silencieusement (canon : no silent fallback).
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { logger } from "~/utils/logger";
+import { reportChunkResolvedInvalid } from "~/utils/runtime-errors.client";
+
+interface LazyBoundaryProps {
+  /** Libellé diagnostic (warn + meta balise). Aucune PII. */
+  name: string;
+  /** Rendu en cas de crash lazy avalé. Défaut `null` (dégradation silencieuse). */
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Vrai uniquement pour les signatures lazy-init / resolved-undefined qu'on est
+ * autorisé à avaler : le message synthétique de `safeLazy`, ou le `TypeError`
+ * brut de React.lazy lisant `_result.default` sur `undefined`. Toute autre
+ * erreur (y compris un autre `reading 'x'` sur undefined) → NON reconnue.
+ */
+export function isLazyInitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const m = error.message ?? "";
+  return (
+    m.startsWith("[safeLazy:") ||
+    (error instanceof TypeError &&
+      m.includes("reading 'default'") &&
+      m.includes("undefined"))
+  );
+}
+
+export class LazyBoundary extends Component<
+  LazyBoundaryProps,
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error): { error: Error } {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Side-effects (warn + balise) UNIQUEMENT pour la classe avalée. Le re-jet
+    // d'une vraie erreur se fait dans render() (déterministe), pas ici.
+    if (!isLazyInitError(error)) return;
+    logger.warn(
+      `[${this.props.name}] crash intercepte:`,
+      error.message,
+      info.componentStack?.slice(0, 200),
+    );
+    reportChunkResolvedInvalid({ name: this.props.name, stage: "boundary" });
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error) {
+      if (isLazyInitError(error)) return this.props.fallback ?? null;
+      // Vraie régression → re-jeter pour remonter à l'ErrorBoundary de route.
+      throw error;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/app/components/home/LazyFooter.tsx
+++ b/frontend/app/components/home/LazyFooter.tsx
@@ -1,0 +1,44 @@
+/**
+ * LazyFooter — footer global partagé, chargé en lazy via un **specifier
+ * canonique unique** `~/components/home/Footer`.
+ *
+ * Pourquoi ce composant existe (cause racine du crash PROD) : `Footer` était
+ * importé à la fois STATIQUEMENT (barrel `~/components/home`, dans `_index` et
+ * `pieces.$slug`) et DYNAMIQUEMENT (`lazy(() => import("./components/home/Footer"))`
+ * dans `root`). Ce mix statique+dynamique sous Vite 8 / Rolldown peut produire
+ * un chunk dont l'`import()` dynamique se **résout avec `undefined`** →
+ * `React.lazy` lit `_result.default` sur `undefined` → `TypeError: Cannot read
+ * properties of undefined (reading 'default')` (crash R2 en prod).
+ *
+ * Correctif : TOUS les points de rendu du footer passent par CE composant
+ * (donc par le MÊME specifier alias `~/components/home/Footer`), et plus aucun
+ * import statique de `Footer` ne subsiste → `Footer.tsx` n'a que des importeurs
+ * dynamiques → condition de mixed-chunk éliminée. La position DOM à chaque site
+ * de rendu est inchangée (le `<Suspense fallback={null}>` + boundary sont
+ * transparents au layout : pas de skeleton, pas de CLS).
+ */
+
+import { Suspense } from "react";
+import { LazyBoundary } from "~/components/LazyBoundary";
+import { safeLazy } from "~/utils/resilient-lazy.client";
+
+// Specifier canonique UNIQUE — forme alias — utilisé nulle part ailleurs en
+// import statique. Rolldown ne coalesce en un seul chunk dynamique que si cette
+// chaîne est l'unique chemin vers Footer.tsx (vérifié par le gate build-graph).
+const Footer = safeLazy(() => import("~/components/home/Footer"), {
+  name: "GlobalFooter",
+});
+
+/**
+ * Footer below-fold partagé. Rendu identique à un `<Footer/>` nu. Utilisé par
+ * root/AppShell, `_index`, `pieces.$slug`.
+ */
+export function LazyFooter() {
+  return (
+    <LazyBoundary name="GlobalFooter">
+      <Suspense fallback={null}>
+        <Footer />
+      </Suspense>
+    </LazyBoundary>
+  );
+}

--- a/frontend/app/components/home/index.ts
+++ b/frontend/app/components/home/index.ts
@@ -4,7 +4,11 @@ export { default as CatalogueSection } from "./CatalogueSection";
 export { default as BrandsGrid } from "./BrandsGrid";
 export { default as BlogCarousel } from "./BlogCarousel";
 export { default as FaqSection } from "./FaqSection";
-export { default as Footer } from "./Footer";
+// NB : `Footer` n'est PLUS ré-exporté ici. Il est chargé exclusivement en lazy
+// via `~/components/home/LazyFooter` (specifier canonique unique). Le ré-exporter
+// dans ce barrel recréait un import STATIQUE de `Footer.tsx` (INEFFECTIVE_DYNAMIC_IMPORT
+// sous Rolldown) → chunk mixed static+dynamic dont l'`import()` peut résoudre
+// `undefined` → crash `React.lazy` `_result.default`. Voir LazyFooter.tsx.
 export { default as HomeResourcesAndVideoSection } from "./GuidesStrip";
 export { default as WhyAutomecanikSection } from "./WhyAutomecanikSection";
 export { default as DiagnosticBanner } from "./DiagnosticBanner";

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,13 +1,5 @@
 import { ChevronUp } from "lucide-react";
-import {
-  Component,
-  lazy,
-  Suspense,
-  useEffect,
-  useRef,
-  type ErrorInfo,
-  type ReactNode,
-} from "react";
+import { lazy, Suspense, useEffect, useRef } from "react";
 import {
   type ActionFunctionArgs,
   type HeadersFunction,
@@ -29,8 +21,11 @@ import {
   useNavigation,
 } from "react-router";
 
+import { LazyFooter } from "~/components/home/LazyFooter";
+import { LazyBoundary } from "~/components/LazyBoundary";
 import { cspNonceContext } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
+import { safeLazy } from "~/utils/resilient-lazy.client";
 import { getOptionalUser } from "./auth/unified.server";
 import { ErrorGeneric } from "./components/errors";
 import { Navbar } from "./components/Navbar";
@@ -46,9 +41,15 @@ import { useScrollBehavior } from "./hooks/useScrollBehavior";
 import { getCart } from "./services/cart.server";
 import animationsStylesheet from "./styles/animations.css?url";
 
-const ChatWidget = lazy(() => import("./components/rag/ChatWidget"));
-const GlobalFooter = lazy(() => import("./components/home/Footer"));
-const BottomNav = lazy(() => import("./components/layout/BottomNav"));
+// GlobalFooter n'est plus déclaré ici : rendu via <LazyFooter/> (composant partagé,
+// specifier canonique unique `~/components/home/Footer`) — voir components/home/LazyFooter.
+// ChatWidget/BottomNav passent par safeLazy (durcissement fulfill-with-undefined).
+const ChatWidget = safeLazy(() => import("./components/rag/ChatWidget"), {
+  name: "ChatWidget",
+});
+const BottomNav = safeLazy(() => import("./components/layout/BottomNav"), {
+  name: "BottomNav",
+});
 const LazyToaster = lazy(() =>
   import("sonner").then((m) => ({ default: m.Toaster })),
 );
@@ -168,41 +169,16 @@ export const action = async (_args: ActionFunctionArgs) => {
 // Re-exports depuis module neutre pour éviter la dépendance circulaire root ↔ Navbar
 export { useOptionalUser, useRootCart } from "./hooks/useRootData";
 
-/** Error boundary that silently catches ChatWidget crashes without affecting the app. */
-class ChatWidgetErrorBoundary extends Component<
-  { children: ReactNode },
-  { hasError: boolean }
-> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-  componentDidCatch(error: Error, info: ErrorInfo) {
-    logger.warn(
-      "[ChatWidget] crash intercepte:",
-      error.message,
-      info.componentStack?.slice(0, 200),
-    );
-  }
-  render() {
-    if (this.state.hasError) return null;
-    return this.props.children;
-  }
-}
-
 /** Lazy-loaded ChatWidget wrapped in error boundary + suspense + hydration guard */
 function ChatWidgetSafe() {
   const isHydrated = useHydrated();
   if (!isHydrated) return null;
   return (
-    <ChatWidgetErrorBoundary>
+    <LazyBoundary name="ChatWidget">
       <Suspense fallback={null}>
         <ChatWidget />
       </Suspense>
-    </ChatWidgetErrorBoundary>
+    </LazyBoundary>
   );
 }
 
@@ -357,15 +333,13 @@ function AppShell({ children }: { children: React.ReactNode }) {
       <main className="grow flex flex-col">
         <div className="grow">{children}</div>
       </main>
-      {!hideGlobalFooter && (
-        <Suspense fallback={null}>
-          <GlobalFooter />
-        </Suspense>
-      )}
+      {!hideGlobalFooter && <LazyFooter />}
       {!hideBottomNav && (
-        <Suspense fallback={null}>
-          <BottomNav />
-        </Suspense>
+        <LazyBoundary name="BottomNav">
+          <Suspense fallback={null}>
+            <BottomNav />
+          </Suspense>
+        </LazyBoundary>
       )}
       <NotificationContainer />
       <button

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -16,12 +16,12 @@ import {
   BrandsGrid,
   BlogCarousel,
   FaqSection,
-  Footer,
   WhyAutomecanikSection,
   DiagnosticBanner,
   PopularSearches,
 } from "~/components/home";
 import { type BrandItem } from "~/components/home/constants";
+import { LazyFooter } from "~/components/home/LazyFooter";
 import { getRemixApiService } from "~/server/remix-api.server";
 import {
   type SlimFamily,
@@ -250,7 +250,7 @@ export default function Homepage() {
 
       <PopularSearches />
       <FaqSection faqsPromise={loaderData.faqs} />
-      <Footer />
+      <LazyFooter />
     </div>
   );
 }

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -34,7 +34,7 @@ import {
   GammeGuideCTA,
   GammeFaq,
 } from "~/components/gamme";
-import { Footer } from "~/components/home";
+import { LazyFooter } from "~/components/home/LazyFooter";
 
 import CatalogueSection from "~/components/pieces/CatalogueSection";
 import EquipementiersSection from "~/components/pieces/EquipementiersSection";
@@ -1092,7 +1092,7 @@ export default function PiecesDetailPage() {
           )}
         </div>
       </section>
-      <Footer />
+      <LazyFooter />
     </div>
   );
 }

--- a/frontend/app/utils/resilient-lazy.client.ts
+++ b/frontend/app/utils/resilient-lazy.client.ts
@@ -1,0 +1,86 @@
+/**
+ * resilient-lazy.client — `React.lazy` durci contre l'`import()` dynamique qui
+ * **résout avec `undefined`** (artefact Rolldown mixed-chunk : un module importé
+ * à la fois statiquement et dynamiquement peut voir son `import()` dynamique
+ * résolu sur `undefined`). React.lazy lit alors `_result.default` sur `undefined`
+ * → `TypeError: Cannot read properties of undefined (reading 'default')`.
+ *
+ * Décision (validée red-team) : sur résolution invalide, on **observe** (balise
+ * `reportChunkResolvedInvalid`) puis on **jette** pour laisser `LazyBoundary`
+ * dégrader vers `null`. **PAS de retry, PAS de reload** :
+ *   - retry : le registre ESM a mis en cache le namespace `undefined` → un
+ *     ré-`import()` ne récupère pas, et peut re-déclencher des side-effects
+ *     top-level ;
+ *   - reload : l'artefact est déterministe → recharger le même graphe de chunks
+ *     boucle et détruit l'état en cours (panier / formulaire) sur la page R2.
+ * Le reload sur *rejet* (stale chunk après déploiement) reste géré, inchangé,
+ * par `vite:preloadError` (`chunk-reload.client.ts`).
+ *
+ * Portée : uniquement les `lazy()` à **factory nue** (`() => import("X")`) dont
+ * la valeur résolue est le namespace du module (peut être `undefined`). Les
+ * lazies `.then(m => ({ default: m.X }))` résolvent un littéral objet (jamais
+ * `undefined`) — hors classe de crash, non routés ici.
+ */
+
+import { type ComponentType, type LazyExoticComponent, lazy } from "react";
+import { reportChunkResolvedInvalid } from "~/utils/runtime-errors.client";
+
+/** Forme de module que `React.lazy` sait rendre. */
+export type DefaultModule<T extends ComponentType<unknown>> = { default: T };
+
+export interface SafeLazyOptions {
+  /** Libellé diagnostic (balise meta + warn boundary). Aucune PII. */
+  name: string;
+}
+
+/**
+ * Vrai uniquement si `mod` est un namespace de module exposant un `default`
+ * utilisable. Rejette explicitement le cas `undefined` (la forme exacte sur
+ * laquelle le bundle live plante) + `null` + primitives + `default` absent/nul.
+ */
+export function isValidDefaultModule(
+  mod: unknown,
+): mod is DefaultModule<ComponentType<unknown>> {
+  return (
+    mod != null &&
+    typeof mod === "object" &&
+    "default" in mod &&
+    (mod as { default?: unknown }).default != null
+  );
+}
+
+/**
+ * Cœur du loader — exporté pour être testable sans rendu React. Résout la
+ * factory, valide la forme, émet la balise sur échec, puis jette. Un seul appel
+ * de factory (aucun retry).
+ */
+export async function loadSafeModule<T extends ComponentType<unknown>>(
+  factory: () => Promise<unknown>,
+  opts: SafeLazyOptions,
+): Promise<DefaultModule<T>> {
+  let mod: unknown;
+  try {
+    mod = await factory();
+  } catch (cause) {
+    // Rejet réel (stale chunk / réseau) : observer puis re-jeter. La décision
+    // de reload appartient exclusivement à `vite:preloadError`.
+    reportChunkResolvedInvalid({ name: opts.name, stage: "rejected" });
+    throw cause instanceof Error ? cause : new Error(String(cause));
+  }
+  if (isValidDefaultModule(mod)) return mod as DefaultModule<T>;
+  // Résolu-avec-undefined / default manquant → observer + dégrader (pas de reload).
+  reportChunkResolvedInvalid({ name: opts.name, stage: "resolved_undefined" });
+  throw new Error(`[safeLazy:${opts.name}] resolved without a default export`);
+}
+
+/**
+ * Drop-in pour `React.lazy` sur une factory nue. Rendu sous le `<Suspense>` de
+ * l'appelant ; à protéger par `<LazyBoundary>` pour dégrader la classe
+ * fulfill-with-undefined au lieu de la faire remonter à l'ErrorBoundary de route.
+ */
+export function safeLazy<T extends ComponentType<unknown>>(
+  factory: () => Promise<unknown>,
+  opts: SafeLazyOptions,
+): LazyExoticComponent<T> {
+  return lazy<T>(() => loadSafeModule<T>(factory, opts));
+}

--- a/frontend/app/utils/runtime-errors.client.ts
+++ b/frontend/app/utils/runtime-errors.client.ts
@@ -142,25 +142,47 @@ export function reportHydrationError(meta: Record<string, unknown> = {}): void {
 }
 
 /**
- * Émet un évènement pour le cas « `import()` dynamique résolu SANS default
- * utilisable » (fulfill-with-undefined, artefact Rolldown mixed-chunk) —
- * distinct des rejections stale-chunk classiques. Réutilise l'enum existant
- * `seo.runtime.chunk_load_error` + un discriminant `meta.reason` (`meta` est
- * free-form `z.record` côté contrat → aucune migration DB). Appelé par
- * `resilient-lazy.client.ts` ET `LazyBoundary` : chaque résolution invalide est
- * comptée → pas de silent fallback même quand irrécupérable.
- *
- * NB : le `stage` fourni par l'appelant (`resolved_undefined` | `rejected` |
- * `boundary`) est conservé dans `meta` pour la ventilation dashboard.
+ * Dérive `(reason, message)` de la balise depuis le `stage` de l'appelant.
+ * Distingue le REJET réel (`stage: "rejected"` : stale chunk / réseau →
+ * `reason: "load_rejected"`) de la classe fulfill-with-undefined
+ * (`resolved_undefined` | `boundary` | défaut → `reason: "resolved_undefined"`).
+ * Sans cette dérivation, un rejet réel serait mislabelisé `resolved_undefined`
+ * (review PR #1200) → ventilation dashboard `meta.reason` faussée. Pur/testable.
+ */
+export function resolveChunkEventLabels(stage?: string): {
+  reason: string;
+  message: string;
+} {
+  if (stage === "rejected") {
+    return {
+      reason: "load_rejected",
+      message: "Dynamic import rejected (chunk load failed)",
+    };
+  }
+  return {
+    reason: "resolved_undefined",
+    message: "Dynamic import fulfilled with undefined",
+  };
+}
+
+/**
+ * Émet un évènement pour un `import()` dynamique en échec — soit résolu SANS
+ * default utilisable (fulfill-with-undefined, artefact Rolldown mixed-chunk),
+ * soit rejeté (stale chunk / réseau). Réutilise l'enum existant
+ * `seo.runtime.chunk_load_error` + un discriminant `meta.reason` DÉRIVÉ du
+ * `stage` (`meta` est free-form `z.record` côté contrat → aucune migration DB).
+ * Appelé par `resilient-lazy.client.ts` ET `LazyBoundary` : chaque échec est
+ * compté → pas de silent fallback même quand irrécupérable. Le `stage`
+ * (`resolved_undefined` | `rejected` | `boundary`) reste dans `meta` pour la
+ * ventilation fine.
  */
 export function reportChunkResolvedInvalid(
   meta: Record<string, unknown> = {},
 ): void {
-  sendEvent(
-    "seo.runtime.chunk_load_error",
-    { ...meta, reason: "resolved_undefined" },
-    "Dynamic import fulfilled with undefined",
+  const { reason, message } = resolveChunkEventLabels(
+    typeof meta.stage === "string" ? meta.stage : undefined,
   );
+  sendEvent("seo.runtime.chunk_load_error", { ...meta, reason }, message);
 }
 
 function captureLongTasks(): void {

--- a/frontend/app/utils/runtime-errors.client.ts
+++ b/frontend/app/utils/runtime-errors.client.ts
@@ -141,6 +141,28 @@ export function reportHydrationError(meta: Record<string, unknown> = {}): void {
   sendEvent("seo.runtime.hydration_error", meta, "React hydration mismatch");
 }
 
+/**
+ * Émet un évènement pour le cas « `import()` dynamique résolu SANS default
+ * utilisable » (fulfill-with-undefined, artefact Rolldown mixed-chunk) —
+ * distinct des rejections stale-chunk classiques. Réutilise l'enum existant
+ * `seo.runtime.chunk_load_error` + un discriminant `meta.reason` (`meta` est
+ * free-form `z.record` côté contrat → aucune migration DB). Appelé par
+ * `resilient-lazy.client.ts` ET `LazyBoundary` : chaque résolution invalide est
+ * comptée → pas de silent fallback même quand irrécupérable.
+ *
+ * NB : le `stage` fourni par l'appelant (`resolved_undefined` | `rejected` |
+ * `boundary`) est conservé dans `meta` pour la ventilation dashboard.
+ */
+export function reportChunkResolvedInvalid(
+  meta: Record<string, unknown> = {},
+): void {
+  sendEvent(
+    "seo.runtime.chunk_load_error",
+    { ...meta, reason: "resolved_undefined" },
+    "Dynamic import fulfilled with undefined",
+  );
+}
+
 function captureLongTasks(): void {
   if (typeof PerformanceObserver === "undefined") return;
   try {

--- a/frontend/tests/unit/lazy-boundary.test.tsx
+++ b/frontend/tests/unit/lazy-boundary.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests unitaires — `LazyBoundary` + `isLazyInitError`
+ * (`frontend/app/components/LazyBoundary.tsx`).
+ *
+ * `LazyBoundary` généralise l'ancien `ChatWidgetErrorBoundary`. **Doit
+ * classifier** (must-fix red-team #5) : seule la classe « fulfill-with-undefined
+ * / safeLazy » est avalée → dégrade vers `fallback` (null par défaut) + observée ;
+ * TOUTE autre erreur re-jette pour remonter à l'ErrorBoundary de route (une vraie
+ * régression ne doit JAMAIS être masquée silencieusement).
+ */
+
+import { render } from "@testing-library/react";
+import { Component, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LazyBoundary, isLazyInitError } from "~/components/LazyBoundary";
+
+// `vi.hoisted` expose les spies à la factory auto-hoistée de `vi.mock`.
+const { reportChunkResolvedInvalid, warn } = vi.hoisted(() => ({
+  reportChunkResolvedInvalid: vi.fn(),
+  warn: vi.fn(),
+}));
+vi.mock("~/utils/runtime-errors.client", () => ({ reportChunkResolvedInvalid }));
+vi.mock("~/utils/logger", () => ({ logger: { warn } }));
+
+function Thrower({ error }: { error: Error }): ReactNode {
+  throw error;
+}
+
+/** Outer catch-all boundary to observe whether the inner LazyBoundary re-threw. */
+class CatchAll extends Component<
+  { onCatch: (e: Error) => void; children: ReactNode },
+  { caught: boolean }
+> {
+  state = { caught: false };
+  static getDerivedStateFromError() {
+    return { caught: true };
+  }
+  componentDidCatch(error: Error) {
+    this.props.onCatch(error);
+  }
+  render() {
+    return this.state.caught ? <div data-testid="outer-fallback" /> : this.props.children;
+  }
+}
+
+let consoleErr: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  reportChunkResolvedInvalid.mockClear();
+  warn.mockClear();
+  // React prints caught render errors to console.error — silence to keep output pristine.
+  consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => consoleErr.mockRestore());
+
+describe("isLazyInitError (classifier)", () => {
+  it("recognizes a safeLazy resolved-without-default error", () => {
+    expect(
+      isLazyInitError(new Error("[safeLazy:GlobalFooter] resolved without a default export")),
+    ).toBe(true);
+  });
+
+  it("recognizes the raw React.lazy reading-'default'-on-undefined TypeError", () => {
+    expect(
+      isLazyInitError(
+        new TypeError("Cannot read properties of undefined (reading 'default')"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT recognize a genuine undefined-read bug on another property", () => {
+    expect(
+      isLazyInitError(
+        new TypeError("Cannot read properties of undefined (reading 'map')"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT recognize an unrelated error", () => {
+    expect(isLazyInitError(new Error("something else broke"))).toBe(false);
+  });
+});
+
+describe("LazyBoundary component", () => {
+  it("swallows a lazy-init error → renders fallback null + observes it", () => {
+    const { container } = render(
+      <LazyBoundary name="GlobalFooter">
+        <Thrower error={new Error("[safeLazy:GlobalFooter] resolved without a default export")} />
+      </LazyBoundary>,
+    );
+    expect(container.innerHTML).toBe(""); // degraded to null
+    expect(reportChunkResolvedInvalid).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("re-throws a genuine (non-lazy) error to the parent boundary (not swallowed, not beaconed)", () => {
+    const onCatch = vi.fn();
+    const { getByTestId } = render(
+      <CatchAll onCatch={onCatch}>
+        <LazyBoundary name="GlobalFooter">
+          <Thrower error={new TypeError("Cannot read properties of undefined (reading 'map')")} />
+        </LazyBoundary>
+      </CatchAll>,
+    );
+    expect(getByTestId("outer-fallback")).toBeTruthy(); // inner re-threw → outer caught
+    expect(reportChunkResolvedInvalid).not.toHaveBeenCalled();
+  });
+
+  it("renders children normally when nothing throws", () => {
+    const { getByText } = render(
+      <LazyBoundary name="X">
+        <span>ok</span>
+      </LazyBoundary>,
+    );
+    expect(getByText("ok")).toBeTruthy();
+  });
+});

--- a/frontend/tests/unit/resilient-lazy.test.ts
+++ b/frontend/tests/unit/resilient-lazy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests unitaires — `safeLazy` / `loadSafeModule` / `isValidDefaultModule`
+ * (`frontend/app/utils/resilient-lazy.client.ts`).
+ *
+ * Contexte : crash PROD `TypeError: Cannot read properties of undefined
+ * (reading 'default')` dans le `lazyInitializer` de React.lazy — un `import()`
+ * dynamique qui **résout avec `undefined`** (artefact Rolldown mixed-chunk), pas
+ * un rejet. `safeLazy` valide la forme du module résolu et, sur résolution
+ * invalide, ÉMET une balise d'observabilité puis JETTE (dégradation via
+ * `LazyBoundary`) — SANS retry, SANS reload (décision red-team : reload d'un
+ * artefact déterministe = boucle + perte d'état panier/formulaire sur la R2).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isValidDefaultModule,
+  loadSafeModule,
+} from '~/utils/resilient-lazy.client';
+
+// DI par mock de module : on espionne la balise sans toucher au vrai sendBeacon.
+// `vi.hoisted` + `vi.mock` (auto-hoisté) → le spy est disponible dans la factory.
+const { reportChunkResolvedInvalid } = vi.hoisted(() => ({
+  reportChunkResolvedInvalid: vi.fn(),
+}));
+vi.mock('~/utils/runtime-errors.client', () => ({ reportChunkResolvedInvalid }));
+
+function Dummy() {
+  return null;
+}
+
+beforeEach(() => {
+  reportChunkResolvedInvalid.mockClear();
+});
+
+describe('isValidDefaultModule', () => {
+  it('accepts a module namespace with a usable default export', () => {
+    expect(isValidDefaultModule({ default: Dummy })).toBe(true);
+  });
+
+  it('rejects undefined (the fulfill-with-undefined crash shape)', () => {
+    expect(isValidDefaultModule(undefined)).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(isValidDefaultModule(null)).toBe(false);
+  });
+
+  it('rejects a non-object primitive', () => {
+    expect(isValidDefaultModule(42)).toBe(false);
+  });
+
+  it('rejects an object whose default is undefined', () => {
+    expect(isValidDefaultModule({ default: undefined })).toBe(false);
+  });
+
+  it('rejects an object with no default key', () => {
+    expect(isValidDefaultModule({ Toaster: Dummy })).toBe(false);
+  });
+});
+
+describe('loadSafeModule', () => {
+  it('returns the module when the default export is valid (no beacon)', async () => {
+    const mod = { default: Dummy };
+    const out = await loadSafeModule(() => Promise.resolve(mod), {
+      name: 'GlobalFooter',
+    });
+    expect(out).toBe(mod);
+    expect(reportChunkResolvedInvalid).not.toHaveBeenCalled();
+  });
+
+  it('on fulfill-with-undefined: beacons resolved_undefined then throws', async () => {
+    await expect(
+      loadSafeModule(() => Promise.resolve(undefined), { name: 'GlobalFooter' }),
+    ).rejects.toThrow(/\[safeLazy:GlobalFooter\]/);
+    expect(reportChunkResolvedInvalid).toHaveBeenCalledTimes(1);
+    expect(reportChunkResolvedInvalid).toHaveBeenCalledWith({
+      name: 'GlobalFooter',
+      stage: 'resolved_undefined',
+    });
+  });
+
+  it('does NOT retry the factory on invalid resolution (called exactly once)', async () => {
+    const factory = vi.fn(() => Promise.resolve(undefined));
+    await expect(
+      loadSafeModule(factory, { name: 'BottomNav' }),
+    ).rejects.toThrow();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('on a genuine rejection: beacons stage=rejected and re-throws the original error', async () => {
+    const boom = new Error('Failed to fetch dynamically imported module');
+    await expect(
+      loadSafeModule(() => Promise.reject(boom), { name: 'ChatWidget' }),
+    ).rejects.toBe(boom);
+    expect(reportChunkResolvedInvalid).toHaveBeenCalledTimes(1);
+    expect(reportChunkResolvedInvalid).toHaveBeenCalledWith({
+      name: 'ChatWidget',
+      stage: 'rejected',
+    });
+  });
+});

--- a/frontend/tests/unit/runtime-errors-chunk-beacon.test.ts
+++ b/frontend/tests/unit/runtime-errors-chunk-beacon.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests unitaires — `resolveChunkEventLabels`
+ * (`frontend/app/utils/runtime-errors.client.ts`).
+ *
+ * Régression (review PR #1200) : `reportChunkResolvedInvalid` hardcodait
+ * `reason: "resolved_undefined"` + message pour TOUS les appelants, y compris le
+ * `stage: "rejected"` (rejet réel : stale chunk / réseau). → toute ventilation
+ * dashboard sur `meta.reason` bucketait les rejets comme fulfill-with-undefined.
+ * `reason`/`message` doivent DÉRIVER du `stage`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { resolveChunkEventLabels } from "~/utils/runtime-errors.client";
+
+describe("resolveChunkEventLabels", () => {
+  it("labels a genuine rejection as load_rejected (NOT resolved_undefined)", () => {
+    const { reason, message } = resolveChunkEventLabels("rejected");
+    expect(reason).toBe("load_rejected");
+    expect(message).toMatch(/reject/i);
+  });
+
+  it("labels a fulfill-with-undefined as resolved_undefined", () => {
+    const { reason, message } = resolveChunkEventLabels("resolved_undefined");
+    expect(reason).toBe("resolved_undefined");
+    expect(message).toMatch(/undefined/i);
+  });
+
+  it("labels a boundary-caught lazy-init error as resolved_undefined", () => {
+    expect(resolveChunkEventLabels("boundary").reason).toBe("resolved_undefined");
+  });
+
+  it("defaults to resolved_undefined when stage is missing", () => {
+    expect(resolveChunkEventLabels(undefined).reason).toBe("resolved_undefined");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -60,6 +60,23 @@ export default defineConfig({
         deps.filter((dep) => !dep.includes("sentry-vendor")),
     },
     rollupOptions: {
+      // Regression guard (incident PROD Footer, `React.lazy` `_result.default`
+      // sur `undefined`) : un module importé à la fois STATIQUEMENT et
+      // DYNAMIQUEMENT produit sous Rolldown un chunk dont l'`import()` dynamique
+      // peut se résoudre avec `undefined` → crash. Rolldown signale ce cas via
+      // `INEFFECTIVE_DYNAMIC_IMPORT` ; on l'élève en ERREUR de build pour
+      // empêcher cette classe de resurgir silencieusement.
+      // Allowlist : `cart.schemas` (cas préexistant same-file `cart.tsx`, un
+      // schéma Zod jamais rendu via React.lazy → hors classe de crash).
+      onwarn(warning, defaultHandler) {
+        if (
+          warning.code === "INEFFECTIVE_DYNAMIC_IMPORT" &&
+          !/cart\.schemas/.test(warning.message ?? "")
+        ) {
+          throw new Error(`[mixed-import guard] ${warning.message}`);
+        }
+        defaultHandler(warning);
+      },
       output: {
         // Vendor chunking — only pure third-party node_modules (never react-router)
         // Previous race condition was caused by splitting Remix internals; this config avoids that

--- a/log.md
+++ b/log.md
@@ -489,3 +489,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/home-translate-no-removechild`
 - **Décision** : fix(home): translate="no" sur widgets interactifs — stoppe le crash removeChild dû à la traduction navigateur
 - **Sortie** : PR aucune | commits bda4ee6d5
+
+## 2026-07-01 — fix/lazy-rolldown-mixed-import (auto)
+
+- **Branche** : `fix/lazy-rolldown-mixed-import`
+- **Décision** : fix(lazy): stop Footer mixed static+dynamic import crashing R2 pages (Rolldown fulfill-undefined)
+- **Sortie** : PR #1200 | commits 4c536b958


### PR DESCRIPTION
## Incident

Sentry PROD `AUTOMECANIK-FRONTEND-PROD-J` — `TypeError: Cannot read properties of undefined (reading 'default')` on R2 product pages (e.g. `/pieces/neiman-1367/seat-147/alhambra-ii-147010/2-0-tdi-521.html`). Decoded from the **live** minified bundle: the throw is inside React.lazy's `lazyInitializer` reading `_result.default` where the resolved module is `undefined`. `_status===1` (resolved, not rejected) ⇒ a dynamic `import()` **fulfilled with `undefined`** — which bypasses both existing chunk guards (`vite:preloadError` reload + `chunk_load_error` beacon only catch *rejections*). Channel `caught`, `handled=yes` (degraded, not white-screen — but real noise + defect).

## Root cause (deterministic, not environmental)

`frontend/app/components/home/Footer.tsx` was imported **both statically** (barrel `~/components/home`, by `routes/_index.tsx` + `routes/pieces.$slug.tsx`) **and dynamically** (`root.tsx` `lazy(() => import(...))`, rendered on every non-`hideGlobalFooter` route incl. R2). Under **Vite 8 / Rolldown ~1.1.2**, this mixed static+dynamic import produces a chunk whose dynamic `import()` can intermittently fulfill `undefined`. Confirmed by the build warning `INEFFECTIVE_DYNAMIC_IMPORT` on `Footer.tsx`.

## Fix

**L1 — root cause.** All footer renders now go through one shared `<LazyFooter>` using a **single canonical specifier** `~/components/home/Footer`, and the barrel `Footer` re-export is dropped → `Footer.tsx` has **only dynamic importers**. Build warning **gone** (verified). Same DOM position at each site (no layout change); LCP preserved — the two routes even shed the eager Footer from their route chunk.

**L2 — defense-in-depth** (extends existing infra, no parallel system):
- `safeLazy()` validates the resolved module shape; on fulfill-undefined it **emits a beacon then throws** — **no retry, no reload** (red-team: reloading a deterministic artifact loops + destroys in-flight cart/form state on the transactional R2 page; reload stays owned by `vite:preloadError`). `ChatWidget` + `BottomNav` converted for parity.
- `LazyBoundary` generalizes `ChatWidgetErrorBoundary` and **classifies**: only the fulfill-undefined class degrades to `null` + is observed; **genuine bugs re-throw** to the route ErrorBoundary (no silent fallback).
- `reportChunkResolvedInvalid` reuses the existing `seo.runtime.chunk_load_error` enum + `meta.reason` (meta is free-form `z.record` → **no DB migration**).
- **Regression ratchet**: `vite.config` `onwarn` elevates `INEFFECTIVE_DYNAMIC_IMPORT` → build **error** (allowlist the pre-existing same-file `cart.schemas` case). Proven positive **and** negative.

## Verification

- **Build gate**: `Footer` `INEFFECTIVE_DYNAMIC_IMPORT` warning eliminated; build green (client + server). Ratchet proven: re-introducing the barrel export → build fails with `[mixed-import guard]`.
- **Tests** (TDD, red-first): `resilient-lazy` (10) + `lazy-boundary` (7, incl. the "genuine bug must re-throw, not be swallowed" case). Full frontend unit suite **361 green**. `tsc` clean.
- Files: 3 new source + 2 new tests + 6 edits, frontend-only. No URL / meta / H1 / payments / backend / DB touched.

## Deploy

Merge → **PREPROD container CI only** (E2E Smoke + Lighthouse). **PROD requires an owner `v*` tag** — not done here. Rollback = revert PR (L1/L2 independent). PROD Sentry `caught reading 'default'` on R2 should trend to ~0 after tag.

## Open questions for owner
1. **Observability enum** — shipped **option A** (reuse `chunk_load_error` + `meta.reason`, zero migration; a `backend/` + `scripts/` grep found no volume-based consumer). Red-team's preferred **option B** = additive enum value `seo.runtime.chunk_resolved_undefined` (one `ALTER TYPE ADD VALUE` migration) so the deterministic Rolldown artifact never raises the stale-deploy metric floor. Follow-up if you want cleaner metric separation.
2. **ChatWidget/BottomNav → `safeLazy`** parity conversion included (they were dynamic-only already; this makes their rare fulfill-undefined recognized + swallowed). Confirm in scope.
3. **`VehicleCarousel`** (bare lazy on R3 blog, not on incident path) parity **deferred** to keep blast radius minimal. Confirm deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)