### PR TITLE
fix(frontend): resilient-lazy isomorphe — répare le crash SSR PREPROD (hotfix #1200)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/constants/seo-control.constants.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.test.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.test.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on:

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/maintenance.md
+++ b/.claude/knowledge/modules/maintenance.md
@@ -2,7 +2,7 @@
 module: maintenance
 sources:
 - backend/src/modules/maintenance
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/maintenance/maintenance.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/merchant-center.md
+++ b/.claude/knowledge/modules/merchant-center.md
@@ -2,7 +2,7 @@
 module: merchant-center
 sources:
 - backend/src/modules/merchant-center
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
 - backend/src/modules/merchant-center/merchant-center.module.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/observability.md
+++ b/.claude/knowledge/modules/observability.md
@@ -2,7 +2,7 @@
 module: observability
 sources:
 - backend/src/modules/observability
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-knowledge-bootstrap.md
+++ b/.claude/knowledge/modules/rag-knowledge-bootstrap.md
@@ -2,7 +2,7 @@
 module: rag-knowledge-bootstrap
 sources:
 - backend/src/modules/rag-knowledge-bootstrap
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/dto/alternatives-v2.dto.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-control-plane.md
+++ b/.claude/knowledge/modules/seo-control-plane.md
@@ -2,7 +2,7 @@
 module: seo-control-plane
 sources:
 - backend/src/modules/seo-control-plane
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo-monitoring.md
+++ b/.claude/knowledge/modules/seo-monitoring.md
@@ -2,7 +2,7 @@
 module: seo-monitoring
 sources:
 - backend/src/modules/seo-monitoring
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
 - backend/src/modules/seo-monitoring/controllers/cwv-dashboard.controller.ts

--- a/.claude/knowledge/modules/seo-shadow-observatory.md
+++ b/.claude/knowledge/modules/seo-shadow-observatory.md
@@ -2,7 +2,7 @@
 module: seo-shadow-observatory
 sources:
 - backend/src/modules/seo-shadow-observatory
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/seo-shadow-observatory/env.schema.ts
 - backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,16 +2,16 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
+- backend/src/modules/seo/__tests__/seo-balise-collision-gate.test.ts
 - backend/src/modules/seo/__tests__/seo-field-gate.test.ts
+- backend/src/modules/seo/__tests__/seo-fingerprint-core.test.ts
 - backend/src/modules/seo/__tests__/seo-placeholder-events.service.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts
 - backend/src/modules/seo/constants/seo-templates.constants.ts
-- backend/src/modules/seo/controllers/diagnostic.controller.ts
-- backend/src/modules/seo/controllers/keywords-dashboard.controller.ts
 depends_on:
 - ConfigModule
 - DatabaseModule

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/shipping/shipping.controller.ts
 - backend/src/modules/shipping/shipping.module.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicle-context.md
+++ b/.claude/knowledge/modules/vehicle-context.md
@@ -2,7 +2,7 @@
 module: vehicle-context
 sources:
 - backend/src/modules/vehicle-context
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts
 - backend/src/modules/vehicle-context/vehicle-context.middleware.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-06-27'
+last_scan: '2026-07-01'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/frontend/app/components/LazyBoundary.tsx
+++ b/frontend/app/components/LazyBoundary.tsx
@@ -58,7 +58,13 @@ export class LazyBoundary extends Component<
       error.message,
       info.componentStack?.slice(0, 200),
     );
-    reportChunkResolvedInvalid({ name: this.props.name, stage: "boundary" });
+    // Garde `typeof window` : `reportChunkResolvedInvalid` vient d'un module
+    // `.client` (stub `undefined` côté serveur). `componentDidCatch` est de fait
+    // client-only, mais la garde rend l'isomorphie explicite et uniforme avec
+    // `resilient-lazy` (pas d'appel de `(void 0)` si le lifecycle évolue).
+    if (typeof window !== "undefined") {
+      reportChunkResolvedInvalid({ name: this.props.name, stage: "boundary" });
+    }
   }
 
   render(): ReactNode {

--- a/frontend/app/components/home/LazyFooter.tsx
+++ b/frontend/app/components/home/LazyFooter.tsx
@@ -20,7 +20,7 @@
 
 import { Suspense } from "react";
 import { LazyBoundary } from "~/components/LazyBoundary";
-import { safeLazy } from "~/utils/resilient-lazy.client";
+import { safeLazy } from "~/utils/resilient-lazy";
 
 // Specifier canonique UNIQUE — forme alias — utilisé nulle part ailleurs en
 // import statique. Rolldown ne coalesce en un seul chunk dynamique que si cette

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -25,7 +25,7 @@ import { LazyFooter } from "~/components/home/LazyFooter";
 import { LazyBoundary } from "~/components/LazyBoundary";
 import { cspNonceContext } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
-import { safeLazy } from "~/utils/resilient-lazy.client";
+import { safeLazy } from "~/utils/resilient-lazy";
 import { getOptionalUser } from "./auth/unified.server";
 import { ErrorGeneric } from "./components/errors";
 import { Navbar } from "./components/Navbar";

--- a/frontend/app/utils/resilient-lazy.ts
+++ b/frontend/app/utils/resilient-lazy.ts
@@ -1,9 +1,19 @@
 /**
- * resilient-lazy.client — `React.lazy` durci contre l'`import()` dynamique qui
+ * resilient-lazy — `React.lazy` durci contre l'`import()` dynamique qui
  * **résout avec `undefined`** (artefact Rolldown mixed-chunk : un module importé
  * à la fois statiquement et dynamiquement peut voir son `import()` dynamique
  * résolu sur `undefined`). React.lazy lit alors `_result.default` sur `undefined`
  * → `TypeError: Cannot read properties of undefined (reading 'default')`.
+ *
+ * ISOMORPHE — PAS de suffixe `.client` (régression PR #1200 → hotfix). `safeLazy`
+ * est appelé au **top-level** de modules rendus en SSR (`root.tsx`, `LazyFooter`).
+ * Un suffixe `.client` fait remplacer ce module par un stub vide dans le bundle
+ * serveur → `safeLazy` devient `undefined` → `safeLazy(...)` au chargement du
+ * module serveur jette `TypeError: (void 0) is not a function` → « Error loading
+ * server build » = **toutes les routes en 500** (capté par E2E Smoke PREPROD).
+ * `safeLazy` n'enveloppe que `React.lazy` (isomorphe) + validation pure : sûr
+ * côté serveur. La balise d'observabilité (browser-only, cf. `runtime-errors.client`,
+ * stub côté serveur) est donc appelée sous garde `typeof window`.
  *
  * Décision (validée red-team) : sur résolution invalide, on **observe** (balise
  * `reportChunkResolvedInvalid`) puis on **jette** pour laisser `LazyBoundary`
@@ -62,14 +72,25 @@ export async function loadSafeModule<T extends ComponentType<unknown>>(
   try {
     mod = await factory();
   } catch (cause) {
-    // Rejet réel (stale chunk / réseau) : observer puis re-jeter. La décision
-    // de reload appartient exclusivement à `vite:preloadError`.
-    reportChunkResolvedInvalid({ name: opts.name, stage: "rejected" });
+    // Rejet réel (stale chunk / réseau) : observer (browser only) puis re-jeter.
+    // La décision de reload appartient exclusivement à `vite:preloadError`.
+    if (typeof window !== "undefined") {
+      reportChunkResolvedInvalid({ name: opts.name, stage: "rejected" });
+    }
     throw cause instanceof Error ? cause : new Error(String(cause));
   }
   if (isValidDefaultModule(mod)) return mod as DefaultModule<T>;
   // Résolu-avec-undefined / default manquant → observer + dégrader (pas de reload).
-  reportChunkResolvedInvalid({ name: opts.name, stage: "resolved_undefined" });
+  // Garde `typeof window` : hors navigateur la balise `.client` est stubée
+  // (`undefined`) → l'appeler jetterait « (void 0) is not a function » et
+  // masquerait l'erreur. La classe fulfill-with-undefined est de toute façon
+  // browser-only (artefact Rolldown côté client).
+  if (typeof window !== "undefined") {
+    reportChunkResolvedInvalid({
+      name: opts.name,
+      stage: "resolved_undefined",
+    });
+  }
   throw new Error(`[safeLazy:${opts.name}] resolved without a default export`);
 }
 

--- a/frontend/tests/unit/resilient-lazy.test.ts
+++ b/frontend/tests/unit/resilient-lazy.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests unitaires — `safeLazy` / `loadSafeModule` / `isValidDefaultModule`
- * (`frontend/app/utils/resilient-lazy.client.ts`).
+ * (`frontend/app/utils/resilient-lazy.ts`).
  *
  * Contexte : crash PROD `TypeError: Cannot read properties of undefined
  * (reading 'default')` dans le `lazyInitializer` de React.lazy — un `import()`
@@ -11,11 +11,11 @@
  * artefact déterministe = boucle + perte d'état panier/formulaire sur la R2).
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   isValidDefaultModule,
   loadSafeModule,
-} from '~/utils/resilient-lazy.client';
+} from '~/utils/resilient-lazy';
 
 // DI par mock de module : on espionne la balise sans toucher au vrai sendBeacon.
 // `vi.hoisted` + `vi.mock` (auto-hoisté) → le spy est disponible dans la factory.
@@ -97,5 +97,33 @@ describe('loadSafeModule', () => {
       name: 'ChatWidget',
       stage: 'rejected',
     });
+  });
+});
+
+// En SSR le module `.client` de la balise est remplacé par un stub vide →
+// `reportChunkResolvedInvalid` y est `undefined`. `loadSafeModule` est isomorphe
+// (rendu par `root.tsx`/`LazyFooter` côté serveur) : il NE DOIT PAS appeler la
+// balise hors navigateur, sinon `(void 0) is not a function` masquerait la vraie
+// erreur (canon : no silent fallback). Garde `typeof window !== "undefined"`.
+describe('loadSafeModule — contexte serveur (aucun `window`)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fulfill-with-undefined en SSR : jette la synthetic error SANS émettre la balise', async () => {
+    vi.stubGlobal('window', undefined);
+    await expect(
+      loadSafeModule(() => Promise.resolve(undefined), { name: 'GlobalFooter' }),
+    ).rejects.toThrow(/\[safeLazy:GlobalFooter\]/);
+    expect(reportChunkResolvedInvalid).not.toHaveBeenCalled();
+  });
+
+  it('rejet réel en SSR : re-jette la cause SANS émettre la balise', async () => {
+    vi.stubGlobal('window', undefined);
+    const boom = new Error('server import failed');
+    await expect(
+      loadSafeModule(() => Promise.reject(boom), { name: 'ChatWidget' }),
+    ).rejects.toBe(boom);
+    expect(reportChunkResolvedInvalid).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Hotfix de régression SSR introduite par #1200

### Symptôme
Après merge de #1200 (@\`2cd60ead7\`), le job **🧪 Deploy PREPROD** (run \`28530541246\`) échoue : l'E2E Smoke reçoit **500 sur toutes les routes** avec, côté conteneur :
\`\`\`
RemixController: Error loading server build: TypeError: (void 0) is not a function
\`\`\`
Le gate PREPROD a fait son travail — **PROD n'a jamais reçu l'image** (aucun tag \`v*\` poussé). PROD tourne toujours l'image précédente.

### Cause racine (vérifiée, non déduite)
#1200 a placé \`safeLazy\` dans \`utils/resilient-lazy.**client**.ts\`. Le suffixe \`.client\` fait remplacer ce module par un **stub vide dans le bundle serveur** (React Router / Remix) → \`safeLazy\` y est \`undefined\`. Or \`root.tsx\` **et** \`LazyFooter\` appellent \`safeLazy(...)\` **au top-level** (modules rendus en SSR) → au chargement du module serveur : \`TypeError: (void 0) is not a function\` → toutes les routes 500.

Pourquoi les gates de #1200 (tsc / build client / unit jsdom) ne l'ont pas vu : ils importent le \`.client\` **directement** (aucun strip serveur). **Seul un vrai SSR** exerce le remplacement \`.client\` → c'est exactement ce que l'E2E Smoke PREPROD teste.

### Correctif (cause racine + défense en profondeur, sans bricolage)
1. **Rename** \`resilient-lazy.client.ts\` → \`resilient-lazy.ts\` (**ISOMORPHE**). \`safeLazy\` n'enveloppe que \`React.lazy\` (isomorphe) + validation pure → sûr côté serveur, présent dans le bundle serveur.
2. **Garde \`typeof window\`** sur les appels à \`reportChunkResolvedInvalid\` (\`loadSafeModule\` ×2 + \`LazyBoundary.componentDidCatch\`). La balise vit dans \`runtime-errors.client.ts\` (stub \`undefined\` côté serveur) ; sans garde, le chemin d'erreur **serveur** appellerait \`(void 0)\` et **masquerait la vraie cause** (canon : *no silent fallback*). La classe fulfill-with-undefined est de toute façon browser-only (artefact Rolldown client).

Aucun changement de comportement navigateur : en SSR \`window\` est absent, la balise n'était **déjà pas** émise (\`sendEvent\` garde \`window\`). L1 (specifier Footer unique) + le gate \`INEFFECTIVE_DYNAMIC_IMPORT\` de #1200 restent **intacts**.

### Vérification (preuve pos + neg)
- ✅ **Bundle serveur** \`build/server/index.js\` évalué en Node : **plus de** \`(void 0) is not a function\` (**pos**) ; **neg** = logs PREPROD @\`2cd60ead7\`.
- ✅ Unit : **47 fichiers / 367 tests** (+2 TDD : \`loadSafeModule\` n'émet PAS la balise en SSR et jette proprement — **RED prouvé avant la garde**).
- ✅ Build client OK, seul \`INEFFECTIVE_DYNAMIC_IMPORT\` = \`cart.schemas\` (allowlisté) → **pas de mixed-import Footer**.
- ✅ tsc : 0 erreur sur les fichiers touchés (bruit \`@playwright/test\` préexistant). eslint : 0 erreur.

### Note revue
Les **49 fichiers \`.claude/knowledge/modules/*.md\`** de ce diff sont des **bumps \`last_scan\` auto-générés** par le hook pre-commit \`refresh-knowledge.py\` (date \`2026-06-27\`→\`2026-07-01\`) — projections générées, **aucune édition manuelle**, aucun impact runtime. Le fix réel = **5 fichiers** sous \`frontend/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)