### PR TITLE
fix(gov): harden __gov_m7-m10 introspection RPCs to service_role-only

### DIFF
--- a/backend/supabase/migrations/20260614_gov_m7_stable_function_volatility_rpc.sql
+++ b/backend/supabase/migrations/20260614_gov_m7_stable_function_volatility_rpc.sql
@@ -66,6 +66,10 @@ as $function$
 $function$;
 
 revoke all on function public.__gov_m7_stable_function_volatility() from public;
+-- Supabase ALTER DEFAULT PRIVILEGES grants EXECUTE to anon/authenticated on every new
+-- public function; `revoke ... from public` does NOT remove those direct grants, so we
+-- must revoke them explicitly to actually reach service_role-only (verified 2026-07-01).
+revoke execute on function public.__gov_m7_stable_function_volatility() from anon, authenticated;
 grant execute on function public.__gov_m7_stable_function_volatility() to service_role;
 
 comment on function public.__gov_m7_stable_function_volatility() is

--- a/backend/supabase/migrations/20260614_gov_m8_partition_coverage_rpc.sql
+++ b/backend/supabase/migrations/20260614_gov_m8_partition_coverage_rpc.sql
@@ -72,6 +72,10 @@ as $function$
 $function$;
 
 revoke all on function public.__gov_m8_partition_coverage() from public;
+-- Supabase ALTER DEFAULT PRIVILEGES grants EXECUTE to anon/authenticated on every new
+-- public function; `revoke ... from public` does NOT remove those direct grants, so we
+-- must revoke them explicitly to actually reach service_role-only (verified 2026-07-01).
+revoke execute on function public.__gov_m8_partition_coverage() from anon, authenticated;
 grant execute on function public.__gov_m8_partition_coverage() to service_role;
 
 comment on function public.__gov_m8_partition_coverage() is

--- a/backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc.sql
+++ b/backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc.sql
@@ -36,6 +36,10 @@ as $function$
 $function$;
 
 revoke all on function public.__gov_m9_callable_functions() from public;
+-- Supabase ALTER DEFAULT PRIVILEGES grants EXECUTE to anon/authenticated on every new
+-- public function; `revoke ... from public` does NOT remove those direct grants, so we
+-- must revoke them explicitly to actually reach service_role-only (verified 2026-07-01).
+revoke execute on function public.__gov_m9_callable_functions() from anon, authenticated;
 grant execute on function public.__gov_m9_callable_functions() to service_role;
 
 comment on function public.__gov_m9_callable_functions() is

--- a/backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc.sql
+++ b/backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc.sql
@@ -65,6 +65,10 @@ as $function$
 $function$;
 
 revoke all on function public.__gov_m10_overload_ambiguity() from public;
+-- Supabase ALTER DEFAULT PRIVILEGES grants EXECUTE to anon/authenticated on every new
+-- public function; `revoke ... from public` does NOT remove those direct grants, so we
+-- must revoke them explicitly to actually reach service_role-only (verified 2026-07-01).
+revoke execute on function public.__gov_m10_overload_ambiguity() from anon, authenticated;
 grant execute on function public.__gov_m10_overload_ambiguity() to service_role;
 
 comment on function public.__gov_m10_overload_ambiguity() is


### PR DESCRIPTION
## Contexte

Remédiation issue de l'audit `runtime-truth-audit` du 2026-07-01. Deux findings MEDIUM
avaient la **même cause racine** : les migrations d'introspection gouvernées
`__gov_m7`–`m10` (réviewées + mergées les 2026-06-14/15) n'avaient **jamais été
appliquées à la DB partagée** (dérive axe 4, cf. `.claude/rules/deployment.md`).
`__gov_m1`–`m6` étaient live ; `m7`–`m10` absents → les runners CI
`scripts/audit/runtime-truth/*.ts` renvoyaient `health=UNKNOWN` **en silence**.

## Ce qui a été fait sur la DB live (cette session)

- **Appliqué** `__gov_m7`–`m10` (read-only, `SECURITY DEFINER`, réversibles via les
  `.down.sql` déjà mergés) — même méthode que `m1`–`m6` (DDL direct ; la famille n'est
  pas dans le tracking supabase-migrations). Vérifié fonctionnels : m7 = 0 writer / 285
  fns · m8 = 0 gap partition / 15 · m9 = 523 fns callables · m10 = 0 overload ambigu.
- **Hardening sécurité** (découvert pendant l'apply) — voir ci-dessous.

**Aucune** mutation de données. **Aucun** DROP.

## Pourquoi ce diff (les 4 lignes ajoutées)

Chaque migration fait `revoke all ... from public` + `grant execute ... to service_role`,
avec un commentaire d'en-tête promettant *« public/anon are explicitly revoked »*.
**Mais** Supabase a un `ALTER DEFAULT PRIVILEGES` (grantors `supabase_admin` + `postgres`)
qui **grant `EXECUTE` à `anon`/`authenticated`** sur toute nouvelle fonction `public`. Le
`revoke ... from public` ne retire que le grant du pseudo-rôle `PUBLIC` — les grants
**directs** `anon=X` / `authenticated=X` survivent.

Net : `__gov_m7` (expose le **source** des fonctions) et `__gov_m9` (inventaire complet des
fonctions) étaient **appelables par `anon`** via PostgREST `/rpc/…`. Ce diff ajoute le
`revoke execute ... from anon, authenticated` explicite aux 4 migrations pour que le SQL
atteigne réellement l'état `service_role`-only promis (sinon un ré-apply réintroduit
l'exposition). Vérifié sur la DB live : ACL final = `postgres=X | service_role=X`
(anon/auth = `false`).

Hors-scope volontaire : `__gov_m1`–`m6` restent `anon`-callable **par design** (tailles de
tables/index — pas de source de fonction) ; non touchés.

## Bonus — finding #2 (rpc-registry-drift) re-caractérisé

Avec `__gov_m9` désormais live (523 fns), le « 55 drift » d'origine (dominé par la
staleness d'un `canonical.json` de 8 j) se réduit à **4 drifts réels** (appels littéraux
`.rpc('<name>')` vers des fonctions absentes) — et **tous les 4 sont fallback-gardés**
(`__admin_job_health_success`, `get_keyword_import_history`, `get_table_names`,
`increment_advice_views`) → **0 risque de casse runtime**. Détail complet dans le rapport
d'audit local `audit/runtime-truth-audit-2026-07-01.md` (non commité — convention `audit/`).

## Risque / rollback

- Read-only introspection, `service_role`-only, appelées uniquement par les runners d'audit.
  **Aucun** impact runtime app (aucune route/queue/cache).
- Rollback : `.down.sql` déjà mergés (`drop function if exists …`).

## Runtime verification

- PRE-PR : fonctions appliquées + ACL durci vérifiés live (pg_catalog).
- POST-MERGE : `git push main` redéploie le container PREPROD CI uniquement (pas PROD).
  Les fonctions étant déjà appliquées à la DB partagée, aucune action DB supplémentaire au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
