### PR TITLE
chore(audit): add npm run audit:runtime-truth to invoke the runtime-truth runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "audit:db-usage": "node scripts/audit/build-db-usage-map.js",
     "audit:inventory": "node scripts/audit/build-deep-inventory.js && node scripts/audit/build-db-usage-map.js",
     "audit:inventory:check": "npm run audit:inventory && git diff --exit-code -- audit/*.json",
+    "audit:runtime-truth": "for c in pg-stable-write partition-cron-gap rpc-registry-drift rpc-overload-ambiguity bull-repeatable-drift; do tsx scripts/audit/runtime-truth/$c.ts; done",
     "registry:build:files": "node scripts/registry/build-files-registry.js",
     "registry:build:runtime": "node scripts/registry/build-runtime-registry.js",
     "registry:build:deps": "node scripts/registry/build-deps-registry.js",


### PR DESCRIPTION
## Quoi

Ajoute `npm run audit:runtime-truth` — un point d'entrée unique qui exécute les 5 runners
déterministes `scripts/audit/runtime-truth/*.ts` (Trust Ledger PR-B0a).

## Pourquoi

Ces runners existaient mais avaient **0 câblage** : aucun script npm, aucun workflow CI
(`grep -rc runtime-truth .github/workflows/ package.json` = 0). Fonctionnels mais
**non-découvrables**. Suite au déploiement de leurs RPC d'introspection gouvernées
`__gov_m7–m10` (#1202), la voie automatisée fonctionne — il ne manquait que l'entrypoint.

## Vérifié (live DB, session 2026-07-01)

```
✓ pg-stable-write:        health=PASS findings=0
✓ partition-cron-gap:     health=PASS findings=0
✓ rpc-registry-drift:     health=WARN findings=7   (7 .rpc() littéraux vers fns absentes ;
                                                     6 fallback-gardés, 1 silencieux)
✓ rpc-overload-ambiguity: health=PASS findings=0
✓ bull-repeatable-drift:  health=PASS findings=0
```

Chaque runner est **report-only**, exit 0, et **skip proprement** sans creds
(`SUPABASE_*` pour les runners DB, `REDIS_URL` pour bull). Sorties écrites dans
`audit-reports/runtime-truth/*.json` (gitignoré).

## Hors-scope (follow-ups séparés)

- **Câblage CI** (workflow qui lance ces runners on-schedule/PR) = follow-up gouverné.
- `rpc-registry-drift` finding `count_distinct_crawled_urls` (dégradation silencieuse, seul
  des 7 sans garde) → fix observabilité séparé.

## Risque

Additif pur (1 ligne `scripts`), réversible, aucun impact runtime app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
