### PR TITLE
chore(seo): corriger + durcir le garde anthropic (contenu = wiki, ferme gap http)

### DIFF
--- a/.ast-grep/rules/no-anthropic-direct-import-in-scripts.yml
+++ b/.ast-grep/rules/no-anthropic-direct-import-in-scripts.yml
@@ -1,24 +1,29 @@
 id: no-anthropic-direct-import-in-scripts
 language: python
-# Phase 1 PR-B (ADR-046 § Layer L4 GENERATORS) :
-# - Aucun script `scripts/seo/` ou `scripts/rag/` ne doit importer Anthropic directement.
-# - Le passage canon est via le skill `/content-gen` (Claude Code) ou via les
-#   AnthropicProvider du backend (`backend/src/modules/ai-content/providers/anthropic.provider.ts`).
-# - Évite la prolifération d'appels API Anthropic non gouvernés (rate limit, cost,
-#   audit trail) — voir mémoire feedback_no_groq.md "Anthropic uniquement via
-#   provider canon".
+# ADR-046 § Layer L4 GENERATORS + ADR-031 (RAG = chatbot only) :
+# - Aucun script `scripts/seo/` ou `scripts/rag/` ne doit appeler Anthropic directement —
+#   ni par import SDK (`import anthropic`), ni par HTTP direct (`api.anthropic.com`).
+#   Appels non gouvernés (rate limit, coût, audit trail) + hors chaîne contenu canonique.
+# - Le CONTENU ne se génère pas depuis un script qui appelle Claude : la vérité contenu
+#   vient du WIKI (chaîne RAW → WIKI → projection, ADR-059 ; méthode = skill `/seo-content-loop`).
+#   Le RAG n'est PAS une source de contenu (ADR-031/046). Le skill `/content-gen` est
+#   NEUTRALISÉ (PR-C #1205, RAG-as-source) — ne PAS le recommander.
+# - Besoin Anthropic légitime NON-contenu : passer par le provider gouverné
+#   `backend/src/modules/ai-content/providers/anthropic.provider.ts` (rate-limit + observabilité).
 severity: error
 message: |
-  Import direct du SDK Anthropic interdit dans scripts/seo/ et scripts/rag/.
+  Appel direct à Anthropic interdit dans scripts/seo/ et scripts/rag/
+  (import SDK `anthropic` OU HTTP vers api.anthropic.com).
 
-  Pour générer du contenu via Claude :
-    - Préférer le skill Claude Code `/content-gen --r{N}` (pas d'API key, pas de coût)
-    - Ou passer par AnthropicProvider canon (backend/src/modules/ai-content/providers/anthropic.provider.ts)
-      avec gouvernance rate-limit + observabilité Sentry
+  Le CONTENU ne se génère pas via un script qui appelle Claude :
+    - Vérité contenu = WIKI (chaîne RAW → WIKI → projection, ADR-059).
+    - Méthode canonique = skill Claude Code `/seo-content-loop`.
+    - RAG ≠ source de contenu (ADR-031/046). `/content-gen` est NEUTRALISÉ (PR-C #1205).
 
-  Si vous avez un cas légitime (POC, debugging) :
-    - Rangez le script hors `scripts/seo/` et `scripts/rag/`
-    - Ou demandez ADR fils (cf. ADR-046 § Layer L4)
+  Besoin Anthropic légitime NON-contenu (ex. outil interne gouverné) :
+    - Passer par AnthropicProvider canon
+      (backend/src/modules/ai-content/providers/anthropic.provider.ts) — rate-limit + observabilité.
+    - Ou ranger le script hors scripts/seo/ et scripts/rag/ (+ ADR fils si besoin, ADR-046 §L4).
 files:
   - scripts/seo/**/*.py
   - scripts/rag/**/*.py
@@ -30,3 +35,9 @@ rule:
     - pattern: 'import anthropic'
     - pattern: 'from anthropic import $$$'
     - pattern: 'from anthropic.$$$ import $$$'
+    # Gap A (2026-07-02, audit F0-a §12bis) : ferme l'évasion par HTTP direct —
+    # `generate-content-r1.py` appelait api.anthropic.com sans importer le SDK.
+    # Ciblé sur les string-literals pour ne pas flagger un commentaire descriptif.
+    - all:
+        - kind: string
+        - regex: 'api\.anthropic\.com'


### PR DESCRIPTION
## Corriger + durcir le garde anthropic (suite PR-C #1205)

Suite au retour owner : *« le contenu doit être créé/édité depuis le WIKI »* — vérification en profondeur → **confusion réelle confirmée** dans un artefact gouverné.

### Problème 1 — conseil faux (confusion WIKI vs RAG)
Le garde `no-anthropic-direct-import-in-scripts` **recommandait `/content-gen`** comme chemin de génération de contenu. Or `/content-gen` a été **neutralisé** en PR-C #1205 (RAG-as-source interdit). Le garde renvoyait donc vers un skill mort.

**Corrigé** — le message pointe désormais vers le vrai chemin canonique :
- Contenu = **WIKI** (RAW → WIKI → projection, ADR-059 ; méthode `/seo-content-loop`).
- RAG ≠ source de contenu (ADR-031/046).
- Besoin Anthropic **non-contenu** légitime → provider gouverné `ai-content` (rate-limit + observabilité).

### Problème 2 — gap A (évasion HTTP)
Le garde (severity `error`) ne détectait que `import anthropic`. `generate-content-r1.py` l'**évadait** via HTTP direct (`api.anthropic.com` sans SDK). Neutralisé en PR-C, mais un futur script pourrait refaire l'astuce.

**Durci** — ajout d'un matcher string-literal : `all: [kind: string, regex: 'api\.anthropic\.com']`.

### Vérification (testé avant commit, fixtures)
- ✅ attrape `import anthropic` (1:1) **et** l'appel HTTP `requests.post("https://api.anthropic.com/...")` (string literal).
- ✅ **0 faux positif** sur les tombstones PR-C (docstrings mentionnant « l'API Anthropic » — pas le littéral `api.anthropic.com` — non flaggées).
- ✅ scan `scripts/{seo,rag}` post-PR-C = 0 violation (aucun violateur live).

### Hors scope (tracé, pas fait ici — anti-bricolage)
Les **23 hints backend** qui pointent encore vers `/content-gen` **ne sont pas** repointés ici : la cible WIKI (`seo-projection`) est **flag-OFF** (pas encore déployée) → repointer vers un chemin non-live serait une autre dérive. C'est le chantier **P5/P6** (rollout WIKI puis retrait des pointeurs RAG), à séquencer correctement.

**Rollback** = `git revert`. Réf : `audit/rag-legacy-inventory-2026-07-02.md` §12bis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
