### PR TITLE
fix(seo,admin): repair R1 batch anti-join + surface silent rpc-drift fallbacks

### DIFF
--- a/backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts
@@ -334,10 +334,20 @@ export class AdminKeywordPlannerController {
   async importHistory() {
     this.logger.log('GET /api/admin/keyword-planner/import-history');
     try {
-      const { data } = await this.supabase.rpc('get_keyword_import_history');
-      if (data) return { history: data };
-    } catch {
-      /* RPC may not exist, fallback to raw query */
+      const { data, error } = await this.supabase.rpc(
+        'get_keyword_import_history',
+      );
+      if (error) {
+        this.logger.warn(
+          `RPC get_keyword_import_history unavailable → client-side fallback: ${error.message}`,
+        );
+      } else if (data) {
+        return { history: data };
+      }
+    } catch (e) {
+      this.logger.warn(
+        `RPC get_keyword_import_history threw → client-side fallback: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
 
     // Fallback: client-side grouping

--- a/backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts
+++ b/backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts
@@ -67,74 +67,58 @@ export class R1KeywordPlanBatchService extends SupabaseBaseService {
     const limit = options.limit ?? 50;
     const minR3Score = options.minR3Score ?? 70;
 
-    // Find eligible gammes: R3 validated, no R1 yet
-    const { data: eligible } = await this.client.rpc(
-      'execute_sql' as never,
-      {
-        query: `
-        SELECT r3.skp_pg_id AS pg_id, r3.skp_pg_alias AS pg_alias,
-               r3.skp_quality_score AS r3_score, r3.skp_section_terms AS r3_terms
-        FROM __seo_r3_keyword_plan r3
-        LEFT JOIN __seo_r1_keyword_plan r1 ON r1.rkp_pg_id = r3.skp_pg_id
-        WHERE r3.skp_status = 'validated'
-          AND r3.skp_quality_score >= ${minR3Score}
-          AND r1.rkp_id IS NULL
-        ORDER BY r3.skp_quality_score DESC
-        LIMIT ${limit}
-      `,
-      } as never,
+    // Eligible gammes = validated R3 (score ≥ min) that don't yet have an R1 plan.
+    // Fetch ALL validated R3 (well under the supabase-js 1000-row cap: ~255), then
+    // anti-join against existing R1 via a bounded .in(), then take the top `limit`.
+    // Fixes runtime-truth audit #1 (2026-07-02): the removed `execute_sql` RPC never
+    // existed, and the previous fallback capped the R3 fetch at `limit+50` by score
+    // BEFORE filtering already-R1 rows, so it silently returned 0/6 eligible gammes
+    // at the default limit (HTTP 200 with summary.total=0).
+    const { data: r3Plans, error: r3Error } = await this.client
+      .from('__seo_r3_keyword_plan')
+      .select('skp_pg_id, skp_pg_alias, skp_quality_score, skp_section_terms')
+      .eq('skp_status', 'validated')
+      .gte('skp_quality_score', minR3Score)
+      .order('skp_quality_score', { ascending: false })
+      .limit(1000);
+
+    if (r3Error) {
+      this.logger.warn(`[BATCH] R3 plans query failed: ${r3Error.message}`);
+    }
+    if (r3Plans && r3Plans.length >= 1000) {
+      this.logger.warn(
+        '[BATCH] validated R3 plans hit the 1000-row cap — anti-join may be truncated (paginate if this persists)',
+      );
+    }
+    if (!r3Plans?.length) {
+      return { results: [], summary: { total: 0 } };
+    }
+
+    // Anti-join: drop gammes that already have an R1 plan, THEN take the top `limit`.
+    const pgIds = r3Plans.map((r) => Number(r.skp_pg_id));
+    const { data: existingR1, error: r1Error } = await this.client
+      .from('__seo_r1_keyword_plan')
+      .select('rkp_pg_id')
+      .in('rkp_pg_id', pgIds);
+    if (r1Error) {
+      this.logger.warn(`[BATCH] R1 plans query failed: ${r1Error.message}`);
+    }
+    const existingSet = new Set(
+      (existingR1 ?? []).map((r: { rkp_pg_id: number }) => Number(r.rkp_pg_id)),
     );
 
-    // Fallback: direct query if RPC not available
-    let gammes: Array<{
-      pg_id: number;
-      pg_alias: string;
-      r3_score: number;
-      r3_terms: Record<string, { include_terms?: string[] }> | null;
-    }> = [];
-
-    if (eligible && Array.isArray(eligible)) {
-      gammes = eligible;
-    } else {
-      // Direct query approach
-      const { data: r3Plans } = await this.client
-        .from('__seo_r3_keyword_plan')
-        .select('skp_pg_id, skp_pg_alias, skp_quality_score, skp_section_terms')
-        .eq('skp_status', 'validated')
-        .gte('skp_quality_score', minR3Score)
-        .order('skp_quality_score', { ascending: false })
-        .limit(limit + 50); // fetch extra to filter
-
-      if (!r3Plans?.length) {
-        return { results: [], summary: { total: 0 } };
-      }
-
-      // Filter out those that already have R1
-      const pgIds = r3Plans.map((r) => Number(r.skp_pg_id));
-      const { data: existingR1 } = await this.client
-        .from('__seo_r1_keyword_plan')
-        .select('rkp_pg_id')
-        .in('rkp_pg_id', pgIds);
-
-      const existingSet = new Set(
-        (existingR1 ?? []).map((r: { rkp_pg_id: number }) =>
-          Number(r.rkp_pg_id),
-        ),
-      );
-
-      gammes = r3Plans
-        .filter((r) => !existingSet.has(Number(r.skp_pg_id)))
-        .slice(0, limit)
-        .map((r) => ({
-          pg_id: Number(r.skp_pg_id),
-          pg_alias: r.skp_pg_alias as string,
-          r3_score: r.skp_quality_score as number,
-          r3_terms: r.skp_section_terms as Record<
-            string,
-            { include_terms?: string[] }
-          > | null,
-        }));
-    }
+    const gammes = r3Plans
+      .filter((r) => !existingSet.has(Number(r.skp_pg_id)))
+      .slice(0, limit)
+      .map((r) => ({
+        pg_id: Number(r.skp_pg_id),
+        pg_alias: r.skp_pg_alias as string,
+        r3_score: r.skp_quality_score as number,
+        r3_terms: r.skp_section_terms as Record<
+          string,
+          { include_terms?: string[] }
+        > | null,
+      }));
 
     this.logger.log(`[BATCH] Found ${gammes.length} eligible gammes`);
 

--- a/backend/src/modules/products/services/products-catalog.service.ts
+++ b/backend/src/modules/products/services/products-catalog.service.ts
@@ -269,6 +269,11 @@ export class ProductsCatalogService extends SupabaseBaseService {
       const { data: tables, error: tablesError } = await this.client
         .rpc('get_table_names')
         .limit(10);
+      if (tablesError) {
+        this.logger.warn(
+          `RPC get_table_names unavailable → tables=[]: ${tablesError.message}`,
+        );
+      }
 
       return {
         debug: true,

--- a/backend/src/modules/seo/services/googlebot-detector.service.ts
+++ b/backend/src/modules/seo/services/googlebot-detector.service.ts
@@ -246,10 +246,15 @@ export class GooglebotDetectorService {
         .gte('crawled_at', lastWeek.toISOString());
 
       // Unique URLs last 24h
-      const { data: uniqueData } = await this.supabase.rpc(
+      const { data: uniqueData, error: uniqueError } = await this.supabase.rpc(
         'count_distinct_crawled_urls',
         { since: yesterday.toISOString() },
       );
+      if (uniqueError) {
+        this.logger.warn(
+          `RPC count_distinct_crawled_urls unavailable → uniqueUrls24h=0: ${uniqueError.message}`,
+        );
+      }
 
       // Average response time
       const { data: avgData } = await this.supabase


### PR DESCRIPTION
## Contexte

`runtime-truth-audit` (2026-07-02, check `rpc-registry-drift`) : le backend appelle 7 RPC Postgres **absentes de tous les schémas**. `postgrest-js` résout un appel `.rpc()` vers une fonction manquante en `{data:null, error:PGRST202}` **sans throw** → l'erreur était avalée et les fallbacks tournaient en silence (violation canon **« No silent fallback »**). Rapport + vérif adversariale (15 agents) : `audit/runtime-truth-report-2026-07-02.md`.

Cette PR traite les 2 lots **code-only** (A + B). Les migrations (#3 RPC atomique) sont **hors scope** (owner GO séparé).

## Lot B — #1 `execute_sql` (vrai défaut fonctionnel)

Le batch R1 keyword (`POST /api/admin/keyword-planner/batch-r1`) appelait une RPC `execute_sql` qui n'a jamais existé, et son fallback **bornait** le fetch R3 à `limit+50` trié score DESC **AVANT** de filtrer les gammes déjà-R1 → renvoyait **0/6 gammes éligibles au défaut** (HTTP 200, `summary.total=0`), silencieusement.

**Fix** : suppression de la branche `execute_sql` morte ; fetch de **tout** le R3 validé (~255, sous le cap supabase-js 1000) puis anti-join contre R1 existant via `.in()` borné, puis `slice(limit)`.

**Preuve runtime (DB live)** : ancien comportement = **0** éligibles ; nouveau anti-join = **6** éligibles.

## Lot A — observabilité (No silent fallback)

Capture + `logger.warn` de l'erreur PGRST202 avalée sur **3 sites admin peu fréquents** :
- #2 `count_distinct_crawled_urls` (googlebot crawl-stats)
- #6 `get_keyword_import_history` (keyword import-history)
- #7 `get_table_names` (products debug-real-data)

## Déféré (décision owner, PAS dans cette PR)

- **#3 `increment_advice_views`** — route **publique** → la vraie correction est une **RPC atomique** (migration owner-gated). Pas de `logger.warn` par-vue (flood sur hot-path).
- **#4 `__admin_job_health_success`** — le fallback EST l'impl de-facto prod correcte (compteurs avancent) ; décision remove-branch vs create-RPC.
- **#5** déjà observable (`log.warn`).

## Vérification

- `tsc --noEmit` backend : **0 erreur**
- `eslint` sur les 4 fichiers : **0 erreur** (2 warnings `any` pré-existants, hors zones modifiées)
- Preuve runtime #1 : **0 → 6** éligibles sur la DB live
- Aucun test cassé (pas de test existant sur ces chemins)

## Note d'implémentation

Choix vs proposition initiale : pour l'observabilité (Lot A), capture explicite `if (error) logger.warn` **uniforme** plutôt que routage via `callRpc()` — même résultat (erreur observable), **blast radius plus faible** (pas de changement de call-path/gate, pas de dépendance à l'injection `rpcGate`).

Aucun changement touchant paiement / auth / RLS / URL / prix. Merge = PREPROD (owner-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)