### PR TITLE
fix(blog): atomic increment_advice_views RPC + observable fallback (runtime-truth #3, Lot C)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -510,6 +510,13 @@ entries:
     owner: '@ak125/content-team'
     sourceConfidence: medium
     risk: medium
+  # Glob exact volontaire — les migrations ne sont PAS auto-couvertes (review ownership à chaque fois).
+  # Couvre .sql + .down.sql de la migration increment_advice_views (runtime-truth #3, Lot C).
+  - glob: backend/supabase/migrations/*blog_advice_increment_views*
+    domain: D5
+    owner: '@ak125/content-team'
+    sourceConfidence: high
+    risk: low
   # bot-guard = anti-bot access-control middleware (throttling, geo/IP filtering,
   # GOOD_BOTS allowlist) → Security & Governance. Risk high: can 403 real traffic.
   - glob: backend/src/modules/bot-guard/**

--- a/backend/src/modules/blog/services/advice.service.ts
+++ b/backend/src/modules/blog/services/advice.service.ts
@@ -507,28 +507,51 @@ export class AdviceService {
         return;
       }
 
-      await this.supabaseService.client.rpc('increment_advice_views', {
-        advice_id: adviceId,
-      });
+      // Atomic path — migration 20260703 creates public.increment_advice_views(text).
+      // ba_id is a TEXT column, so send a string: PostgREST binds the text param
+      // (a JS number would risk PGRST202/203 and — critically — postgrest-js resolves
+      // that to { error } WITHOUT throwing, so we MUST inspect `error` explicitly).
+      const { error } = await this.supabaseService.client.rpc(
+        'increment_advice_views',
+        { advice_id: String(adviceId) },
+      );
+      if (!error) return;
+
+      // RPC absent (PGRST202) or failed: surface it, then fall through to the
+      // non-atomic fallback below — observable, never silent (CLAUDE.md CRITICAL).
+      this.logger.warn(
+        `RPC increment_advice_views failed (${error.code ?? '?'}: ${error.message}) → non-atomic fallback for ba_id=${adviceId}`,
+      );
+    } catch (e) {
+      this.logger.warn(
+        `RPC increment_advice_views threw → non-atomic fallback for ba_id=${adviceId}: ${(e as Error).message}`,
+      );
+    }
+
+    await this.incrementViewsFallback(adviceId);
+  }
+
+  /**
+   * Fallback non-atomique (best-effort) : lit puis réécrit ba_visit.
+   * NB: supabase-js .update() écrit une valeur littérale — il faut donc lire puis
+   * réécrire le compteur (un `'ba_visit::int + 1'` littéral n'incrémentait rien).
+   * Comptage de vues non-critique — ne jamais casser la requête appelante.
+   */
+  private async incrementViewsFallback(adviceId: number): Promise<void> {
+    try {
+      const { data } = await this.supabaseService.client
+        .from(TABLES.blog_advice)
+        .select('ba_visit')
+        .eq('ba_id', adviceId)
+        .maybeSingle();
+      const current = Number.parseInt(data?.ba_visit ?? '0', 10);
+      const next = (Number.isNaN(current) ? 0 : current) + 1;
+      await this.supabaseService.client
+        .from(TABLES.blog_advice)
+        .update({ ba_visit: String(next) })
+        .eq('ba_id', adviceId);
     } catch {
-      // Fallback (non-atomic, best-effort) si la RPC increment_advice_views est absente.
-      // NB: supabase-js .update() écrit une valeur littérale — il faut donc lire puis
-      // réécrire le compteur (un `'ba_visit::int + 1'` littéral n'incrémentait rien).
-      try {
-        const { data } = await this.supabaseService.client
-          .from(TABLES.blog_advice)
-          .select('ba_visit')
-          .eq('ba_id', adviceId)
-          .maybeSingle();
-        const current = Number.parseInt(data?.ba_visit ?? '0', 10);
-        const next = (Number.isNaN(current) ? 0 : current) + 1;
-        await this.supabaseService.client
-          .from(TABLES.blog_advice)
-          .update({ ba_visit: String(next) })
-          .eq('ba_id', adviceId);
-      } catch {
-        // Comptage de vues non-critique — ne jamais casser la requête.
-      }
+      // Comptage de vues non-critique — ne jamais casser la requête.
     }
   }
 

--- a/backend/supabase/migrations/20260703_blog_advice_increment_views_rpc.down.sql
+++ b/backend/supabase/migrations/20260703_blog_advice_increment_views_rpc.down.sql
@@ -1,0 +1,6 @@
+-- Rollback: increment_advice_views atomic view counter.
+-- Additive function → fully reversible, no data loss (ba_visit values untouched).
+-- After rollback, advice.service.ts falls back to the non-atomic read-modify-write
+-- path (observable: it logs the PGRST202 "function absent" before falling back).
+
+drop function if exists public.increment_advice_views(text);

--- a/backend/supabase/migrations/20260703_blog_advice_increment_views_rpc.sql
+++ b/backend/supabase/migrations/20260703_blog_advice_increment_views_rpc.sql
@@ -1,0 +1,58 @@
+-- =====================================================
+-- increment_advice_views — atomic view counter for __blog_advice
+-- Date: 2026-07-03
+-- Refs: audit/runtime-truth-report-2026-07-02.md (finding #3)
+--       audit/runtime-truth-remediation-proposal-2026-07-02.md (Lot C)
+--       20260614_gov_m9_callable_functions_rpc.sql (names this RPC as absent /
+--         "silent feature breakage"; introspection that detects the drift)
+--       backend/src/modules/blog/services/advice.service.ts (caller: incrementViews)
+-- =====================================================
+--
+-- Why: advice.service.ts calls `.rpc('increment_advice_views', { advice_id })` on
+-- every public advice-page view, but the function never existed. postgrest-js
+-- resolves an absent RPC to { data:null, error:PGRST202 } WITHOUT throwing, so the
+-- call's try/catch never fired and the non-atomic fallback (read-modify-write) was
+-- the only path — best-effort, race-prone, and doubly silent. `ba_visit` was, in
+-- practice, incremented only via the fallback (when writes were allowed at all).
+--
+-- This creates the atomic increment the caller always intended. `ba_id` and
+-- `ba_visit` are TEXT columns holding numeric strings, so the counter is parsed,
+-- incremented, and re-serialized in a single UPDATE (no lost-update race).
+--
+-- VOLATILE (not STABLE): this function WRITES. A STABLE function that mutates is an
+-- anti-pattern — PostgREST may route STABLE calls through a read-only transaction.
+--
+-- SECURITY DEFINER: __blog_advice has RLS enabled. The advice-view route is public
+-- (anon) and the PREPROD backend runs as anon (ADR-028 READ_ONLY). Neither can
+-- UPDATE under RLS, so the increment runs as the function owner. The mutation is
+-- fully bounded: single row by primary key, single column, parameterized (no
+-- injection surface), rate-limited upstream by the global Cloudflare throttler.
+--
+-- Grants: EXECUTE to anon + authenticated (public route) + service_role (backend).
+-- Unlike the service_role-only __gov_* introspection family, this RPC is meant to
+-- be reachable from the public page-view path.
+
+set lock_timeout = '2s';
+set statement_timeout = '10s';
+
+create or replace function public.increment_advice_views(advice_id text)
+  returns void
+  language sql
+  volatile
+  security definer
+  set search_path to 'public'
+as $function$
+  update public.__blog_advice
+     set ba_visit = (coalesce(nullif(ba_visit, '')::int, 0) + 1)::text
+   where ba_id = advice_id;
+$function$;
+
+-- Supabase ALTER DEFAULT PRIVILEGES grants EXECUTE to anon/authenticated on every
+-- new public function; `revoke ... from public` does NOT remove those direct grants.
+-- We intentionally KEEP anon/authenticated here (public advice-view route), then
+-- re-assert the full intended grant set explicitly (auditable, no implicit reliance).
+revoke all on function public.increment_advice_views(text) from public;
+grant execute on function public.increment_advice_views(text) to anon, authenticated, service_role;
+
+comment on function public.increment_advice_views(text) is
+  'Atomic view counter for __blog_advice (runtime-truth #3, Lot C): increments ba_visit for the given ba_id in a single UPDATE. VOLATILE + SECURITY DEFINER (RLS-enabled table, public/anon caller). Replaces the race-prone read-modify-write fallback in advice.service.ts. EXECUTE: anon, authenticated, service_role.';


### PR DESCRIPTION
## Runtime-truth #3 (Lot C) — atomic `increment_advice_views` + observable fallback

Third of three remediations from `audit/runtime-truth-report-2026-07-02.md`. Lots A+B shipped in #1211; this closes the last verified defect. **Migration-bearing → owner-gated.**

### The defect (verified)
`advice.service.ts` calls `.rpc('increment_advice_views', { advice_id })` on **every public advice-page view**, but the function **never existed**. `postgrest-js` resolves an absent RPC to `{ error: PGRST202 }` **without throwing**, so the `try/catch` never fired — `ba_visit` was only ever bumped by the race-prone read-modify-write fallback, and doubly silent (`__gov_m9` already names this RPC as "silent feature breakage").

### What's in this PR
1. **Migration** `20260703_blog_advice_increment_views_rpc.sql` (+ `.down.sql`):
   - `create public.increment_advice_views(advice_id text)` — single-`UPDATE` atomic counter.
   - **`VOLATILE`** (it writes — *not* `STABLE`, which PostgREST may route read-only).
   - **`SECURITY DEFINER`** — RLS is enabled on `__blog_advice`; the public/anon caller (+ READ_ONLY-PREPROD-as-anon) can't `UPDATE` otherwise. Bounded: 1 row by PK, 1 column, parameterized (0 injection surface).
   - `EXECUTE` → `anon, authenticated, service_role` (public route), grants re-asserted explicitly (default-priv lesson, #1202).
   - `.down.sql` = `drop function` (no data loss).
2. **Code wiring** (`advice.service.ts`):
   - send `String(adviceId)` — `ba_id` is `text`; a JS number risks PGRST202/203, which postgrest-js swallows into `{ error }` without throwing.
   - **capture `{ error }`** and fall through to the fallback on error *or* throw — the fallback is now reached **observably** (`logger.warn`) instead of silently.
   - extract `incrementViewsFallback()` so both paths reach it (DRY).
3. **Ownership glob** (`ownership.yaml`, owner-directed override) — block-new gate coverage for the migration.

### Verification (evidence)
- `tsc --noEmit` = **0**, `eslint` (advice.service.ts) = **0**.
- Increment expression proven **read-only** on live DB: `ba_id '10'` 350→351, `'100'` 157→158, `'101'` 382→383. The `where ba_id = advice_id` text-match resolves rows.
- The `create function` / any write was **NOT executed** — see below.

### ⚠️ Owner action after merge — apply the migration
Merging this PR does **not** touch the DB (migrations are not auto-applied to the shared DB). The atomic RPC only comes alive once the migration is applied (owner-gated `apply_migration`/psql). **Until applied, the code falls back observably** (logs PGRST202, uses the read-modify-write path) — so merge is safe and non-breaking regardless of apply timing. PREPROD is READ_ONLY (writes blocked there anyway); the atomic path activates in PROD once applied.

Merge target = `main` → PREPROD container CI only. No payment/auth/URL/pricing touched. Rollback = `.down.sql`.
