### PR TITLE
fix(knowledge): make headers-only refresh respect changed module files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -117,6 +117,25 @@ if command -v python3 >/dev/null 2>&1 \
   fi
 fi
 
+# Guard the churn-preservation logic itself: when a scripts/knowledge/*.py file
+# is staged, its unit + integration + drift-guard tests must pass — otherwise a
+# regression could silently reintroduce the daily 49-module last_scan churn.
+# Soft-skip if python3/pyyaml absent (same policy as the refresh above); HARD-fail
+# on a real test failure so the guard actually guards.
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '^scripts/knowledge/.*\.py$'; then
+  if command -v python3 >/dev/null 2>&1 \
+     && python3 -c "import yaml" >/dev/null 2>&1 \
+     && [ -f scripts/knowledge/test_refresh_knowledge.py ]; then
+    python3 scripts/knowledge/test_refresh_knowledge.py || {
+      echo ""
+      echo "ERROR: scripts/knowledge/test_refresh_knowledge.py failed."
+      echo "The headers-only last_scan preservation invariant is broken — fix it"
+      echo "before committing (this guards the daily knowledge-module churn)."
+      exit 1
+    }
+  fi
+fi
+
 # Repository Control Plane (ADR-058) — Layer 2 overlay validation + Layer 1/3 no-manual-edit guard
 # Lightweight pre-commit checks per ADR-058 §Stratégie hooks :
 #   - validate-overlay : Zod check on .spec/00-canon/repository-registry/*.yaml (< 1s)

--- a/scripts/knowledge/refresh-knowledge.py
+++ b/scripts/knowledge/refresh-knowledge.py
@@ -162,11 +162,42 @@ def _rel(p: Path) -> str:
     return str(p.relative_to(APP_ROOT))
 
 
-def build_frontmatter(mod: ModuleInfo) -> str:
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+# Fields derived from the module's code. `last_scan` is intentionally excluded:
+# it is a freshness marker, not derived content, so it must not by itself force a
+# rewrite (that was the source of the daily 49-module churn on every first commit
+# of the day — the frontmatter differed only because the calendar date rolled over).
+_CONTENT_KEYS = ("module", "sources", "primary_files", "depends_on")
+
+
+def _parse_frontmatter(existing: str) -> dict:
+    """Parsed YAML frontmatter of an existing .md, or {} if absent/invalid."""
+    m = _FRONTMATTER_RE.match(existing)
+    if not m:
+        return {}
+    try:
+        data = yaml.safe_load(m.group(1))
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _content_fields(mod: ModuleInfo) -> dict:
+    """The derived (code-sourced) frontmatter fields, excluding `last_scan`."""
+    return {
+        "module": mod.name,
+        "sources": [_rel(mod.module_file.parent)],
+        "primary_files": [_rel(p) for p in mod.primary_files],
+        "depends_on": list(mod.depends_on),
+    }
+
+
+def build_frontmatter(mod: ModuleInfo, last_scan: str | None = None) -> str:
     fm: dict = {
         "module": mod.name,
         "sources": [_rel(mod.module_file.parent)],
-        "last_scan": str(date.today()),
+        "last_scan": last_scan or str(date.today()),
         "primary_files": [_rel(p) for p in mod.primary_files],
         "depends_on": mod.depends_on,
     }
@@ -232,8 +263,21 @@ def replace_auto_block(existing: str, mod: ModuleInfo) -> str:
     return existing.rstrip() + "\n\n" + new_block + "\n"
 
 
-def replace_frontmatter(existing: str, mod: ModuleInfo) -> str:
-    new_fm = f"---\n{build_frontmatter(mod)}\n---\n"
+def replace_frontmatter(existing: str, mod: ModuleInfo, preserve_unchanged: bool = False) -> str:
+    """Rewrite the YAML frontmatter block.
+
+    When `preserve_unchanged` is set (the `--headers-only` path), the existing
+    `last_scan` is kept if the module's derived content (`_CONTENT_KEYS`) is
+    unchanged — so a mere calendar-day rollover no longer rewrites every module's
+    frontmatter. `last_scan` bumps to today only when the derived content changed.
+    """
+    last_scan: str | None = None
+    if preserve_unchanged:
+        existing_fm = _parse_frontmatter(existing)
+        existing_content = {k: existing_fm.get(k) for k in _CONTENT_KEYS}
+        if existing_fm.get("last_scan") and existing_content == _content_fields(mod):
+            last_scan = str(existing_fm["last_scan"])
+    new_fm = f"---\n{build_frontmatter(mod, last_scan=last_scan)}\n---\n"
     if existing.startswith("---\n"):
         return re.sub(r"^---\n.*?\n---\n", new_fm, existing, count=1, flags=re.DOTALL)
     return new_fm + existing
@@ -253,10 +297,13 @@ def process(mode: str, mods: Iterable[ModuleInfo], headers_only: bool) -> tuple[
                 print(f"SKIP     {mod.name} (no .md, use `bootstrap` mode to create)")
             continue
         existing = md_path.read_text(encoding="utf-8")
-        new = replace_frontmatter(existing, mod) if headers_only else replace_auto_block(existing, mod)
-        if headers_only is False and not headers_only:
-            # Always refresh frontmatter too in non-headers-only modes (keeps last_scan current)
-            new = replace_frontmatter(new, mod)
+        if headers_only:
+            # Pre-commit fast path: refresh frontmatter only, preserving last_scan
+            # when the module's derived content is unchanged (no daily churn).
+            new = replace_frontmatter(existing, mod, preserve_unchanged=True)
+        else:
+            # Full refresh: rewrite the AUTO block, then the frontmatter.
+            new = replace_frontmatter(replace_auto_block(existing, mod), mod)
         if new != existing:
             md_path.write_text(new, encoding="utf-8")
             print(f"UPDATED  {_rel(md_path)}")

--- a/scripts/knowledge/test_refresh_knowledge.py
+++ b/scripts/knowledge/test_refresh_knowledge.py
@@ -3,17 +3,29 @@
 
 Run:  python3 scripts/knowledge/test_refresh_knowledge.py
 Exit 0 = all pass. Stdlib + pyyaml only (same deps as the script under test).
+Wired into `.husky/pre-commit`: it runs (and must pass) whenever a
+`scripts/knowledge/*.py` file is staged, so the daily-churn regression cannot
+silently return.
 
 Guards the fix for the daily 49-module churn: `--headers-only` must preserve
 `last_scan` when a module's derived content is unchanged, and bump it to today
-only when the content actually changed.
+only when the content actually changed. Coverage:
+  - unit: replace_frontmatter preserve/bump/default paths (pure function)
+  - integration: process() writes ONLY the modules whose content changed (disk)
+  - drift guard: _CONTENT_KEYS stays in sync with build_frontmatter's emitted set
+    (else a future added field would silently stop bumping last_scan)
 """
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import sys
+import tempfile
 from datetime import date
 from pathlib import Path
+
+import yaml
 
 HERE = Path(__file__).resolve().parent
 APP_ROOT = HERE.parents[1]
@@ -28,48 +40,128 @@ OLD = "2020-01-01"
 assert OLD != TODAY, "sanity: fixed OLD date must differ from today"
 
 
-def make_mod(depends_on: list[str]) -> "rk.ModuleInfo":
-    mod_dir = APP_ROOT / "backend" / "src" / "modules" / "foo"
+def make_mod(depends_on: list[str], name: str = "foo") -> "rk.ModuleInfo":
+    mod_dir = APP_ROOT / "backend" / "src" / "modules" / name
     return rk.ModuleInfo(
-        name="foo",
-        module_file=mod_dir / "foo.module.ts",
-        primary_files=[mod_dir / "foo.service.ts"],
-        exports=["FooService"],
-        providers=["FooService"],
+        name=name,
+        module_file=mod_dir / f"{name}.module.ts",
+        primary_files=[mod_dir / f"{name}.service.ts"],
+        exports=[f"{name.capitalize()}Service"],
+        providers=[f"{name.capitalize()}Service"],
         depends_on=list(depends_on),
     )
 
 
 def existing_md(mod: "rk.ModuleInfo", last_scan: str) -> str:
-    return f"---\n{rk.build_frontmatter(mod, last_scan=last_scan)}\n---\n\n# Module Foo\n\n## Rôle\n_x_\n"
+    return f"---\n{rk.build_frontmatter(mod, last_scan=last_scan)}\n---\n\n# Module {mod.name}\n\n## Rôle\n_x_\n"
+
+
+# ── Unit: pure-function last_scan logic ──────────────────────────────────────
+
+def test_case1_no_churn() -> None:
+    """Derived content unchanged → last_scan preserved, file byte-identical."""
+    mod = make_mod(["BarModule"])
+    existing = existing_md(mod, OLD)
+    out = rk.replace_frontmatter(existing, mod, preserve_unchanged=True)
+    assert f"last_scan: '{OLD}'" in out, f"last_scan not preserved:\n{out}"
+    assert TODAY not in out, "today leaked in despite unchanged content"
+    assert out == existing, "unchanged module was rewritten (would churn)"
+
+
+def test_case2_bump_on_change() -> None:
+    """Derived content changed (depends_on) → last_scan bumps to today."""
+    mod = make_mod(["BarModule"])
+    stale = existing_md(make_mod(["OldModule"]), OLD)  # .md derived from old code
+    out = rk.replace_frontmatter(stale, mod, preserve_unchanged=True)
+    assert f"last_scan: '{TODAY}'" in out, f"last_scan not bumped:\n{out}"
+    assert "BarModule" in out and "OldModule" not in out, "depends_on not refreshed"
+
+
+def test_default_path_still_bumps() -> None:
+    """Non-headers-only (full refresh) path is unchanged: always bumps to today."""
+    mod = make_mod(["BarModule"])
+    out = rk.replace_frontmatter(existing_md(mod, OLD), mod)  # preserve_unchanged=False
+    assert f"last_scan: '{TODAY}'" in out, "default path must still bump to today"
+
+
+# ── Integration: process() writes ONLY changed modules (the real Case 3) ─────
+
+def test_process_only_writes_changed_modules() -> None:
+    """End-to-end on disk: an unchanged module is left byte-identical (no write,
+    last_scan preserved); a module whose derived content changed is rewritten
+    with last_scan bumped. Exercises process()'s `new != existing` write gate —
+    the actual decision the churn fix targets, not just the pure function."""
+    orig_dir = rk.MODULES_DIR
+    try:
+        # Under APP_ROOT so process()'s `_rel(md_path)` print resolves (it requires
+        # paths to be inside the repo root); auto-removed on context exit.
+        with tempfile.TemporaryDirectory(dir=APP_ROOT) as td:
+            tdp = Path(td)
+            rk.MODULES_DIR = tdp
+
+            alpha = make_mod(["Dep"], name="alpha")            # content unchanged
+            beta_now = make_mod(["NewDep"], name="beta")       # ModuleInfo after a code change
+            beta_old = make_mod(["OldDep"], name="beta")       # what beta.md was derived from
+
+            (tdp / "alpha.md").write_text(existing_md(alpha, OLD), encoding="utf-8")
+            (tdp / "beta.md").write_text(existing_md(beta_old, OLD), encoding="utf-8")
+            alpha_before = (tdp / "alpha.md").read_bytes()
+
+            with contextlib.redirect_stdout(io.StringIO()):  # mute process()'s per-file prints
+                created, updated = rk.process("refresh", [alpha, beta_now], headers_only=True)
+
+            assert created == 0, f"no module should be created, got {created}"
+            assert updated == 1, f"only the changed module should be written, got updated={updated}"
+
+            # unchanged module: not rewritten, last_scan preserved (no churn)
+            assert (tdp / "alpha.md").read_bytes() == alpha_before, "unchanged module was rewritten (churn)"
+            assert f"last_scan: '{OLD}'" in (tdp / "alpha.md").read_text(encoding="utf-8")
+
+            # changed module: last_scan bumped + depends_on refreshed
+            beta_txt = (tdp / "beta.md").read_text(encoding="utf-8")
+            assert f"last_scan: '{TODAY}'" in beta_txt, "changed module last_scan not bumped"
+            assert "NewDep" in beta_txt and "OldDep" not in beta_txt, "changed module depends_on not refreshed"
+    finally:
+        rk.MODULES_DIR = orig_dir
+
+
+# ── Drift guard: keep the freshness-vs-content split honest ──────────────────
+
+def test_content_keys_stay_in_sync_with_build_frontmatter() -> None:
+    """`_CONTENT_KEYS` (the fields whose change forces a last_scan bump) must equal
+    exactly the set build_frontmatter emits, minus the `last_scan` freshness marker.
+    Without this, a future derived field added to build_frontmatter but not to
+    _CONTENT_KEYS would SILENTLY stop bumping last_scan when it changes — the
+    no-silent-fallback class the repo forbids. This turns that trap into a loud
+    failure. Also checks values, catching list()-vs-raw / comprehension drift
+    between _content_fields and build_frontmatter."""
+    mod = make_mod(["BarModule"])
+    emitted = yaml.safe_load(rk.build_frontmatter(mod))
+    assert set(emitted) - {"last_scan"} == set(rk._CONTENT_KEYS), (
+        f"_CONTENT_KEYS drifted from build_frontmatter keys: "
+        f"emitted={sorted(emitted)} _CONTENT_KEYS={sorted(rk._CONTENT_KEYS)}"
+    )
+    emitted.pop("last_scan", None)
+    assert rk._content_fields(mod) == emitted, (
+        f"_content_fields diverged from build_frontmatter values: "
+        f"{rk._content_fields(mod)} != {emitted}"
+    )
+
+
+ALL_TESTS = [
+    test_case1_no_churn,
+    test_case2_bump_on_change,
+    test_default_path_still_bumps,
+    test_process_only_writes_changed_modules,
+    test_content_keys_stay_in_sync_with_build_frontmatter,
+]
 
 
 def run() -> None:
-    mod = make_mod(["BarModule"])
-
-    # Case 1 — derived content unchanged → last_scan preserved, file byte-identical
-    # (no calendar-day churn). This is the core regression the fix removes.
-    existing = existing_md(mod, OLD)
-    out1 = rk.replace_frontmatter(existing, mod, preserve_unchanged=True)
-    assert f"last_scan: '{OLD}'" in out1, f"Case 1: last_scan not preserved:\n{out1}"
-    assert TODAY not in out1, "Case 1: today leaked in despite unchanged content"
-    assert out1 == existing, "Case 1: unchanged module was rewritten (would churn)"
-
-    # Case 2 — derived content changed (depends_on) → last_scan bumps to today.
-    stale = existing_md(make_mod(["OldModule"]), OLD)              # .md derived from old code
-    out2 = rk.replace_frontmatter(stale, mod, preserve_unchanged=True)  # mod now depends on BarModule
-    assert f"last_scan: '{TODAY}'" in out2, f"Case 2: last_scan not bumped:\n{out2}"
-    assert "BarModule" in out2 and "OldModule" not in out2, "Case 2: depends_on not refreshed"
-
-    # Case 3 — isolation: an unchanged module is not rewritten, so process() writes
-    # ONLY the modules whose content changed (Case 1 = no-op, Case 2 = diff).
-    assert rk.replace_frontmatter(existing, mod, preserve_unchanged=True) == existing
-
-    # Guard — default (non-headers-only) path is unchanged: always bumps to today.
-    out_default = rk.replace_frontmatter(existing, mod)  # preserve_unchanged=False
-    assert f"last_scan: '{TODAY}'" in out_default, "Default path must still bump to today"
-
-    print("OK — Case 1 (no-churn), Case 2 (bump-on-change), Case 3 (isolation), default unchanged")
+    for t in ALL_TESTS:
+        t()
+    print(f"OK — {len(ALL_TESTS)} tests passed "
+          "(no-churn, bump-on-change, default-path, process-isolation, content-keys-sync)")
 
 
 if __name__ == "__main__":

--- a/scripts/knowledge/test_refresh_knowledge.py
+++ b/scripts/knowledge/test_refresh_knowledge.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Tests for refresh-knowledge.py `--headers-only` last_scan preservation.
+
+Run:  python3 scripts/knowledge/test_refresh_knowledge.py
+Exit 0 = all pass. Stdlib + pyyaml only (same deps as the script under test).
+
+Guards the fix for the daily 49-module churn: `--headers-only` must preserve
+`last_scan` when a module's derived content is unchanged, and bump it to today
+only when the content actually changed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+APP_ROOT = HERE.parents[1]
+
+_spec = importlib.util.spec_from_file_location("refresh_knowledge", HERE / "refresh-knowledge.py")
+rk = importlib.util.module_from_spec(_spec)
+sys.modules["refresh_knowledge"] = rk  # let @dataclass resolve cls.__module__ during exec
+_spec.loader.exec_module(rk)
+
+TODAY = str(date.today())
+OLD = "2020-01-01"
+assert OLD != TODAY, "sanity: fixed OLD date must differ from today"
+
+
+def make_mod(depends_on: list[str]) -> "rk.ModuleInfo":
+    mod_dir = APP_ROOT / "backend" / "src" / "modules" / "foo"
+    return rk.ModuleInfo(
+        name="foo",
+        module_file=mod_dir / "foo.module.ts",
+        primary_files=[mod_dir / "foo.service.ts"],
+        exports=["FooService"],
+        providers=["FooService"],
+        depends_on=list(depends_on),
+    )
+
+
+def existing_md(mod: "rk.ModuleInfo", last_scan: str) -> str:
+    return f"---\n{rk.build_frontmatter(mod, last_scan=last_scan)}\n---\n\n# Module Foo\n\n## Rôle\n_x_\n"
+
+
+def run() -> None:
+    mod = make_mod(["BarModule"])
+
+    # Case 1 — derived content unchanged → last_scan preserved, file byte-identical
+    # (no calendar-day churn). This is the core regression the fix removes.
+    existing = existing_md(mod, OLD)
+    out1 = rk.replace_frontmatter(existing, mod, preserve_unchanged=True)
+    assert f"last_scan: '{OLD}'" in out1, f"Case 1: last_scan not preserved:\n{out1}"
+    assert TODAY not in out1, "Case 1: today leaked in despite unchanged content"
+    assert out1 == existing, "Case 1: unchanged module was rewritten (would churn)"
+
+    # Case 2 — derived content changed (depends_on) → last_scan bumps to today.
+    stale = existing_md(make_mod(["OldModule"]), OLD)              # .md derived from old code
+    out2 = rk.replace_frontmatter(stale, mod, preserve_unchanged=True)  # mod now depends on BarModule
+    assert f"last_scan: '{TODAY}'" in out2, f"Case 2: last_scan not bumped:\n{out2}"
+    assert "BarModule" in out2 and "OldModule" not in out2, "Case 2: depends_on not refreshed"
+
+    # Case 3 — isolation: an unchanged module is not rewritten, so process() writes
+    # ONLY the modules whose content changed (Case 1 = no-op, Case 2 = diff).
+    assert rk.replace_frontmatter(existing, mod, preserve_unchanged=True) == existing
+
+    # Guard — default (non-headers-only) path is unchanged: always bumps to today.
+    out_default = rk.replace_frontmatter(existing, mod)  # preserve_unchanged=False
+    assert f"last_scan: '{TODAY}'" in out_default, "Default path must still bump to today"
+
+    print("OK — Case 1 (no-churn), Case 2 (bump-on-change), Case 3 (isolation), default unchanged")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Improvement Check

- **Problem:** The pre-commit `refresh-knowledge.py --headers-only` fast path stamped `last_scan: today` on every module unconditionally, so the first commit of each calendar day flipped all 49 `.claude/knowledge/modules/*.md` and the hook `git add`ed them "to ride along" — recurring diff-noise on unrelated PRs.
- **Evidence before:** On a tree matching `origin/main`, all 49 modules are stamped `last_scan: '2026-07-02'`. Old code run today (`2026-07-03`) bumps all 49 → 49-file diff with no code change behind it.
- **Expected gain:** `--headers-only` touches a module's `last_scan` **only when that module's derived content changed** — eliminating the daily calendar-rollover churn while keeping `last_scan` honest.
- **Risk:** Low, bounded. Content-diff based (no git), deterministic. Full-refresh path unchanged. The old redundant `if headers_only is False and not headers_only:` branch is consolidated with byte-identical default behaviour.
- **Test:** `scripts/knowledge/test_refresh_knowledge.py` (stdlib + pyyaml) — 5 tests: no-churn preserve, bump-on-change, default-path bump, **process() disk-isolation integration** (only changed modules written), and a **drift-guard** (`_CONTENT_KEYS` must equal build_frontmatter's emitted set minus `last_scan`). Wired into `.husky/pre-commit`: runs and must pass whenever a `scripts/knowledge/*.py` file is staged.
- **Evidence after:** `python3 scripts/knowledge/test_refresh_knowledge.py` → `OK — 5 tests passed`. End-to-end `--headers-only` → `0 updated`, empty `git status .claude/knowledge/` (where old code flipped 49). Negative tests confirm both guards fire: the drift-guard catches a forgotten derived field, and a failing invariant makes the pre-commit block the commit.
- **Verdict:** `GO` — small, tested, isolated; retro-compatible; no runtime/CI/canon surface touched.
- **Next action:** Owner review + merge. Standalone maintenance fix, deliberately separate from PR #1214.

## Hardening (adversarial audit)

An adversarial multi-lens audit (correctness / better-solution / test-and-CI / anti-bricolage, each finding independently verified by a refutation pass) confirmed the fix is **correct on every lens** and closed the two real gaps it found:

1. **The test now actually runs** — it was a green guard nothing invoked. Wired into `.husky/pre-commit` (extends the existing knowledge block; no new CI workflow; soft-skip if python3/pyyaml absent, hard-fail on a real failure).
2. **`process()` is now covered** — "Case 3" previously only re-asserted the pure function; a tmpdir integration test now drives the real disk-write decision.
3. **Silent-no-bump trap neutralized** — `_CONTENT_KEYS` is hand-kept in sync with `build_frontmatter`; a drift-guard test turns a future forgotten field (which would silently stop bumping `last_scan`) into a loud failure. The tempting refactor to derive the set from `build_frontmatter` was **rejected** — it reorders `last_scan` and would itself re-churn all 49 files.

> Note: the pre-commit guard is dormant in a git worktree (husky's absolute `core.hooksPath` points at the main checkout's hook); it goes live for all committers once merged to `main`. Verified functional via a direct negative test.

## Scope

Exactly 3 files — no knowledge `*.md`, no `log.md`:
- `scripts/knowledge/refresh-knowledge.py` — the fix.
- `scripts/knowledge/test_refresh_knowledge.py` — unit + integration + drift-guard tests.
- `.husky/pre-commit` — wires the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)