### PR TITLE
fix(search): stop client calls to disabled autocomplete route + align debounce (429 relief)

### DIFF
--- a/frontend/app/components/search/SearchBar.tsx
+++ b/frontend/app/components/search/SearchBar.tsx
@@ -23,10 +23,7 @@ import { Form, useNavigate, useSearchParams } from "react-router";
 
 import { logger } from "~/utils/logger";
 import { safeLocalStorage } from "~/utils/safe-storage";
-import {
-  useEnhancedSearchWithDebounce,
-  useEnhancedAutocomplete,
-} from "../../hooks/useEnhancedSearch";
+import { useEnhancedSearchWithDebounce } from "../../hooks/useEnhancedSearch";
 import { cn } from "../../lib/utils";
 import { searchApi } from "../../services/api/search.api";
 
@@ -83,9 +80,6 @@ export const SearchBar = memo(function SearchBar({
     debouncedQuery,
     loading: isSearching,
   } = useEnhancedSearchWithDebounce(initialQuery, 300);
-
-  // Hook d'autocomplete Enhanced
-  useEnhancedAutocomplete(query);
 
   // Historique local (localStorage)
   const [searchHistory, setSearchHistory] = useState<string[]>([]);

--- a/frontend/app/components/search/SearchBarEnhancedHomepage.tsx
+++ b/frontend/app/components/search/SearchBarEnhancedHomepage.tsx
@@ -68,13 +68,17 @@ export const SearchBarEnhancedHomepage = memo(
     const [selectedIndex, setSelectedIndex] = useState(-1);
     const [recentSearches, setRecentSearches] = useState<string[]>([]);
 
-    // Hook Enhanced avec debounce
+    // Hook Enhanced avec debounce.
+    // 300 ms (au lieu de 200) = valeur par défaut du hook : moins de requêtes
+    // `/api/search-existing/search` envoyées à l'origine pendant la frappe, donc
+    // moins de pression sur le rate-limiter par-IP partagé (incident 429 mobile
+    // CGNAT, 2026-07-03), pour un délai imperceptible.
     const {
       query,
       setQuery,
       loading: isSearching,
       results,
-    } = useEnhancedSearchWithDebounce(initialQuery, 200);
+    } = useEnhancedSearchWithDebounce(initialQuery, 300);
 
     // Hook d'autocomplete Enhanced
     const { suggestions } = useEnhancedAutocomplete(query);

--- a/frontend/app/hooks/useEnhancedSearch.ts
+++ b/frontend/app/hooks/useEnhancedSearch.ts
@@ -80,26 +80,22 @@ export function useEnhancedSearch() {
     }
   }, []);
 
-  // Fonction d'autocomplete
-  const autocomplete = useCallback(async (query: string): Promise<string[]> => {
-    if (query.length < 2) return [];
-
-    try {
-      const response = await fetch(
-        `/api/search-existing/autocomplete?q=${encodeURIComponent(query)}`,
-      );
-
-      if (!response.ok) {
-        throw new Error("Erreur autocomplete");
-      }
-
-      const data = await response.json();
-      return data.suggestions || [];
-    } catch (err) {
-      logger.warn("Erreur autocomplete:", err);
+  // Fonction d'autocomplete.
+  //
+  // La route backend `GET /api/search-existing/autocomplete` est DÉSACTIVÉE
+  // (commentée dans `search-enhanced-existing.controller.ts`, elle renvoyait
+  // toujours `{ suggestions: [] }`). L'appeler à chaque frappe ne produisait
+  // qu'une requête morte (404, ou 429 quand le rate-limiter `@nestjs/throttler`
+  // court-circuitait avant le routing) qui consommait le budget par-IP partagé —
+  // pénalisant les vrais visiteurs derrière une IP mutualisée (CGNAT mobile).
+  // Incident 429 PROD 2026-07-03. Tant que la route n'est pas rétablie côté
+  // backend, on ne la sollicite pas ; les suggestions restent vides comme avant.
+  const autocomplete = useCallback(
+    async (_query: string): Promise<string[]> => {
       return [];
-    }
-  }, []);
+    },
+    [],
+  );
 
   // Charger les métriques
   const loadMetrics = useCallback(async () => {

--- a/frontend/tests/unit/use-enhanced-search.test.ts
+++ b/frontend/tests/unit/use-enhanced-search.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests unitaires — `useEnhancedSearch` (`frontend/app/hooks/useEnhancedSearch.ts`).
+ *
+ * Contexte (incident 429 PROD 2026-07-03) : le endpoint backend
+ * `GET /api/search-existing/autocomplete` est DÉSACTIVÉ (commenté dans
+ * `search-enhanced-existing.controller.ts`, renvoyait toujours `suggestions: []`).
+ * Le hook l'appelait pourtant à CHAQUE frappe (via `useEnhancedAutocomplete` dans
+ * `SearchBarEnhancedHomepage`), produisant une requête morte (404/429) qui
+ * consommait le budget du rate-limiter partagé par IP (`@nestjs/throttler`,
+ * `cf-connecting-ip`). Ce test verrouille le contrat : le client ne sollicite pas
+ * une route désactivée, mais la recherche réelle (`/search`) continue de marcher.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEnhancedSearch } from "~/hooks/useEnhancedSearch";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("useEnhancedSearch", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(() => Promise.resolve(jsonResponse({ suggestions: [] })));
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not call the disabled /api/search-existing/autocomplete route and returns []", async () => {
+    const { result } = renderHook(() => useEnhancedSearch());
+    // Flush the mount-time `loadMetrics` effect so its setState runs inside act.
+    await act(async () => {});
+
+    const suggestions = await result.current.autocomplete("90915YZZM3");
+
+    expect(suggestions).toEqual([]);
+    const autocompleteCalls = fetchSpy.mock.calls.filter(([url]) =>
+      String(url).includes("/api/search-existing/autocomplete"),
+    );
+    expect(autocompleteCalls).toHaveLength(0);
+  });
+
+  it("still performs the real search against /api/search-existing/search", async () => {
+    fetchSpy.mockImplementation((url: string) =>
+      Promise.resolve(
+        String(url).includes("/search")
+          ? jsonResponse({ items: [{ id: 1 }], total: 1 })
+          : jsonResponse({ suggestions: [] }),
+      ),
+    );
+
+    const { result } = renderHook(() => useEnhancedSearch());
+    let data: Awaited<ReturnType<typeof result.current.search>>;
+    await act(async () => {
+      data = await result.current.search({ query: "filtre huile" });
+    });
+
+    expect(data?.total).toBe(1);
+    const searchCalls = fetchSpy.mock.calls.filter(([url]) =>
+      String(url).includes("/api/search-existing/search"),
+    );
+    expect(searchCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Improvement Check

- **Problem:** Real users occasionally get the app's per-IP throttler page (« Trop de requêtes ») on the homepage. The search box fired `GET /api/search-existing/autocomplete` on **every keystroke**, but that backend route is **deliberately disabled** (commented in `search-enhanced-existing.controller.ts`, always returned `{ suggestions: [] }`). Each keystroke = a dead 404/429 request burning the shared per-IP rate-limit budget (`@nestjs/throttler`, keyed on `cf-connecting-ip`), penalising CGNAT/mobile visitors who share a public IP.
- **Evidence before:** PROD `__error_logs` (24h): search-as-you-type fired `autocomplete` **and** `search` per keystroke (identical-ms pairs); an Orange-France mobile IP got 429 with only ~30 requests total (under every tier alone → shared-IP collateral). Backend route disabled at `search-enhanced-existing.controller.ts:124`.
- **Expected gain:** ~½ the origin calls per keystroke removed on **both** search bars; less collateral 429 for shared-IP visitors; minor INP win.
- **Risk:** Frontend-only, hook signature unchanged, no consumer broken, fully **reversible** (restore the fetch when the backend route is re-enabled). No user-visible change (suggestions were already always empty).
- **Test:** `frontend/tests/unit/use-enhanced-search.test.ts` (TDD, RED→GREEN): locks « client does not call the disabled route » + « the real `/search` still works ».
- **Evidence after:** `tsc` **0** · `eslint` **0** · **2/2** tests green.
- **Verdict:** `GO_WITH_WATCH` — watch the `/api/search-existing/*` 429 count after PROD deploy.

## Changes

- **`useEnhancedSearch.autocomplete()`** — no longer calls the disabled route (returns `[]`; fixes both search bars via the shared hook).
- **`SearchBar`** — removed the residual dead `useEnhancedAutocomplete()` call + import.
- **`SearchBarEnhancedHomepage`** — debounce `200 → 300ms` (the hook default) → fewer `/search` requests reach origin per keystroke.
- **Test** — new unit test locking the contract.

## Out of scope (unchanged, by design)

97.4% of PROD 429s are a separate `curl` scraper on a Hetzner box that the throttler **correctly** blocks (cheap rejections, no DB load). Blocking it at Cloudflare is owner-side and constrained (free plan, Custom Rules 5/5 full; the scraper's ASN is shared with our own DEV/PROD infra) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)