### PR TITLE
fix(caddy): no-store on Caddy-generated 5xx errors (handle_errors block)

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -332,6 +332,15 @@ automecanik.com, www.automecanik.com {
     
     # ===== GESTION DES ERREURS =====
     handle_errors {
+        # 🛡️ Anti-cache-poisoning (complément de @up_error, ~l.268) : quand Caddy génère
+        # LUI-MÊME un 5xx — upstream monorepo_prod:3000 injoignable au reboot backend —
+        # handle_response @up_error ne se déclenche PAS (il n'intercepte que les réponses
+        # de l'upstream). La réponse hérite alors du Cache-Control long posé par @products
+        # (s-maxage=86400) SANS no-store, et Cloudflare (Cache Rule /pieces respect-origin)
+        # la cacherait 24h — figeant une erreur transitoire de reboot sur une page qui
+        # existe. no-store ici couvre ce chemin Caddy-généré. Incident 2026-06-25 (#1140)
+        # + résolution CF Cache Rule /pieces 2026-07-04.
+        header Cache-Control "no-store"
         @404 expression {http.error.status_code} == 404
         @500 expression {http.error.status_code} >= 500
         redir @404 /404 302


### PR DESCRIPTION
## Contexte

Follow-up de l'incident GSC **« Indexation → Erreur serveur (5xx) »** sur `/pieces/*` & `/constructeurs/*` (validation GSC échouée 2026-07-01), diagnostiqué et résolu 2026-07-04 :

- **Origine (Caddy)** : garde `@up_error status 4xx 5xx → no-store` (#1140) — déployée sur PROD (via `docker restart`).
- **Edge (Cloudflare)** : Cache Rule `/pieces` passée de « ignore cache-control, TTL 2h » → **respecter l'origine** + Purge Everything.

Root cause = un **503 transitoire volontaire** (crawler-retry, `ServiceUnavailableException` sur échec RPC) **figé 24h par le cache CDN** — jamais une panne, jamais le challenge CF (403 ≠ 5xx).

## Ce que ferme cette PR

Une **faille résiduelle de récurrence**. `handle_response @up_error` (#1140) n'intercepte QUE les réponses **renvoyées par l'upstream**. Quand **Caddy génère lui-même** un 5xx — `monorepo_prod:3000` injoignable pendant un **redémarrage backend** (le scénario « boot container » cité dans le commentaire de #1140) — la réponse hérite du `s-maxage=86400` posé par `@products` **sans `no-store`**. Or, maintenant que Cloudflare **respecte l'origine** sur `/pieces`, cette 502/500 serait **cachée 24h** → réintroduction de l'empoisonnement à chaque restart backend.

**Fix** : `header Cache-Control "no-store"` en première directive du bloc `handle_errors` existant → les 5xx générés par Caddy lui-même ne sont jamais mis en cache CDN. Complète `@up_error` ; ensemble ils couvrent **les deux origines** de 5xx (upstream + Caddy-self).

## Diff

`+9` lignes dans `config/caddy/Caddyfile` (8 de commentaire explicatif + 1 directive). **Aucune URL / route / slug touchée.**

## Vérification

- `caddy adapt --adapter caddyfile` → **VALIDE** (exit 0) sur l'image épinglée `caddy:2.11-alpine`. Seuls warnings **pré-existants** (`header_up` inutiles, fichier non formaté ligne 7) — `caddy fmt` volontairement **PAS** lancé pour ne pas reformater le reste du fichier (hors-scope).
- Comportement (vérifié sur banc `caddy:2.11-alpine` lors de l'analyse) : upstream DOWN → 502 porte `no-store` ; upstream UP → `/pieces` 410 garde `no-store` via `@up_error` (pas de régression) ; `/pieces` 200 → `s-maxage=86400` préservé.

## Déploiement (owner-gated)

⚠️ Le Caddyfile est **monté en volume** sur la box PROD (`/home/deploy/production/config/caddy/Caddyfile`) — **merger `main` ne le déploie PAS**. Application owner : propager le fichier sur la box + **`docker restart nestjs-remix-caddy`** (`admin off` ⇒ `caddy reload` indisponible ; CMD sans `--resume` ⇒ le restart relit le fichier monté).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
