### PR TITLE
chore(registry): PR-B dependency-truth — L1 deps rebuild + 3 owner-approved L2 ids

### DIFF
--- a/.spec/00-canon/repository-registry/dep-governance.yaml
+++ b/.spec/00-canon/repository-registry/dep-governance.yaml
@@ -96,7 +96,7 @@ dependencies:
     owner: "@ak125"
 
   # ── backend-platform (3 entries — D14) ──
-  - id: "npm:@nestjs/bull@^10.2.3"
+  - id: "npm:@nestjs/bull@^11.0.4"
     name: "@nestjs/bull"
     family: backend-platform
     domain: D14
@@ -106,7 +106,7 @@ dependencies:
     family: backend-platform
     domain: D14
     owner: "@ak125"
-  - id: "npm:@nestjs/cache-manager@^2.3.0"
+  - id: "npm:@nestjs/cache-manager@^3.1.3"
     name: "@nestjs/cache-manager"
     family: backend-platform
     domain: D14
@@ -220,7 +220,7 @@ dependencies:
     owner: "@ak125"
 
   # ── validation (1 entry — D14) ──
-  - id: "npm:zod@^3.25.76"
+  - id: "npm:zod@^4.4.3"
     name: "zod"
     family: validation
     domain: D14

--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,68 +1,6 @@
 {
-  "artifact_immutability_hash": "sha256:a532cd0ebe899379043138db0f9a64789fd85c7c73b2de29a54f6c9f2ed319ee",
+  "artifact_immutability_hash": "sha256:f99e660b1ea68bd8d5696738e2f815311c8041c12496d89134a0bb0f3b7a0e82",
   "divergences": [
-    {
-      "kind": "specifier",
-      "name": "@nestjs/common",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^10.0.0",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^10.4.20",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "11.1.27"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "@nestjs/core",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^10.0.0",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^10.4.20",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "11.1.27"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "@react-router/express",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^7.0.0",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^7.15.0",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^7.15.0",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "8.0.1"
-      ]
-    },
     {
       "kind": "resolved",
       "name": "@types/eslint",
@@ -122,31 +60,12 @@
       ]
     },
     {
-      "kind": "specifier",
-      "name": "autoprefixer",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^10.4.20",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^10.4.14",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "10.5.2"
-      ]
-    },
-    {
       "kind": "resolved",
       "name": "connect-redis",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
-          "specifier": "^5.2.0",
+          "specifier": "^9.0.0",
           "workspace": "@fafa/backend"
         }
       ],
@@ -174,6 +93,22 @@
         "16.6.1",
         "17.4.1",
         "17.4.2"
+      ]
+    },
+    {
+      "kind": "resolved",
+      "name": "esbuild",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^0.27.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "0.21.5",
+        "0.27.7",
+        "0.28.1"
       ]
     },
     {
@@ -328,6 +263,26 @@
     },
     {
       "kind": "resolved",
+      "name": "keyv",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^5.6.0",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^5.6.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "4.5.4",
+        "5.6.0"
+      ]
+    },
+    {
+      "kind": "resolved",
       "name": "node-fetch",
       "occurrences": [
         {
@@ -352,7 +307,7 @@
         },
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^1.56.1",
+          "specifier": "1.61.0",
           "workspace": "@fafa/frontend"
         }
       ],
@@ -401,49 +356,6 @@
       ]
     },
     {
-      "kind": "specifier",
-      "name": "react-router",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^7.0.0",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^7.15.0",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^7.15.0",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "8.0.1"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "reflect-metadata",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^0.2.2",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^0.1.14",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "0.2.2"
-      ]
-    },
-    {
       "kind": "resolved",
       "name": "rxjs",
       "occurrences": [
@@ -476,25 +388,6 @@
       "resolved_versions": [
         "0.5.13",
         "0.5.21"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "swagger-ui-express",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^4.6.3",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^5.0.1",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
       ]
     },
     {
@@ -626,12 +519,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "7.3.5",
+          "specifier": "8.1.0",
           "workspace": "@fafa/frontend"
         },
         {
           "declaredIn": "package.json",
-          "specifier": "7.3.5",
+          "specifier": "8.1.0",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
@@ -666,72 +559,58 @@
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
-          "specifier": "^3.25.76",
+          "specifier": "^4.4.3",
           "workspace": "@fafa/backend"
         },
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^3.25.76",
-          "workspace": "@fafa/frontend"
+          "specifier": "^4.4.3",
+          "workspace": "@fafa/design-tokens"
         },
         {
           "declaredIn": "package.json",
-          "specifier": "^3.25.76",
-          "workspace": "@repo/cwv-taxonomy"
+          "specifier": "^4.4.3",
+          "workspace": "@fafa/frontend"
         },
         {
           "declaredIn": "packages/cwv-taxonomy/package.json",
-          "specifier": "^3.25.76",
-          "workspace": "@repo/database-types"
+          "specifier": "^4.4.3",
+          "workspace": "@repo/cwv-taxonomy"
         },
         {
           "declaredIn": "packages/database-types/package.json",
-          "specifier": "^3.25.76",
+          "specifier": "^4.4.3",
+          "workspace": "@repo/database-types"
+        },
+        {
+          "declaredIn": "packages/design-tokens/package.json",
+          "specifier": "^4.4.3",
           "workspace": "@repo/registry"
         },
         {
           "declaredIn": "packages/registry/package.json",
-          "specifier": "^3.25.76",
+          "specifier": "^4.4.3",
           "workspace": "@repo/seo-role-contracts"
         },
         {
           "declaredIn": "packages/seo-role-contracts/package.json",
-          "specifier": "^3.25.76",
+          "specifier": "^4.4.3",
           "workspace": "@repo/seo-roles"
         },
         {
           "declaredIn": "packages/seo-roles/package.json",
-          "specifier": "^3.25.76",
+          "specifier": "^4.4.3",
           "workspace": "@repo/seo-types"
         },
         {
           "declaredIn": "packages/seo-types/package.json",
-          "specifier": "^3.25.76",
+          "specifier": "^4.4.3",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
       "resolved_versions": [
         "3.25.76",
         "4.4.3"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "zod-to-json-schema",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^3.25.2",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "packages/registry/package.json",
-          "specifier": "3.23.0",
-          "workspace": "@repo/registry"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
       ]
     }
   ],
@@ -838,7 +717,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.0.3",
+              "specifier": "^11.0.5",
               "workspace": "@fafa/backend"
             }
           ],
@@ -873,7 +752,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^5.2.0",
+              "specifier": "^9.0.0",
               "workspace": "@fafa/backend"
             }
           ],
@@ -889,7 +768,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^1.17.3",
+              "specifier": "^1.19.0",
               "workspace": "@fafa/backend"
             }
           ],
@@ -1697,7 +1576,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.2.3",
+              "specifier": "^11.0.4",
               "workspace": "@fafa/backend"
             }
           ],
@@ -1959,7 +1838,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^2.3.0",
+              "specifier": "^3.1.3",
               "workspace": "@fafa/backend"
             }
           ],
@@ -1974,7 +1853,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.0.0",
+              "specifier": "^11.0.23",
               "workspace": "@fafa/backend"
             }
           ],
@@ -1984,17 +1863,17 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "@nestjs/common",
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.0.0",
+              "specifier": "^11.1.27",
               "workspace": "@fafa/backend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^10.4.20",
+              "specifier": "^11.1.27",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2009,7 +1888,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^4.0.2",
+              "specifier": "^4.0.4",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2019,17 +1898,17 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "@nestjs/core",
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.0.0",
+              "specifier": "^11.1.27",
               "workspace": "@fafa/backend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^10.4.20",
+              "specifier": "^11.1.27",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2044,7 +1923,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^2.1.1",
+              "specifier": "^3.1.0",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2059,7 +1938,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.4.20",
+              "specifier": "^11.1.27",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2074,7 +1953,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.4.20",
+              "specifier": "^11.1.27",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2089,7 +1968,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^6.0.1",
+              "specifier": "^6.1.3",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2104,7 +1983,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.0.0",
+              "specifier": "^11.1.0",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2119,7 +1998,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "7.4.2",
+              "specifier": "11.4.4",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2134,7 +2013,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.4.20",
+              "specifier": "^11.1.27",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2149,7 +2028,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^5.0.0",
+              "specifier": "^6.5.0",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2164,7 +2043,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^10.4.20",
+              "specifier": "^11.1.27",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2179,7 +2058,7 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^1.20.3",
+              "specifier": "^2.3.0",
               "workspace": "@fafa/backend"
             }
           ],
@@ -2189,7 +2068,7 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "reflect-metadata",
           "occurrences": [
             {
@@ -2199,7 +2078,7 @@
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^0.1.14",
+              "specifier": "^0.2.2",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2549,12 +2428,12 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2564,22 +2443,22 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "@react-router/express",
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^7.0.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/backend"
             },
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2594,12 +2473,12 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2614,7 +2493,7 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/frontend"
             }
           ],
@@ -2629,12 +2508,12 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2714,22 +2593,22 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "react-router",
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^7.0.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/backend"
             },
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^7.15.0",
+              "specifier": "8.0.1",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2744,12 +2623,12 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "7.3.5",
+              "specifier": "8.1.0",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "7.3.5",
+              "specifier": "8.1.0",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -3473,7 +3352,6 @@
         "eslint-plugin-prettier",
         "eslint-plugin-react",
         "eslint-plugin-react-hooks",
-        "eslint-plugin-storybook",
         "eslint-plugin-testing-library",
         "typescript"
       ],
@@ -3708,73 +3586,58 @@
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^3.25.76",
+              "specifier": "^4.4.3",
               "workspace": "@fafa/backend"
             },
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^3.25.76",
-              "workspace": "@fafa/frontend"
+              "specifier": "^4.4.3",
+              "workspace": "@fafa/design-tokens"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^3.25.76",
-              "workspace": "@repo/cwv-taxonomy"
+              "specifier": "^4.4.3",
+              "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "packages/cwv-taxonomy/package.json",
-              "specifier": "^3.25.76",
-              "workspace": "@repo/database-types"
+              "specifier": "^4.4.3",
+              "workspace": "@repo/cwv-taxonomy"
             },
             {
               "declaredIn": "packages/database-types/package.json",
-              "specifier": "^3.25.76",
+              "specifier": "^4.4.3",
+              "workspace": "@repo/database-types"
+            },
+            {
+              "declaredIn": "packages/design-tokens/package.json",
+              "specifier": "^4.4.3",
               "workspace": "@repo/registry"
             },
             {
               "declaredIn": "packages/registry/package.json",
-              "specifier": "^3.25.76",
+              "specifier": "^4.4.3",
               "workspace": "@repo/seo-role-contracts"
             },
             {
               "declaredIn": "packages/seo-role-contracts/package.json",
-              "specifier": "^3.25.76",
+              "specifier": "^4.4.3",
               "workspace": "@repo/seo-roles"
             },
             {
               "declaredIn": "packages/seo-roles/package.json",
-              "specifier": "^3.25.76",
+              "specifier": "^4.4.3",
               "workspace": "@repo/seo-types"
             },
             {
               "declaredIn": "packages/seo-types/package.json",
-              "specifier": "^3.25.76",
+              "specifier": "^4.4.3",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
           "resolved_versions": [
             "3.25.76",
             "4.4.3"
-          ]
-        },
-        {
-          "divergent_resolved": false,
-          "divergent_specifiers": true,
-          "name": "zod-to-json-schema",
-          "occurrences": [
-            {
-              "declaredIn": "backend/package.json",
-              "specifier": "^3.25.2",
-              "workspace": "@fafa/backend"
-            },
-            {
-              "declaredIn": "packages/registry/package.json",
-              "specifier": "3.23.0",
-              "workspace": "@repo/registry"
-            }
-          ],
-          "resolved_versions": [
-            "<unresolved>"
           ]
         }
       ],
@@ -3845,7 +3708,7 @@
       ],
       "supports_dual_runtime": "none",
       "target_major": "4.x",
-      "total_occurrences": 11,
+      "total_occurrences": 10,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 10,
         "estimated_review_load": "high"
@@ -3859,7 +3722,7 @@
   ],
   "generatedFrom": {
     "deps_registry": "audit/registry/deps.json",
-    "deps_registry_sha": "sha256:9b722879fab181ddf8a7942e3c00324fd6d8fddd5323646c2d7f939e7739234d",
+    "deps_registry_sha": "sha256:a580f64acf4bb9bea3d25c935e014765913150f69ac4073803b4f650b2c35b72",
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:dc7c5bd4696d0359ce2883ef4c195ae1316ac725c5de79360f5779b0b29874b5",
     "overlay": "audit/dependencies/family-overlay.yaml",
@@ -3878,23 +3741,23 @@
       "runtime-backend": 17,
       "runtime-frontend": 11,
       "tooling": 15,
-      "unassigned": 163,
-      "validation": 2
+      "unassigned": 160,
+      "validation": 1
     },
     "by_pr_assignment": {
       "deferred": 26,
       "pr-9b": 10,
-      "pr-9c": 2,
+      "pr-9c": 1,
       "pr-9d": 5,
       "pr-9e": 8,
       "pr-9f": 17,
       "pr-9g": 0
     },
-    "divergent_packages_count": 33,
+    "divergent_packages_count": 27,
     "families_count": 12,
-    "total_occurrences": 339,
-    "total_packages": 231,
-    "unassigned_count": 163
+    "total_occurrences": 334,
+    "total_packages": 227,
+    "unassigned_count": 160
   },
   "unassigned_packages": [
     {
@@ -3955,21 +3818,6 @@
       ],
       "resolved_versions": [
         "2.31.0"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "@chromatic-com/storybook",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^4.1.1",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
       ]
     },
     {
@@ -4084,7 +3932,7 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^1.59.1",
+          "specifier": "1.61.0",
           "workspace": "@fafa/frontend"
         }
       ],
@@ -4460,76 +4308,16 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
-      "name": "@storybook/addon-a11y",
+      "name": "@tailwindcss/vite",
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.13",
+          "specifier": "^4.3.1",
           "workspace": "@fafa/frontend"
         }
       ],
       "resolved_versions": [
-        "<unresolved>"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "@storybook/addon-docs",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.13",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "@storybook/addon-onboarding",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.20",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "@storybook/addon-vitest",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.13",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "@storybook/react-vite",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.13",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
+        "4.3.1"
       ]
     },
     {
@@ -4545,6 +4333,21 @@
       ],
       "resolved_versions": [
         "5.101.1"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@testcontainers/redis",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^12.0.3",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "12.0.3"
       ]
     },
     {
@@ -4715,21 +4518,6 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
-      "name": "@types/cache-manager",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^4.0.0",
-          "workspace": "@fafa/backend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
       "name": "@types/compression",
       "occurrences": [
         {
@@ -4740,21 +4528,6 @@
       ],
       "resolved_versions": [
         "1.8.1"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "@types/connect-redis",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^0.0.23",
-          "workspace": "@fafa/backend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
       ]
     },
     {
@@ -5195,14 +4968,9 @@
     },
     {
       "divergent_resolved": false,
-      "divergent_specifiers": true,
+      "divergent_specifiers": false,
       "name": "autoprefixer",
       "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^10.4.20",
-          "workspace": "@fafa/frontend"
-        },
         {
           "declaredIn": "package.json",
           "specifier": "^10.4.14",
@@ -5235,12 +5003,27 @@
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
-          "specifier": "^5.0.0",
+          "specifier": "^6.0.0",
           "workspace": "@fafa/backend"
         }
       ],
       "resolved_versions": [
         "6.4.3"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "cacheable",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^2.3.0",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "2.3.5"
       ]
     },
     {
@@ -5306,6 +5089,21 @@
       ],
       "resolved_versions": [
         "1.8.1"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "connect-redis-v5",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "npm:connect-redis@^5.2.0",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "<unresolved>"
       ]
     },
     {
@@ -5406,6 +5204,23 @@
       ]
     },
     {
+      "divergent_resolved": true,
+      "divergent_specifiers": false,
+      "name": "esbuild",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^0.27.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "0.21.5",
+        "0.27.7",
+        "0.28.1"
+      ]
+    },
+    {
       "divergent_resolved": false,
       "divergent_specifiers": false,
       "name": "eslint-import-resolver-typescript",
@@ -5463,21 +5278,6 @@
       ],
       "resolved_versions": [
         "5.5.0"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": false,
-      "name": "eslint-plugin-storybook",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.13",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
       ]
     },
     {
@@ -5767,6 +5567,27 @@
       ]
     },
     {
+      "divergent_resolved": true,
+      "divergent_specifiers": false,
+      "name": "keyv",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^5.6.0",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^5.6.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "4.5.4",
+        "5.6.0"
+      ]
+    },
+    {
       "divergent_resolved": false,
       "divergent_specifiers": false,
       "name": "knip",
@@ -5984,7 +5805,7 @@
         },
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^1.56.1",
+          "specifier": "1.61.0",
           "workspace": "@fafa/frontend"
         }
       ],
@@ -6071,6 +5892,21 @@
       ],
       "resolved_versions": [
         "2.15.4"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "redis",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "~5.12.0",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "5.12.1"
       ]
     },
     {
@@ -6222,16 +6058,16 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
-      "name": "storybook",
+      "name": "style-dictionary",
       "occurrences": [
         {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^9.1.13",
-          "workspace": "@fafa/frontend"
+          "declaredIn": "packages/design-tokens/package.json",
+          "specifier": "5.5.0",
+          "workspace": "@fafa/design-tokens"
         }
       ],
       "resolved_versions": [
-        "<unresolved>"
+        "5.5.0"
       ]
     },
     {
@@ -6247,26 +6083,6 @@
       ],
       "resolved_versions": [
         "7.2.2"
-      ]
-    },
-    {
-      "divergent_resolved": false,
-      "divergent_specifiers": true,
-      "name": "swagger-ui-express",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^4.6.3",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^5.0.1",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "<unresolved>"
       ]
     },
     {
@@ -6296,12 +6112,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^3.4.15",
+          "specifier": "^4.3.1",
           "workspace": "@fafa/frontend"
         },
         {
           "declaredIn": "package.json",
-          "specifier": "^3.4.15",
+          "specifier": "^4.3.1",
           "workspace": "nestjs-remix-monorepo"
         }
       ],

--- a/audit/registry/deps.json
+++ b/audit/registry/deps.json
@@ -66,22 +66,6 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:@chromatic-com/storybook@^4.1.1",
-      "name": "@chromatic-com/storybook",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^4.1.1",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
         "package.json"
       ],
       "id": "npm:@commitlint/cli@^20.5.3",
@@ -196,14 +180,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/bull@^10.2.3",
+      "id": "npm:@nestjs/bull@^11.0.4",
       "name": "@nestjs/bull",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.2.3",
+      "version": "^11.0.4",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -228,14 +212,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/cache-manager@^2.3.0",
+      "id": "npm:@nestjs/cache-manager@^3.1.3",
       "name": "@nestjs/cache-manager",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^2.3.0",
+      "version": "^3.1.3",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -244,47 +228,33 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/cli@^10.0.0",
+      "id": "npm:@nestjs/cli@^11.0.23",
       "name": "@nestjs/cli",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.0.0",
+      "version": "^11.0.23",
       "workspaces": [
         "@fafa/backend"
       ]
     },
     {
       "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:@nestjs/common@^10.0.0",
-      "name": "@nestjs/common",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^10.0.0",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "backend/package.json",
         "package.json"
       ],
-      "id": "npm:@nestjs/common@^10.4.20",
+      "id": "npm:@nestjs/common@^11.1.27",
       "name": "@nestjs/common",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.4.20",
+      "version": "^11.1.27",
       "workspaces": [
+        "@fafa/backend",
         "nestjs-remix-monorepo"
       ]
     },
@@ -292,47 +262,33 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/config@^4.0.2",
+      "id": "npm:@nestjs/config@^4.0.4",
       "name": "@nestjs/config",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^4.0.2",
+      "version": "^4.0.4",
       "workspaces": [
         "@fafa/backend"
       ]
     },
     {
       "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:@nestjs/core@^10.0.0",
-      "name": "@nestjs/core",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^10.0.0",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "backend/package.json",
         "package.json"
       ],
-      "id": "npm:@nestjs/core@^10.4.20",
+      "id": "npm:@nestjs/core@^11.1.27",
       "name": "@nestjs/core",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.4.20",
+      "version": "^11.1.27",
       "workspaces": [
+        "@fafa/backend",
         "nestjs-remix-monorepo"
       ]
     },
@@ -340,14 +296,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/event-emitter@^2.1.1",
+      "id": "npm:@nestjs/event-emitter@^3.1.0",
       "name": "@nestjs/event-emitter",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^2.1.1",
+      "version": "^3.1.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -372,14 +328,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/passport@^10.0.3",
+      "id": "npm:@nestjs/passport@^11.0.5",
       "name": "@nestjs/passport",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.0.3",
+      "version": "^11.0.5",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -388,14 +344,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/platform-express@^10.4.20",
+      "id": "npm:@nestjs/platform-express@^11.1.27",
       "name": "@nestjs/platform-express",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.4.20",
+      "version": "^11.1.27",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -404,14 +360,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/platform-socket.io@^10.4.20",
+      "id": "npm:@nestjs/platform-socket.io@^11.1.27",
       "name": "@nestjs/platform-socket.io",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.4.20",
+      "version": "^11.1.27",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -420,14 +376,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/schedule@^6.0.1",
+      "id": "npm:@nestjs/schedule@^6.1.3",
       "name": "@nestjs/schedule",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^6.0.1",
+      "version": "^6.1.3",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -436,14 +392,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/schematics@^10.0.0",
+      "id": "npm:@nestjs/schematics@^11.1.0",
       "name": "@nestjs/schematics",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.0.0",
+      "version": "^11.1.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -452,14 +408,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/swagger@7.4.2",
+      "id": "npm:@nestjs/swagger@11.4.4",
       "name": "@nestjs/swagger",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "7.4.2",
+      "version": "11.4.4",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -468,14 +424,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/testing@^10.4.20",
+      "id": "npm:@nestjs/testing@^11.1.27",
       "name": "@nestjs/testing",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.4.20",
+      "version": "^11.1.27",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -484,14 +440,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/throttler@^5.0.0",
+      "id": "npm:@nestjs/throttler@^6.5.0",
       "name": "@nestjs/throttler",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^5.0.0",
+      "version": "^6.5.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -500,14 +456,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@nestjs/websockets@^10.4.20",
+      "id": "npm:@nestjs/websockets@^11.1.27",
       "name": "@nestjs/websockets",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^10.4.20",
+      "version": "^11.1.27",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -532,14 +488,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@playwright/test@^1.59.1",
+      "id": "npm:@playwright/test@1.61.0",
       "name": "@playwright/test",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^1.59.1",
+      "version": "1.61.0",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -789,14 +745,14 @@
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:@react-router/dev@^7.15.0",
+      "id": "npm:@react-router/dev@8.0.1",
       "name": "@react-router/dev",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^7.15.0",
+      "version": "8.0.1",
       "workspaces": [
         "@fafa/frontend",
         "nestjs-remix-monorepo"
@@ -804,34 +760,20 @@
     },
     {
       "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:@react-router/express@^7.0.0",
-      "name": "@react-router/express",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^7.0.0",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "backend/package.json",
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:@react-router/express@^7.15.0",
+      "id": "npm:@react-router/express@8.0.1",
       "name": "@react-router/express",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^7.15.0",
+      "version": "8.0.1",
       "workspaces": [
+        "@fafa/backend",
         "@fafa/frontend",
         "nestjs-remix-monorepo"
       ]
@@ -841,14 +783,14 @@
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:@react-router/node@^7.15.0",
+      "id": "npm:@react-router/node@8.0.1",
       "name": "@react-router/node",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^7.15.0",
+      "version": "8.0.1",
       "workspaces": [
         "@fafa/frontend",
         "nestjs-remix-monorepo"
@@ -858,14 +800,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@react-router/remix-routes-option-adapter@^7.15.0",
+      "id": "npm:@react-router/remix-routes-option-adapter@8.0.1",
       "name": "@react-router/remix-routes-option-adapter",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^7.15.0",
+      "version": "8.0.1",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -875,14 +817,14 @@
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:@react-router/serve@^7.15.0",
+      "id": "npm:@react-router/serve@8.0.1",
       "name": "@react-router/serve",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^7.15.0",
+      "version": "8.0.1",
       "workspaces": [
         "@fafa/frontend",
         "nestjs-remix-monorepo"
@@ -938,86 +880,6 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:@storybook/addon-a11y@^9.1.13",
-      "name": "@storybook/addon-a11y",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^9.1.13",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:@storybook/addon-docs@^9.1.13",
-      "name": "@storybook/addon-docs",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^9.1.13",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:@storybook/addon-onboarding@^9.1.20",
-      "name": "@storybook/addon-onboarding",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^9.1.20",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:@storybook/addon-vitest@^9.1.13",
-      "name": "@storybook/addon-vitest",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^9.1.13",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:@storybook/react-vite@^9.1.13",
-      "name": "@storybook/react-vite",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^9.1.13",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
         "backend/package.json",
         "package.json"
       ],
@@ -1038,6 +900,22 @@
       "declaredIn": [
         "frontend/package.json"
       ],
+      "id": "npm:@tailwindcss/vite@^4.3.1",
+      "name": "@tailwindcss/vite",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^4.3.1",
+      "workspaces": [
+        "@fafa/frontend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "frontend/package.json"
+      ],
       "id": "npm:@tanstack/react-query@^5.87.1",
       "name": "@tanstack/react-query",
       "owner": "__unassigned__",
@@ -1048,6 +926,22 @@
       "version": "^5.87.1",
       "workspaces": [
         "@fafa/frontend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
+      "id": "npm:@testcontainers/redis@^12.0.3",
+      "name": "@testcontainers/redis",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^12.0.3",
+      "workspaces": [
+        "@fafa/backend"
       ]
     },
     {
@@ -1230,22 +1124,6 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:@types/cache-manager@^4.0.0",
-      "name": "@types/cache-manager",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^4.0.0",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "backend/package.json"
-      ],
       "id": "npm:@types/compression@^1.8.1",
       "name": "@types/compression",
       "owner": "__unassigned__",
@@ -1254,22 +1132,6 @@
       "sourceConfidence": "high",
       "status": "LIVE",
       "version": "^1.8.1",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:@types/connect-redis@^0.0.23",
-      "name": "@types/connect-redis",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^0.0.23",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -1820,22 +1682,6 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:autoprefixer@^10.4.20",
-      "name": "autoprefixer",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^10.4.20",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
       "id": "npm:axe-core@^4.12.0",
       "name": "axe-core",
       "owner": "__unassigned__",
@@ -1870,14 +1716,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:body-parser@^1.20.3",
+      "id": "npm:body-parser@^2.3.0",
       "name": "body-parser",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^1.20.3",
+      "version": "^2.3.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -1918,14 +1764,30 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:cache-manager@^5.0.0",
+      "id": "npm:cache-manager@^6.0.0",
       "name": "cache-manager",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^5.0.0",
+      "version": "^6.0.0",
+      "workspaces": [
+        "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
+      "id": "npm:cacheable@^2.3.0",
+      "name": "cacheable",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^2.3.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -2000,14 +1862,30 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:connect-redis@^5.2.0",
+      "id": "npm:connect-redis-v5@npm:connect-redis@^5.2.0",
+      "name": "connect-redis-v5",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "npm:connect-redis@^5.2.0",
+      "workspaces": [
+        "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
+      "id": "npm:connect-redis@^9.0.0",
       "name": "connect-redis",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^5.2.0",
+      "version": "^9.0.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -2120,6 +1998,22 @@
       "sourceConfidence": "high",
       "status": "LIVE",
       "version": "^8.6.0",
+      "workspaces": [
+        "@fafa/frontend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "frontend/package.json"
+      ],
+      "id": "npm:esbuild@^0.27.0",
+      "name": "esbuild",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^0.27.0",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -2288,22 +2182,6 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:eslint-plugin-storybook@^9.1.13",
-      "name": "eslint-plugin-storybook",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^9.1.13",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
       "id": "npm:eslint-plugin-testing-library@^7.16.2",
       "name": "eslint-plugin-testing-library",
       "owner": "__unassigned__",
@@ -2378,14 +2256,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:express-session@^1.17.3",
+      "id": "npm:express-session@^1.19.0",
       "name": "express-session",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^1.17.3",
+      "version": "^1.19.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -2681,6 +2559,24 @@
       "sourceConfidence": "high",
       "status": "LIVE",
       "version": "^4.1.1",
+      "workspaces": [
+        "@fafa/backend",
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json",
+        "package.json"
+      ],
+      "id": "npm:keyv@^5.6.0",
+      "name": "keyv",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^5.6.0",
       "workspaces": [
         "@fafa/backend",
         "nestjs-remix-monorepo"
@@ -2998,6 +2894,22 @@
     },
     {
       "declaredIn": [
+        "frontend/package.json"
+      ],
+      "id": "npm:playwright@1.61.0",
+      "name": "playwright",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "1.61.0",
+      "workspaces": [
+        "@fafa/frontend"
+      ]
+    },
+    {
+      "declaredIn": [
         "backend/package.json"
       ],
       "id": "npm:playwright@^1.48.2",
@@ -3010,22 +2922,6 @@
       "version": "^1.48.2",
       "workspaces": [
         "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:playwright@^1.56.1",
-      "name": "playwright",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^1.56.1",
-      "workspaces": [
-        "@fafa/frontend"
       ]
     },
     {
@@ -3146,34 +3042,20 @@
     },
     {
       "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:react-router@^7.0.0",
-      "name": "react-router",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^7.0.0",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "backend/package.json",
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:react-router@^7.15.0",
+      "id": "npm:react-router@8.0.1",
       "name": "react-router",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^7.15.0",
+      "version": "8.0.1",
       "workspaces": [
+        "@fafa/backend",
         "@fafa/frontend",
         "nestjs-remix-monorepo"
       ]
@@ -3214,23 +3096,24 @@
     },
     {
       "declaredIn": [
-        "package.json"
+        "backend/package.json"
       ],
-      "id": "npm:reflect-metadata@^0.1.14",
-      "name": "reflect-metadata",
+      "id": "npm:redis@~5.12.0",
+      "name": "redis",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^0.1.14",
+      "version": "~5.12.0",
       "workspaces": [
-        "nestjs-remix-monorepo"
+        "@fafa/backend"
       ]
     },
     {
       "declaredIn": [
-        "backend/package.json"
+        "backend/package.json",
+        "package.json"
       ],
       "id": "npm:reflect-metadata@^0.2.2",
       "name": "reflect-metadata",
@@ -3241,7 +3124,8 @@
       "status": "LIVE",
       "version": "^0.2.2",
       "workspaces": [
-        "@fafa/backend"
+        "@fafa/backend",
+        "nestjs-remix-monorepo"
       ]
     },
     {
@@ -3412,18 +3296,18 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
+        "packages/design-tokens/package.json"
       ],
-      "id": "npm:storybook@^9.1.13",
-      "name": "storybook",
+      "id": "npm:style-dictionary@5.5.0",
+      "name": "style-dictionary",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^9.1.13",
+      "version": "5.5.0",
       "workspaces": [
-        "@fafa/frontend"
+        "@fafa/design-tokens"
       ]
     },
     {
@@ -3440,38 +3324,6 @@
       "version": "^7.0.0",
       "workspaces": [
         "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:swagger-ui-express@^4.6.3",
-      "name": "swagger-ui-express",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^4.6.3",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
-        "package.json"
-      ],
-      "id": "npm:swagger-ui-express@^5.0.1",
-      "name": "swagger-ui-express",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^5.0.1",
-      "workspaces": [
-        "nestjs-remix-monorepo"
       ]
     },
     {
@@ -3527,14 +3379,14 @@
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:tailwindcss@^3.4.15",
+      "id": "npm:tailwindcss@^4.3.1",
       "name": "tailwindcss",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^3.4.15",
+      "version": "^4.3.1",
       "workspaces": [
         "@fafa/frontend",
         "nestjs-remix-monorepo"
@@ -3823,14 +3675,14 @@
         "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:vite@7.3.5",
+      "id": "npm:vite@8.1.0",
       "name": "vite",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "7.3.5",
+      "version": "8.1.0",
       "workspaces": [
         "@fafa/frontend",
         "nestjs-remix-monorepo"
@@ -3886,58 +3738,28 @@
     },
     {
       "declaredIn": [
-        "packages/registry/package.json"
-      ],
-      "id": "npm:zod-to-json-schema@3.23.0",
-      "name": "zod-to-json-schema",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "3.23.0",
-      "workspaces": [
-        "@repo/registry"
-      ]
-    },
-    {
-      "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:zod-to-json-schema@^3.25.2",
-      "name": "zod-to-json-schema",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^3.25.2",
-      "workspaces": [
-        "@fafa/backend"
-      ]
-    },
-    {
-      "declaredIn": [
         "backend/package.json",
         "frontend/package.json",
         "package.json",
         "packages/cwv-taxonomy/package.json",
         "packages/database-types/package.json",
+        "packages/design-tokens/package.json",
         "packages/registry/package.json",
         "packages/seo-role-contracts/package.json",
         "packages/seo-roles/package.json",
         "packages/seo-types/package.json"
       ],
-      "id": "npm:zod@^3.25.76",
+      "id": "npm:zod@^4.4.3",
       "name": "zod",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^3.25.76",
+      "version": "^4.4.3",
       "workspaces": [
         "@fafa/backend",
+        "@fafa/design-tokens",
         "@fafa/frontend",
         "@repo/cwv-taxonomy",
         "@repo/database-types",


### PR DESCRIPTION
## PR-B — Dependency-truth freshness (deps L1 rebuild + 3 owner-approved L2 ids)

Part of the runtime-truth P0 (green-but-wrong control plane). This is the **dependency-truth** slice only. Sibling PRs: #1218 (PR-A, deps freshness CI gate), #1221 (PR-C, agent/context stack facts).

### What this PR repairs

Closes exactly this chain — nothing wider:

```
real package.json manifests
      ↓  (L1 rebuilt from the 15 workspace manifests)
audit/registry/deps.json                 237 entries
      ↓  (L2 resynced to match L1)
.spec/00-canon/repository-registry/dep-governance.yaml   3 version-ids
      ↓  (projection regenerated)
audit/dependencies/dependency-modernization-inventory.json
```

**Root cause:** L1 `deps.json` was not regenerated from the workspace manifests, so the L2↔L1 §4.2 cross-contract test was **green-but-wrong** — both layers had drifted together and the subset check passed while both were stale. `deps.json` is now rebuilt from manifests.

**3 owner-approved L2 corrections** in `dep-governance.yaml` (versions only; `name`/`family`/`domain`/`owner` untouched):

| dep | before | after |
|-----|--------|-------|
| `@nestjs/bull` | `^10.2.3` | `^11.0.4` |
| `@nestjs/cache-manager` | `^2.3.0` | `^3.1.3` |
| `zod` | `^3.25.76` | `^4.4.3` |

### Files (exactly 3)

- `.spec/00-canon/repository-registry/dep-governance.yaml` — Bucket 2, owner-gated L2 patch (3 ids)
- `audit/registry/deps.json` — Bucket 1, L1 rebuilt from manifests (generated)
- `audit/dependencies/dependency-modernization-inventory.json` — Bucket 1, projection regenerated with its official producer (`audit:pr-9-modernization-inventory`)

### canonical.json is intentionally NOT regenerated in this PR

> canonical.json is intentionally not regenerated in this PR. Its official rebuild is a unified projection and exposes pre-existing drift in other L1 registries (files, runtime, rpc). Folding that independent catch-up into the dependency-truth PR would destroy scope isolation. A dedicated follow-up will rebuild the complete registry chain and canonical projection.

Concretely, a faithful `canonical.json` rebuild here would drag in **pre-existing, deps-unrelated drift**: the committed `files.json` is stale by **~70 real recent source files** (synthetic-probe-credential, seo-field-gate, seo-balise-collision-gate, seo-projection-feeder, splat-path…), **+6 RPC**, **+4 runtime entrypoints** — **zero node_modules pollution**. Hand-editing a generated artifact to be deps-only is forbidden (ADR-058), so the only faithful options are "balloon PR-B by ~70 files" or "defer". We defer.

That catch-up is tracked separately as **PR-E — full L1 registry catch-up → canonical closure** (census-classified KEEP / REMOVE / REVIEW). It is a *different* freshness defect with a *different* blast radius; merging the two would produce an unreviewable diff.

### Scope of the freshness claim (no overclaim)

- ✅ manifests → `deps.json` — fresh
- ✅ `deps.json` ↔ `dep-governance.yaml` — in sync (§4.2 green-and-right)
- ✅ deps + overlay + lockfile → modernization inventory — fresh
- ⚠️ `canonical.json` remains a unified projection that is historically stale — **out of scope here**, tracked in PR-E

**The dependency-specific truth chain is fresh; unified canonical registry freshness is tracked separately.** This PR does **not** claim "all downstream projections are fresh," and does **not** declare the P0 resolved.

The regenerated `dependency-modernization-inventory.json` is fresh **w.r.t. its inputs** — it is **not** a claim that `family-overlay.yaml` is semantically modernized. Bucket 3 (family-overlay.yaml / phase-progression-rules.md / `Node20Required`) remains a separate, untouched concern.

### Gates

- **§4.2 cross-contract** (`@repo/registry`): 216/216 pass — `every contract dependency.id appears in L1 deps.json (subset)` is now green-**and-right**.
- **deps.json reproducibility** (PR-A #1218 gate logic): `deps.json` rebuilds byte-identical from manifests.
- **inventory:check** determinism: regenerated by its official producer, no hand edits.
- Pre-commit ADR-058 no-manual-edit guard: passed (env-marker + hash-reproducibility, sanctioned path).

Built on `origin/main@849f6d04d` (rebased after main advanced mid-work; all proofs replayed on the new base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
