### PR TITLE
fix(observatory): canonical "fingerprint fresh" → liveness (PR-E0, honesty relabel)

### DIFF
--- a/.github/workflows/contract-drift-observatory.yml
+++ b/.github/workflows/contract-drift-observatory.yml
@@ -145,7 +145,7 @@ jobs:
                 `**Recorded sotFingerprint:** \`${sotFp}\` — provenance only; not verified here`,
                 `**Ownership gaps:** ${gaps}`,
                 '',
-                '> This Observatory does not prove source→L1→L3 freshness. Canonical input-hash freshness is enforced by registry invariant **I6** (`npm run registry:validate-invariants`).',
+                '> This Observatory does not prove source→L1→L3 freshness. Canonical input-hash consistency is checked separately by registry invariant **I6** — this Observatory does not perform that check.',
                 '> This check never blocks. Reproduce locally with `npm run audit:drift-dashboard`.',
               ].join('\n');
 

--- a/.github/workflows/contract-drift-observatory.yml
+++ b/.github/workflows/contract-drift-observatory.yml
@@ -122,9 +122,13 @@ jobs:
               const rows   = health.contracts
                 .map(c => `| \`${c.name}\` | \`${c.file}\` | ${glyph(c.status)} ${c.status} | ${c.entries} |`)
                 .join('\n');
-              const stale  = health.fingerprint?.canonical?.stale
-                ? `⚠️ stale (${health.fingerprint.canonical.staleReason})`
-                : '✅ fresh';
+              // Signal 2 is a LIVENESS check (canonical present + required
+              // sections non-empty), NOT a source→L1→L3 freshness proof. We read
+              // the same `.canonical.stale` field but label it honestly; real
+              // canonical input-hash freshness is enforced by invariant I6.
+              const liveness = health.fingerprint?.canonical?.stale
+                ? `⚠️ incomplete (${health.fingerprint.canonical.staleReason})`
+                : '✅ present + required sections non-empty';
               const sotFp  = health.fingerprint?.canonical?.sotFingerprint ?? '?';
               const gaps   = health.ownership?.gapCount ?? '?';
               const body = [
@@ -137,9 +141,11 @@ jobs:
                 '|---|---|---|---:|',
                 rows,
                 '',
-                `**Canonical fingerprint:** ${stale} · sotFingerprint \`${sotFp}\``,
+                `**Canonical liveness:** ${liveness}`,
+                `**Recorded sotFingerprint:** \`${sotFp}\` — provenance only; not verified here`,
                 `**Ownership gaps:** ${gaps}`,
                 '',
+                '> This Observatory does not prove source→L1→L3 freshness. Canonical input-hash freshness is enforced by registry invariant **I6** (`npm run registry:validate-invariants`).',
                 '> This check never blocks. Reproduce locally with `npm run audit:drift-dashboard`.',
               ].join('\n');
 

--- a/.github/workflows/contract-drift-observatory.yml
+++ b/.github/workflows/contract-drift-observatory.yml
@@ -124,8 +124,8 @@ jobs:
                 .join('\n');
               // Signal 2 is a LIVENESS check (canonical present + required
               // sections non-empty), NOT a source→L1→L3 freshness proof. We read
-              // the same `.canonical.stale` field but label it honestly; real
-              // canonical input-hash freshness is enforced by invariant I6.
+              // the same `.canonical.stale` field but label it honestly;
+              // canonical input-hash consistency is checked separately by invariant I6.
               const liveness = health.fingerprint?.canonical?.stale
                 ? `⚠️ incomplete (${health.fingerprint.canonical.staleReason})`
                 : '✅ present + required sections non-empty';

--- a/scripts/audit/build-drift-dashboard.test.ts
+++ b/scripts/audit/build-drift-dashboard.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -154,14 +155,28 @@ test("canonical liveness passes when canonical is parseable and required section
 });
 
 test("canonical liveness ignores recorded inputHashes — the dashboard is NOT the freshness engine (I6 is)", async () => {
-  // Anti-overclaim guardrail. The repo-ok fixture's canonical.meta.inputHashes
-  // are placeholder strings ("fixture-hash-files", …) that are NOT the real
-  // sha256 of any input file — i.e. by any true freshness measure the fixture
-  // canonical is "stale". Yet liveness still passes, precisely because Signal 2
-  // never recomputes or compares inputHashes. That comparison is I6's job
-  // (scripts/registry/validate-invariants.ts). If a future change makes this
-  // signal go ⚠️ on hash mismatch, it has silently re-become a freshness gate
-  // and duplicated I6 — this test must then fail on purpose.
+  // Anti-overclaim guardrail. This test must PROVE its own precondition, not
+  // assume it: first establish that the fixture is genuinely hash-stale (its
+  // recorded inputHashes ≠ the real sha256 of the input), THEN prove liveness
+  // still passes. Signal 2 never recomputes or compares inputHashes — that is
+  // I6's contract (scripts/registry/validate-invariants.ts). If someone ever
+  // refreshes the fixture with real hashes, the notEqual below fails loudly, so
+  // this test can never silently stop proving independence from freshness; and
+  // if Signal 2 ever goes ⚠️ on hash mismatch it has re-become a freshness gate
+  // duplicating I6, which the stale=false assertion then catches.
+  const canonical = JSON.parse(
+    readFileSync(join(FIXTURE_OK, "audit/registry/canonical.json"), "utf8"),
+  );
+  const declared = canonical.meta.inputHashes["audit/registry/files.json"];
+  const actual = createHash("sha256")
+    .update(readFileSync(join(FIXTURE_OK, "audit/registry/files.json")))
+    .digest("hex");
+  assert.notEqual(
+    declared,
+    actual,
+    "fixture must remain intentionally hash-stale for this anti-overclaim test",
+  );
+
   const r = await buildDashboard({ repoRoot: FIXTURE_OK });
   assert.equal(
     r.json.fingerprint.canonical.stale,

--- a/scripts/audit/build-drift-dashboard.test.ts
+++ b/scripts/audit/build-drift-dashboard.test.ts
@@ -30,7 +30,7 @@ test("dashboard markdown contains the 6 fixed H2 sections", async () => {
   const r = await buildDashboard({ repoRoot: FIXTURE_OK });
   for (const heading of [
     "Contracts build status",
-    "Canonical fingerprint consistency",
+    "Canonical liveness / structural completeness",
     "Ownership gaps",
     "Runtime contract coverage",
     "Dep governance coverage",
@@ -126,12 +126,46 @@ test("ownership gap detection: full orphans list emitted, sorted, >10 entries", 
   );
 });
 
-test("canonical fingerprint: sotFingerprint surfaced, stale=false when sections non-empty", async () => {
+test("canonical liveness passes when canonical is parseable and required sections are non-empty", async () => {
   const r = await buildDashboard({ repoRoot: FIXTURE_OK });
+  // Signal 2 is a LIVENESS check: canonical present + all required sections
+  // non-empty. `stale=false` here means "alive & structurally complete", NOT
+  // "fresh vs sources". The rendered section title reflects that scope.
   assert.equal(r.json.fingerprint.canonical.stale, false);
-  assert.equal(r.json.fingerprint.canonical.sotFingerprint, "FIXTUREok0000");
-  // Section sizes reflect the fixture: 1 entry per Layer 1 array.
   assert.equal(r.json.fingerprint.canonical.sectionSizes.files, 1);
   assert.equal(r.json.fingerprint.canonical.sectionSizes["db.tables"], 1);
   assert.equal(r.json.fingerprint.canonical.sectionSizes["db.rpc"], 1);
+  // The markdown must NOT claim freshness, and MUST redirect freshness to I6.
+  assert.ok(
+    r.markdown.includes("## Canonical liveness / structural completeness"),
+    "liveness section title must not use the word 'fresh'/'fingerprint consistency'",
+  );
+  assert.ok(
+    r.markdown.includes("does not verify source→L1→L3 freshness") &&
+      r.markdown.includes("I6"),
+    "markdown must disclaim freshness and point to invariant I6",
+  );
+  // sotFingerprint is surfaced for provenance only, labelled as recorded.
+  assert.equal(r.json.fingerprint.canonical.sotFingerprint, "FIXTUREok0000");
+  assert.ok(
+    r.markdown.includes("recorded sotFingerprint"),
+    "sotFingerprint must be presented as recorded/provenance, not proof",
+  );
+});
+
+test("canonical liveness ignores recorded inputHashes — the dashboard is NOT the freshness engine (I6 is)", async () => {
+  // Anti-overclaim guardrail. The repo-ok fixture's canonical.meta.inputHashes
+  // are placeholder strings ("fixture-hash-files", …) that are NOT the real
+  // sha256 of any input file — i.e. by any true freshness measure the fixture
+  // canonical is "stale". Yet liveness still passes, precisely because Signal 2
+  // never recomputes or compares inputHashes. That comparison is I6's job
+  // (scripts/registry/validate-invariants.ts). If a future change makes this
+  // signal go ⚠️ on hash mismatch, it has silently re-become a freshness gate
+  // and duplicated I6 — this test must then fail on purpose.
+  const r = await buildDashboard({ repoRoot: FIXTURE_OK });
+  assert.equal(
+    r.json.fingerprint.canonical.stale,
+    false,
+    "liveness must not depend on inputHashes matching real inputs — that is I6's contract",
+  );
 });

--- a/scripts/audit/build-drift-dashboard.ts
+++ b/scripts/audit/build-drift-dashboard.ts
@@ -410,7 +410,7 @@ function renderMarkdown(json: DashboardJson): string {
   lines.push(`## Canonical liveness / structural completeness`);
   lines.push("");
   lines.push(
-    `> This signal does not verify source→L1→L3 freshness and does not recompute or validate \`sotFingerprint\`. Canonical input-hash freshness (canonical vs its 10 declared L1 registries + L2 overlays) is enforced by registry invariant **I6** (\`npm run registry:validate-invariants\`).`,
+    `> This signal does not verify source→L1→L3 freshness and does not recompute or validate \`sotFingerprint\`. Canonical input-hash consistency against its 10 declared inputs (5 L1 registries + 5 L2 overlays) is **checked** by registry invariant **I6** (\`npm run registry:validate-invariants\`); this Observatory does not perform that check, and the current \`registry-fresh\` CI rollout is warn-only.`,
   );
   lines.push("");
   const f = json.fingerprint.canonical;

--- a/scripts/audit/build-drift-dashboard.ts
+++ b/scripts/audit/build-drift-dashboard.ts
@@ -406,12 +406,20 @@ function renderMarkdown(json: DashboardJson): string {
   }
   lines.push("");
 
-  // Signal 2
-  lines.push(`## Canonical fingerprint consistency`);
+  // Signal 2 — LIVENESS ONLY (not a freshness proof; see note below).
+  lines.push(`## Canonical liveness / structural completeness`);
+  lines.push("");
+  lines.push(
+    `> This signal does not verify source→L1→L3 freshness and does not recompute or validate \`sotFingerprint\`. Canonical input-hash freshness (canonical vs its 10 declared L1 registries + L2 overlays) is enforced by registry invariant **I6** (\`npm run registry:validate-invariants\`).`,
+  );
   lines.push("");
   const f = json.fingerprint.canonical;
   lines.push(
-    `- **sotFingerprint**: \`${f.sotFingerprint ?? "(none)"}\` (computed by \`scripts/registry/build-canonical-registry.js\` from input hashes)`,
+    `- **canonical present + required sections non-empty**: ${f.stale ? "⚠️ no" : "✅ yes"}`,
+  );
+  if (f.staleReason) lines.push(`- **reason**: ${f.staleReason}`);
+  lines.push(
+    `- **recorded sotFingerprint**: \`${f.sotFingerprint ?? "(none)"}\` (provenance only — written by \`scripts/registry/build-canonical-registry.js\`; **not** verified here, see I6)`,
   );
   lines.push(
     `- **canonical.meta.generatedAt**: \`${f.generatedAt ?? "(none)"}\` (V1-2 epoch-zero placeholder — informational only)`,
@@ -419,8 +427,6 @@ function renderMarkdown(json: DashboardJson): string {
   lines.push(
     `- **file mtime age**: ${f.mtimeAgeHours === null ? "n/a" : `${f.mtimeAgeHours}h`}`,
   );
-  lines.push(`- **stale**: ${f.stale ? "⚠️ yes" : "✅ no"}`);
-  if (f.staleReason) lines.push(`- **staleReason**: ${f.staleReason}`);
   lines.push("");
   lines.push("| Section | Entries |");
   lines.push("|---|---:|");


### PR DESCRIPTION
## PR-E0 — Observatory honesty fix (canonical "fresh" → liveness)

Standalone interface-honesty fix. Reviewable and mergeable **without** the ~70-file registry census — it does not depend on PR-E.

### The lie it removes
The Contract Drift Observatory's Signal 2 computes only **liveness**:
```ts
stale = !canonical || emptySection   // canonical present + all 5 sections non-empty
```
…yet rendered it as **"Canonical fingerprint consistency … ✅ fresh"** (dashboard) and **"Canonical fingerprint: ✅ fresh"** (PR comment). It never recomputes or compares `inputHashes`, so real L1 source-staleness (~70 files, +6 RPC, +4 runtime) passes straight through while the Observatory reports "fresh" — false comfort.

### The freshness engine already exists — I6 (do not duplicate)
`scripts/registry/validate-invariants.ts` invariant **I6** reads `canonical.meta.inputHashes`, recomputes the real sha256 of each of the **10 declared inputs (5 L1 registries + 5 L2 overlays)**, and errors on mismatch. This PR adds **no** second fingerprint engine — it relabels the Observatory to its true (liveness) scope and points freshness to I6.

### Changes — 3 files, UI/semantics only, JSON contract unchanged
- **`scripts/audit/build-drift-dashboard.ts`** — section title → *"Canonical liveness / structural completeness"*; verdict → *"present + required sections non-empty"*; `sotFingerprint` demoted to *"recorded … provenance only, not verified here"*; explicit I6 disclaimer.
- **`scripts/audit/build-drift-dashboard.test.ts`** — replaces the test that codified the wrong semantics with a scope-honest one, **plus an anti-overclaim guardrail test**: it proves liveness is indifferent to whether `inputHashes` match real inputs (that comparison is I6's contract). If a future change makes this signal go ⚠️ on hash mismatch, it has silently re-become a freshness gate and duplicated I6 — the test then fails on purpose.
- **`.github/workflows/contract-drift-observatory.yml`** — PR comment relabelled + I6 disclaimer.

### Deliberately NOT done (kept out of scope)
- **JSON field `fingerprint.canonical.stale` NOT renamed.** It is consumed by the contract-drift ratchet (`check-contract-drift-ratchet.ts` → `canonical_stale`). Renaming = a contract migration with baseline + consumer changes → deferred to a future schema V2. This PR is **UI/semantics only**: JSON schema unchanged, baseline unchanged, ratchet unchanged.
- No new fingerprint check, no L1 catch-up, no canonical rebuild (that is **PR-E**).

### Proof
- `.ts` diff is confined to `renderMarkdown` (hunks at L409–430); `signal2_fingerprint` (the JSON builder, L231–277) is untouched → JSON byte-identical.
- Dashboard tests **8/8** green (incl. 2 new); ratchet test **14/14** green.
- Real-repo render verified: title no longer says "fresh"; recorded sotFingerprint shown as provenance-only.

Ref: `audit/p0-rag-runtime-and-version-truth-2026-07-04.md` (Observatory honesty, PR-E0)

---

## Definition of Done — auto-évaluation

_Per vault `rules-engineering-definition-of-done.md` (nine invariants, checklist below). Work type: `governance` / `observability` (interface-honesty relabel). Scope: 3 files, UI/semantics only — no JSON contract, DB, runtime, or generated-artifact change._

- [x] **DoD1 — Tests verts**: dashboard suite **8/8** (2 new incl. anti-overclaim guardrail), ratchet suite **14/14**, pre-commit green. No `.only/.skip/@ts-ignore/eslint-disable` added.
- [x] **DoD2 — Ownership**: domain = repo control-plane / observability CI (owner @ak125). No self-merge. **Assignee to be set + human approval pending at review** (draft; enforced by branch protection).
- [x] **DoD3 — Rollback**: revert this PR. Reversibility = **instant** — text/semantics only, no runtime impact.
- [x] **DoD4 — Observabilité**: this *is* an observability surface; the change makes it more honest (removes a false "fresh"). No application runtime code changed.
- [x] **DoD5 — Drift zéro**: **N/A** — no DB schema, migration, or types change; JSON contract (`fingerprint.canonical.stale`) intentionally unchanged.
- [x] **DoD6 — Docs**: self-documenting — new disclaimer text + code comments + this PR body explain the why and point to I6.
- [x] **DoD7 — Monitoring**: post-merge, the Observatory's comment on the next PR will show the new wording; watcher = owner; abort = revert if the relabel misreads.
- [x] **DoD8 — No TODO unresolved**: no `TODO / FIXME / HACK / XXX` added.
- [x] **DoD9 — No silent skip**: this change *removes* a misleading signal and *adds* a guardrail test against its silent return; no silent skip, catch-swallow, or hidden toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
