### PR TITLE
fix(registry): comment/string-aware SQL lexer in rpc registry parser

### DIFF
--- a/scripts/registry/build-rpc-registry.js
+++ b/scripts/registry/build-rpc-registry.js
@@ -241,12 +241,76 @@ function entryId(schemaName, funcName, args, overloadIndex) {
   return `${schemaName}.${funcName}`;
 }
 
+// Scan `sql` for top-level `CREATE [OR REPLACE] FUNCTION` keywords, returning their
+// byte offsets — but only those occurring in *code*, not inside comments or strings.
+//
+// A plain regex over raw SQL yields phantom functions from prose like the
+// `-- … CREATE FUNCTION grant EXECUTE …` comment in migration 20260619…:77
+// (→ `public.grant`). A naive "is there a `--`/`/*` before idx" test is worse: it
+// mis-flags real DDL because migration bodies contain unmatched `/*` and `--`
+// sequences inside `$$ … $$` bodies and single-quoted strings.
+//
+// The only robust approach is a single forward pass that tracks lexer state and
+// skips over: line comments (`-- … \n`), *closed* block comments (`/* … */`),
+// single-quoted strings (`'…''…'`), and dollar-quoted bodies (`$$ … $$`,
+// `$tag$ … $tag$`). CREATE FUNCTION keywords inside any of those are ignored.
 function findFunctionBlocks(sql) {
   const blocks = [];
-  const createRe = /\bCREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\b/gi;
-  let m;
-  while ((m = createRe.exec(sql)) !== null) {
-    blocks.push(m.index);
+  const n = sql.length;
+  const createRe = /^CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\b/i;
+  const dollarRe = /^\$[A-Za-z0-9_]*\$/;
+  let i = 0;
+  let dollarTag = null; // open dollar-quote tag, e.g. "$$" or "$body$"
+  while (i < n) {
+    if (dollarTag) {
+      // inside a dollar-quoted body — only its matching tag closes it
+      if (sql.startsWith(dollarTag, i)) {
+        i += dollarTag.length;
+        dollarTag = null;
+      } else i++;
+      continue;
+    }
+    const two = sql.slice(i, i + 2);
+    if (two === "--") {
+      const nl = sql.indexOf("\n", i);
+      i = nl === -1 ? n : nl + 1;
+      continue;
+    }
+    if (two === "/*") {
+      const end = sql.indexOf("*/", i + 2);
+      i = end === -1 ? n : end + 2;
+      continue;
+    }
+    const ch = sql[i];
+    if (ch === "'") {
+      i++;
+      while (i < n) {
+        if (sql[i] === "'") {
+          if (sql[i + 1] === "'") { i += 2; continue; } // escaped ''
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (ch === "$") {
+      const dm = dollarRe.exec(sql.slice(i, i + 64));
+      if (dm) {
+        dollarTag = dm[0];
+        i += dm[0].length;
+        continue;
+      }
+    }
+    if (ch === "C" || ch === "c") {
+      const cm = createRe.exec(sql.slice(i, i + 40));
+      if (cm) {
+        blocks.push(i);
+        i += cm[0].length;
+        continue;
+      }
+    }
+    i++;
   }
   return blocks;
 }

--- a/tests/registry/fixtures/rpc-edge-cases.sql
+++ b/tests/registry/fixtures/rpc-edge-cases.sql
@@ -59,16 +59,37 @@ BEGIN
 END;
 $$;
 
--- Case 7 : Partially parseable — missing LANGUAGE (intentional, will be partially_parsed)
+-- Case 8 : CREATE FUNCTION mentions inside comments / strings / bodies must NOT
+-- be extracted. findFunctionBlocks is now comment-aware (single-pass lexer that
+-- skips line comments, closed block comments, single-quoted strings, and
+-- dollar-quoted bodies). Historical false-positives this guards against:
+-- `public.grant` and `public.unknown` (from `-- … CREATE FUNCTION grant …`),
+-- and comment-block copies of real functions (e.g. pricing_commit_chunk).
+
+-- 8a : line comment. CREATE FUNCTION fixture_line_commented(a int) — ignore me.
+-- EXECUTE : verrouiller. CREATE FUNCTION grant EXECUTE à PUBLIC (prose, not DDL).
+
+/* 8b : block comment.
+   CREATE OR REPLACE FUNCTION fixture_block_commented(p uuid)
+     RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;
+*/
+
+-- 8c : CREATE FUNCTION text living inside a real function's dollar-quoted body
+-- (dynamic SQL) must not be double-counted as its own function.
+CREATE FUNCTION fixture_dynamic_ddl_emitter()
+  RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  EXECUTE 'CREATE FUNCTION fixture_inside_body(x int) RETURNS int LANGUAGE sql AS ''SELECT x''';
+END;
+$$;
+
+-- Case 7 : Partially parseable — missing LANGUAGE (intentional, will be
+-- partially_parsed). MUST stay last : its classification depends on the 1KB
+-- lookahead finding no LANGUAGE keyword after it.
 CREATE FUNCTION fixture_no_language(x integer)
   RETURNS integer
 AS $$
   SELECT x
 $$;
-
--- Case bonus : a comment with 'CREATE FUNCTION' inside that should NOT match
--- because we look at top-level CREATE keyword, not inside a comment block.
--- The current parser doesn't strip SQL comments, so this is documented as a
--- known limitation : the regex matches the inline mention. V1.5+ : strip
--- comments before parsing. For now, fixture explicitly avoids triggering false
--- positives by not having CREATE inside comments here.

--- a/tests/registry/rpc-parser.test.ts
+++ b/tests/registry/rpc-parser.test.ts
@@ -168,6 +168,51 @@ describe("parseFunctionBlock — edge cases (V1-3 : 3 parse modes, never throw)"
   });
 });
 
+describe("Case 8 : comment / string / body awareness (no phantom functions)", () => {
+  const names = () =>
+    findFunctionBlocks(FIXTURE_SQL)
+      .map((p) => parseFunctionBlock(FIXTURE_SQL, p))
+      .filter(Boolean)
+      .map((r: any) => r.funcName);
+
+  test("skips CREATE FUNCTION inside a line comment", () => {
+    const found = names();
+    assert.ok(!found.includes("fixture_line_commented"), "line-commented fn leaked");
+    // the real-world `public.grant` phantom came from `… CREATE FUNCTION grant …`
+    assert.ok(!found.includes("grant"), "`grant` phantom leaked from prose comment");
+  });
+
+  test("skips CREATE FUNCTION inside a block comment", () => {
+    assert.ok(
+      !names().includes("fixture_block_commented"),
+      "block-commented fn leaked"
+    );
+  });
+
+  test("skips CREATE FUNCTION text inside a dollar-quoted body (dynamic SQL)", () => {
+    assert.ok(!names().includes("fixture_inside_body"), "body-embedded fn leaked");
+  });
+
+  test("still extracts the real function that emits dynamic DDL", () => {
+    const f = findFunctionBlocks(FIXTURE_SQL)
+      .map((p) => parseFunctionBlock(FIXTURE_SQL, p))
+      .find((r: any) => r?.funcName === "fixture_dynamic_ddl_emitter");
+    assert.ok(f, "real emitter function not found");
+    assert.equal((f as any).parseMode, "parsed");
+  });
+
+  test("no parse yields the unknown_signature fallback on this fixture", () => {
+    const modes = findFunctionBlocks(FIXTURE_SQL)
+      .map((p) => parseFunctionBlock(FIXTURE_SQL, p))
+      .filter(Boolean)
+      .map((r: any) => r.parseMode);
+    assert.ok(
+      !modes.includes("unknown_signature"),
+      "fixture should no longer yield unknown_signature phantoms"
+    );
+  });
+});
+
 describe("sigHash determinism", () => {
   test("same args → same hash", () => {
     const args = [


### PR DESCRIPTION
## rpc registry parser — comment/string-aware SQL lexer (producer fix)

**Split out of #1226** (the PR-E census) as the standalone **producer fix**, per the rule *"a builder-defect fix lands separately from the census replay."* This PR is **code + tests only** — no generated artifact.

### Root cause
`findFunctionBlocks()` scanned raw SQL with a naive regex:
```js
/\bCREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\b/gi
```
So a `CREATE FUNCTION` inside a `--` comment, a `/* */` block, a single-quoted string, or a `$$ … $$` body was counted as a real RPC — e.g. `public.unknown` from prose in a migration comment. A naive "is there a `--`/`/*` before this index" guard is *worse*: migration `$$` bodies contain unmatched `--`/`/*` and would mis-flag real DDL.

### Fix
A single forward-pass lexer that tracks state and skips line comments, closed block comments, single-quoted strings (`''` escape), and dollar-quoted bodies (`$$` / `$tag$`) — counting `CREATE [OR REPLACE] FUNCTION` **only in code**.

### Scope (deliberately code-only)
- ✅ `scripts/registry/build-rpc-registry.js` — the lexer
- ✅ `tests/registry/rpc-parser.test.ts` (+5 tests) · `tests/registry/fixtures/rpc-edge-cases.sql`
- ❌ **`rpc.json` NOT regenerated here.** The fixed parser changes the rpc entry **set** (net +2 vs committed; `public.unknown` phantom dropped, other shifts). Every delta must be **KEEP/REMOVE/REVIEW-classified** in the **PR-E census replay** (post-#1225), where the full L1 + `canonical` rebuild lands coherently. Committing an unclassified `rpc.json` here would smuggle a census change.

### Sequencing (why the data is deferred)
Until the PR-E replay, committed `rpc.json` stays behind the fixed producer — surfaced as a **warn-only** `registry-fresh` drift (non-blocking, ADR-062). Independent of #1225 (touches no `deps.json`/`canonical`).

### Proof
- rpc-parser fixture tests **23/23** (incl. comment / string / dollar-quote edge cases).
- Verified effect (evidence only, not committed): rebuilding `rpc.json` with the fix removes the `public.unknown` phantom (1→0); full delta classified in PR-E.

Ref: `audit/p0-rag-runtime-and-version-truth-2026-07-04.md` (PR-E producer fix, split from #1226)

---

## Definition of Done — auto-évaluation

_Per vault `rules-engineering-definition-of-done.md` (nine invariants, checklist below). Work type: `governance` / tooling (registry producer fix). Scope: 3 code/test files, no generated artifact, no DB/runtime change._

- [x] **DoD1 — Tests verts**: rpc-parser fixture tests **23/23** (5 new). No `.only/.skip/@ts-ignore/eslint-disable` added.
- [x] **DoD2 — Ownership**: domain = repo control-plane / registry tooling (owner @ak125). No self-merge. **Assignee to set + human approval pending at review** (draft; enforced by branch protection).
- [x] **DoD3 — Rollback**: revert this PR. Reversibility = **instant** — code-only, no data/runtime/schema change.
- [x] **DoD4 — Observabilité**: build-time script (not app runtime); the parser's classification path is unchanged except comment/string skipping. No `console.log` left, no silent catch.
- [x] **DoD5 — Drift zéro**: no DB schema / migration / types change. **NOTE (intentional + documented):** committed `rpc.json` is left behind the fixed producer → warn-only `registry-fresh` drift, non-blocking; resolved by the PR-E census replay. No hand-edited artifact.
- [x] **DoD6 — Docs**: self-documented — extensive lexer comments (why the naive guards fail) + this PR body.
- [x] **DoD7 — Monitoring**: post-merge, the PR-E census replay regenerates + classifies `rpc.json`; watcher = owner; abort = revert if a real function is dropped by the lexer.
- [x] **DoD8 — No TODO unresolved**: no `TODO / FIXME / HACK / XXX` added.
- [x] **DoD9 — No silent skip**: the `rpc.json` deferral is **explicit and documented** (this body + commit), surfaced by warn-only `registry-fresh` — not a silent skip. No catch-swallow, no hidden toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
