### PR TITLE
ci(registry): warn-only canonical committed-freshness gate (PR-F)

### DIFF
--- a/.github/workflows/registry-fresh.yml
+++ b/.github/workflows/registry-fresh.yml
@@ -112,3 +112,91 @@ jobs:
               echo "- ❌ canonical.json missing";
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # PR-F — Canonical committed-freshness gate (structural, warn-only first)
+  # ---------------------------------------------------------------------------
+  # WHY THIS JOB EXISTS (distinct from `registry-fresh` above)
+  #   The `registry-fresh` job runs `npm run registry` (a full rebuild) BEFORE it
+  #   runs `registry:validate-invariants`, so its I6 freshness check always
+  #   validates a freshly rebuilt — trivially fresh — canonical. It therefore
+  #   CANNOT catch a *stale committed* canonical.json: the "green but wrong" drift
+  #   where a Layer 1/2 source moved but audit/registry/canonical.json was not
+  #   regenerated (e.g. a deps.json reshape landing without a canonical rebuild).
+  #
+  #   This job runs invariant I6 (`checkCanonicalFresh`) on the COMMITTED tree
+  #   with NO rebuild first: it compares canonical.meta.inputHashes against the
+  #   actual sha256 of the committed Layer 1 ({files,rpc,runtime,db,deps}.json)
+  #   and Layer 2 (.spec/00-canon/repository-registry/*.yaml) sources. If they
+  #   diverge, the committed canonical is stale and the job flags it. This makes
+  #   the merge order between L1/L2-changing PRs irrelevant: whichever source
+  #   moves last, canonical must be regenerated before merge. It REUSES the
+  #   existing, unit-tested invariant (scripts/registry/validate-invariants.ts) —
+  #   no new engine, no parallel fingerprint.
+  #   Ref: audit/p0-rag-runtime-and-version-truth-2026-07-04.md §0 (freshness closure).
+  #
+  # ROLLOUT — WARN-ONLY FIRST (ADR-062 ratchet), same discipline as
+  # dependency-registry-freshness.yml. `continue-on-error: true` at the JOB level:
+  # the check still `exit 1`s on drift (red step + ::error annotation + a
+  # $GITHUB_STEP_SUMMARY explanation), but a failing job does NOT block the PR. On
+  # a drifted `main` this job is RED BY DESIGN until the canonical catch-up
+  # (PR-E) lands — landing it blocking now would wedge every unrelated PR.
+  #
+  # PROMOTION TO BLOCKING — remove `continue-on-error` AND add this as a REQUIRED
+  # status check in branch protection — only after ALL of:
+  #   1. the canonical catch-up (PR-E) has landed so `main` is I6-green;
+  #   2. this job has been observed GREEN on `main` for the ADR-062 ratchet
+  #      window (>= 10 consecutive green builds / ~7-14 days), no false positive.
+  # Flipping earlier requires a vault derogation ADR.
+  canonical-committed-fresh:
+    name: canonical.json == fresh(committed L1+L2) — I6 structural
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    # ADR-062 ratchet — WARN-ONLY FIRST. The step below still exits 1 on drift
+    # (detection intact), but this job-level flag prevents that failure from
+    # blocking the PR. Remove this line to promote to blocking (see ROLLOUT).
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci
+
+      - name: Assert committed canonical.json is fresh vs committed L1+L2 (invariant I6, NO rebuild first)
+        run: |
+          # CRITICAL: do NOT run `npm run registry` before this. We validate the
+          # COMMITTED canonical.meta.inputHashes against the COMMITTED L1/L2
+          # sources on disk. (The sibling `registry-fresh` job rebuilds first, so
+          # its I6 always sees a trivially-fresh canonical — this job is the one
+          # that catches a stale committed canonical.) Do NOT pipe / --silent:
+          # keep the real exit code so `exit 1` on I6 error is honoured.
+          if npm run registry:validate-invariants; then
+            echo "✓ committed canonical.json is fresh vs committed Layer 1 + Layer 2 (invariant I6)"
+          else
+            {
+              echo "## ❌ canonical.json is STALE vs committed Layer 1 + Layer 2 sources (invariant I6)"
+              echo ""
+              echo "A Layer 1 (\`audit/registry/{files,rpc,runtime,db,deps}.json\`) or Layer 2"
+              echo "(\`.spec/00-canon/repository-registry/*.yaml\`) source changed, but the committed"
+              echo "\`audit/registry/canonical.json\` was **not regenerated** — its \`meta.inputHashes\`"
+              echo "no longer match the committed sources."
+              echo ""
+              echo "**Fix:** run \`npm run registry\` then commit \`audit/registry/canonical.json\`"
+              echo "(and \`.claude/knowledge/REPO_MAP.md\`)."
+              echo ""
+              echo "> This gate makes the merge order between L1/L2-changing PRs irrelevant:"
+              echo "> whichever source moves last, canonical must be regenerated before merge."
+              echo ""
+              echo "Doctrine: the L3 projection must stay derived from the L1+L2 SoT couple."
+              echo "See audit/p0-rag-runtime-and-version-truth-2026-07-04.md §0."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error file=audit/registry/canonical.json::canonical.json is stale vs committed L1/L2 (invariant I6) — run 'npm run registry' and commit canonical.json."
+            exit 1
+          fi


### PR DESCRIPTION
## PR-F — structural canonical-freshness gate (makes merge order irrelevant)

Closes the merge-ordering hazard between #1227 (PR-E canonical catch-up) and #1225 (deps `occurrences[]` reshape) **structurally** — not by "remember to rebuild canonical after the 2nd merge" (that reliance-on-memory is the bricolage this replaces).

### The gap (green-but-wrong)

`canonical.json` (L3) embeds a projection of the L1 registries + L2 overlay, fingerprinted in `canonical.meta.inputHashes`. If a PR changes an L1/L2 source but doesn't regenerate `canonical.json`, the committed canonical goes stale — yet **nothing blocks it**:
- The existing `registry-fresh` job runs `npm run registry` (a full rebuild) **before** it validates invariants, so its I6 check always sees a *trivially-fresh* canonical.
- Its committed-vs-rebuilt freshness diff is **warn-only**.

**This is real, not theoretical:** on current `main`, `npm run registry:validate-invariants` exits **1** with 3 `I6-canonical-fresh` STALE errors — canonical drifted vs `automation-reality.yaml`, `ownership.yaml`, and `deps.json`. Main is green-but-wrong today.

### The fix — one new job, reusing the existing invariant

Add `canonical-committed-fresh` to `registry-fresh.yml`: run invariant **I6 (`checkCanonicalFresh`)** on the **committed tree, with no rebuild first**. It compares `canonical.meta.inputHashes` to the actual sha256 of the committed L1 (`{files,rpc,runtime,db,deps}.json`) + L2 (`repository-registry/*.yaml`) sources; divergence = stale = flagged.

- **Extend, don't reinvent:** reuses the unit-tested `scripts/registry/validate-invariants.ts` — no new engine, no parallel fingerprint.
- **No trigger-path change:** canonical's inputs (`audit/registry/**`, `.spec/00-canon/repository-registry/**`) are already this workflow's triggers.
- **Warn-only first** (ADR-062 ratchet), mirroring `dependency-registry-freshness.yml` (#1218): `continue-on-error: true`, detection intact (`exit 1` + `::error` + step summary), non-blocking.

### Why merge order no longer matters

Whichever of #1225 / #1227 lands **last**, its committed `canonical.meta.inputHashes` will not match the just-changed L1/L2 source → I6 fails → the author must `npm run registry` and commit the refreshed canonical before merge. Both orders converge to a fresh canonical — the manual "who rebuilds after the 2nd merge" question disappears.

### Self-test (verified locally)

| case | command | result |
|---|---|---|
| FAIL-on-stale | `registry:validate-invariants` on `main` | exit 1, 3 `I6-canonical-fresh` STALE errors ✅ |
| PASS-on-fresh | same command on the #1227 branch | exit 0, all 6 invariants pass ✅ |

This job is **RED BY DESIGN** on `main` until the canonical catch-up (#1227) lands — that red *is* the proof it catches the real drift.

### Promotion to blocking (documented in the workflow itself)

Remove `continue-on-error` + add as a required status check only after: (1) the canonical catch-up (#1227) has landed → `main` is I6-green; (2) ≥10 consecutive green builds on `main`, no false positive. Flipping earlier needs a vault derogation ADR.

### Follow-ups (deliberately NOT in this PR — minimal scope)

- Local pre-commit fast-fail (same I6 check) — added once `main` is I6-green, to avoid wedging commits while main is still drifted.
- Extend byte-exact diff coverage to un-fingerprinted L3 projections (`.claude/knowledge/REPO_MAP.md`, `audit/*` intermediates).

### Definition of Done

- [x] **DoD1 — Tests verts**: reuses existing `validate-invariants` (I6 unit tests already present in `validate-invariants.test.ts`); self-test FAIL/PASS verified above. Warn-only → cannot red-block CI.
- [x] **DoD2 — Ownership**: CI / registry tooling (D15 Security & Governance — `.github/workflows/**`, `scripts/registry/**`). No self-merge; **draft**, human approval pending.
- [x] **DoD3 — Rollback**: revert this PR — a single workflow file (+88 lines), zero runtime impact, instantly reversible.
- [x] **DoD4 — Observabilité**: N/A app runtime — this change *is* observability (a CI freshness signal). Fail-loud `::error` + `$GITHUB_STEP_SUMMARY`, no silent catch.
- [x] **DoD5 — Drift zéro**: this PR *closes* a drift class. No DB / schema / `deps.json` / migration change.
- [x] **DoD6 — Docs**: self-documented — inline WHY / ROLLOUT / PROMOTION comment block + this body. No README / `.env.example` change (no ENV var, no public surface).
- [x] **DoD7 — Monitoring**: the job itself is the monitor; post-merge signal = it flipping green once #1227 lands, then the ratchet window.
- [x] **DoD8 — No TODO unresolved**: none added.
- [x] **DoD9 — No silent skip**: the antithesis — it makes a silent staleness *loud*. No test skip, no catch-swallow; `continue-on-error` is the governed, documented ADR-062 ratchet (a visible non-blocking signal), not a silent fallback.

**Draft** — not for merge. Cleanest ordering: land #1227 first (main → I6-green), then this job observes green and the ratchet window starts — but warn-only means it is safe to land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
