### PR TITLE
feat(write-guard): fail-closed RAG-provenance refusal + R1 activation

### DIFF
--- a/backend/src/config/content-write-gate.service.test.ts
+++ b/backend/src/config/content-write-gate.service.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ContentWriteGateService — RAG-provenance refusal (fail-closed).
+ *
+ * Canon: ADR-031/046 — RAG = chatbot retrieval only; no RAG-sourced content may
+ * reach a served __seo_* table. This mirrors the already-shipped R4/R5 refusal
+ * shape (execution-router.service.ts:377-388/418-427: status:'failed', 0 rows,
+ * "pas de fallback d'insert générique — échec explicite, jamais silencieux").
+ *
+ * The refusal is the FIRST step of writeToTarget() and returns before any
+ * Supabase call, so these tests are hermetic (createClient is mocked; the
+ * mock client is never queried on the refusal path).
+ */
+import { ContentWriteGateService } from './content-write-gate.service';
+import { SOURCE_TIER } from './source-provenance.constants';
+import type { ConfigService } from '@nestjs/config';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({})),
+}));
+
+function makeGate(): ContentWriteGateService {
+  const config = {
+    get: () => 'https://example.supabase.co',
+  } as unknown as ConfigService;
+  // The 5 collaborators are never touched on the refusal path.
+  return new ContentWriteGateService(
+    config,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+}
+
+describe('ContentWriteGateService — RAG provenance refusal (fail-closed)', () => {
+  it('refuses a write whose provenance is legacy-RAG, writing zero fields', async () => {
+    const gate = makeGate();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await gate.writeToTarget({
+      roleId: 'R1_ROUTER',
+      target: 'seo_gamme_main',
+      pkValue: '123',
+      payload: { sg_content_draft: 'from RAG' },
+      correlationId: 'test-rag-refusal',
+      provenance: SOURCE_TIER.RAG_LEGACY,
+    } as any);
+
+    expect(result.written).toBe(false);
+    expect(result.reason).toBe('rag_provenance_refused');
+    expect(result.fieldsWritten).toEqual([]);
+  });
+
+  it('refuses the bare historical "rag" tier as well, BEFORE the unknown_target check (refusal is the first step)', async () => {
+    const gate = makeGate();
+
+    // Nonexistent target: without the refusal this returns 'unknown_target'.
+    // With the refusal it must return 'rag_provenance_refused' — proving order.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await gate.writeToTarget({
+      roleId: 'R1_ROUTER',
+      target: 'does_not_exist_group',
+      pkValue: '1',
+      payload: { anything: 1 },
+      correlationId: 'test-order',
+      provenance: 'rag',
+    } as any);
+
+    expect(result.reason).toBe('rag_provenance_refused');
+  });
+
+  it('does NOT refuse when provenance is absent — backward-compat, existing callers unaffected', async () => {
+    const gate = makeGate();
+
+    // No provenance + nonexistent target ⇒ proceeds past the rag step and
+    // returns unknown_target (hermetic: returns before any Supabase call).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await gate.writeToTarget({
+      roleId: 'R1_ROUTER',
+      target: 'does_not_exist_group',
+      pkValue: '1',
+      payload: { anything: 1 },
+      correlationId: 'test-compat',
+    } as any);
+
+    expect(result.reason).toBe('unknown_target');
+    expect(result.reason).not.toBe('rag_provenance_refused');
+  });
+});

--- a/backend/src/config/content-write-gate.service.ts
+++ b/backend/src/config/content-write-gate.service.ts
@@ -23,6 +23,8 @@ import {
   getOwnedFieldsForGroup,
   resolveWriteTarget,
 } from './field-catalog.constants';
+import { isLegacyRagTier } from './source-provenance.constants';
+import type { SourceTier } from './source-provenance.constants';
 import { ContentMergeEngine } from './content-merge-engine.service';
 import type { MergeFieldResult } from './content-merge-engine.service';
 import { ContentRegressionGuard } from './content-regression-guard.service';
@@ -48,6 +50,13 @@ export interface WriteTargetInput {
   payload: Record<string, unknown>;
   correlationId: string;
   restoreMode?: 'none' | 'protected_restore';
+  /**
+   * Provenance of the payload content. When it is legacy-RAG (`rag` / `rag-legacy`)
+   * the write is REFUSED (ADR-031/046 — RAG is chatbot-retrieval only, never a
+   * served-content source). Optional for backward-compat: callers that do not stamp
+   * provenance are unaffected. See {@link isLegacyRagTier}.
+   */
+  provenance?: SourceTier;
 }
 
 @Injectable()
@@ -76,6 +85,26 @@ export class ContentWriteGateService {
    * Steps C-J are delegated to ContentWriteExecutor.
    */
   async writeToTarget(input: WriteTargetInput): Promise<WriteGateResult> {
+    // ── Step 0: Provenance refusal (fail-closed, FIRST — before target resolution) ──
+    // RAG is chatbot-retrieval only (ADR-031/046); no RAG-sourced content may reach a
+    // served __seo_* table. Mirrors the shipped R4/R5 refusal shape
+    // (execution-router.service.ts:377-388/418-427): explicit failure, ZERO rows, no
+    // silent fallback. Independent of WRITE_GUARD_ENABLED so the flag can never re-open it.
+    if (isLegacyRagTier(input.provenance)) {
+      this.logger.warn(
+        `WriteGate: REFUSED rag-provenance write — role=${input.roleId} ` +
+          `target=${input.target} corr=${input.correlationId}`,
+      );
+      return {
+        written: false,
+        reason: 'rag_provenance_refused',
+        fieldsWritten: [],
+        fieldsSkipped: [],
+        fieldsStripped: [],
+        mergeDetails: [],
+      };
+    }
+
     const { roleId, target, pkValue, payload, correlationId, restoreMode } =
       input;
 

--- a/backend/src/modules/admin/controllers/admin-keyword-planner.controller.test.ts
+++ b/backend/src/modules/admin/controllers/admin-keyword-planner.controller.test.ts
@@ -1,0 +1,137 @@
+/**
+ * AdminKeywordPlannerController — generate-from-rag endpoints refuse the persist.
+ *
+ * `generate-from-rag` and `batch-generate-from-rag` produce sg_content via
+ * R1ContentFromRagService, which reads the decommissioned legacy RAG corpus
+ * (ADR-031/046). Persisting that to the served `__seo_gamme.sg_content` is
+ * refused (never calls upsert); the `dry_run` preview stays available.
+ */
+const supabaseState: { fromImpl: (table: string) => unknown } = {
+  fromImpl: () => ({}),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: (table: string) => supabaseState.fromImpl(table),
+  })),
+  SupabaseClient: class {},
+}));
+
+import { AdminKeywordPlannerController } from './admin-keyword-planner.controller';
+import type { ConfigService } from '@nestjs/config';
+
+function makeController(
+  r1ContentFromRag: unknown,
+): AdminKeywordPlannerController {
+  const config = {
+    get: () => 'https://example.supabase.co',
+  } as unknown as ConfigService;
+  return new AdminKeywordPlannerController(
+    config,
+    undefined, // r1BatchService
+    r1ContentFromRag as never,
+    undefined, // cacheManager
+  );
+}
+
+// Supabase query-builder stub: chainable + awaitable (thenable), with an upsert spy.
+function makeQb(result: unknown, upsert: jest.Mock): Record<string, unknown> {
+  const qb: Record<string, unknown> = {};
+  const chain = (): Record<string, unknown> => qb;
+  Object.assign(qb, {
+    select: chain,
+    eq: chain,
+    in: chain,
+    order: chain,
+    range: chain,
+    single: () => Promise.resolve(result),
+    upsert,
+    then: (resolve: (v: unknown) => unknown) => resolve(result),
+  });
+  return qb;
+}
+
+const RAG_RESULT = {
+  charCount: 1200,
+  h2Count: 4,
+  quality: 'rich' as const,
+  ragFieldsUsed: ['a', 'b'],
+  html: '<h2>Freinage</h2>',
+};
+
+describe('AdminKeywordPlannerController — generate-from-rag refuses the persist', () => {
+  it('generate-from-rag: refuses the sg_content persist and never calls upsert', async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    supabaseState.fromImpl = () =>
+      makeQb({ data: { pg_name: 'Freinage' } }, upsert);
+    const r1 = { generate: jest.fn().mockResolvedValue(RAG_RESULT) };
+    const controller = makeController(r1);
+
+    const res = (await controller.generateFromRag({
+      pg_id: 42,
+      pg_alias: 'freinage',
+      dry_run: false,
+    })) as Record<string, unknown>;
+
+    expect(res).toMatchObject({
+      status: 'refused',
+      reason: 'rag_provenance_refused',
+    });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('generate-from-rag: dry_run still returns a preview, no persist attempted', async () => {
+    const upsert = jest.fn();
+    supabaseState.fromImpl = () =>
+      makeQb({ data: { pg_name: 'Freinage' } }, upsert);
+    const r1 = { generate: jest.fn().mockResolvedValue(RAG_RESULT) };
+    const controller = makeController(r1);
+
+    const res = (await controller.generateFromRag({
+      pg_id: 42,
+      pg_alias: 'freinage',
+      dry_run: true,
+    })) as Record<string, unknown>;
+
+    expect(res).toMatchObject({ status: 'dry_run' });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('batch-generate-from-rag: refuses each item and never calls upsert', async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    supabaseState.fromImpl = (table: string) => {
+      if (table === 'gamme_aggregates') {
+        return makeQb(
+          { data: [{ ga_pg_id: 42, products_total: 100 }] },
+          upsert,
+        );
+      }
+      if (table === 'pieces_gamme') {
+        return makeQb(
+          { data: [{ pg_id: 42, pg_alias: 'freinage', pg_name: 'Freinage' }] },
+          upsert,
+        );
+      }
+      return makeQb({ data: null }, upsert);
+    };
+    const r1 = { generate: jest.fn().mockResolvedValue(RAG_RESULT) };
+    const controller = makeController(r1);
+
+    const res = (await controller.batchGenerateFromRag({
+      limit: 1,
+      dry_run: false,
+      min_quality: 'minimal',
+    })) as {
+      summary: Record<string, number>;
+      results: Array<Record<string, unknown>>;
+    };
+
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0]).toMatchObject({
+      status: 'refused',
+      reason: 'rag_provenance_refused',
+    });
+    expect(res.summary.refused).toBe(1);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts
@@ -22,6 +22,10 @@ import { IsAdminGuard } from '@auth/is-admin.guard';
 import { getEffectiveSupabaseKey } from '@common/utils';
 import { R1ContentFromRagService } from '../services/r1-content-from-rag.service';
 import { R1KeywordPlanBatchService } from '../services/r1-keyword-plan-batch.service';
+import {
+  SOURCE_TIER,
+  isLegacyRagTier,
+} from '../../../config/source-provenance.constants';
 
 interface CoverageRow {
   role: string;
@@ -1330,6 +1334,26 @@ export class AdminKeywordPlannerController {
       };
     }
 
+    // ── Provenance refusal (ADR-031/046) ──
+    // sg_content here is produced by R1ContentFromRagService, which reads the
+    // decommissioned legacy RAG corpus. Persisting RAG-sourced editorial to the
+    // served __seo_gamme.sg_content is refused until re-sourced from WIKI. The
+    // dry_run preview above stays available (nothing is persisted).
+    const contentProvenance = SOURCE_TIER.RAG_LEGACY;
+    if (isLegacyRagTier(contentProvenance)) {
+      this.logger.warn(
+        `generate-from-rag: REFUSED rag-provenance sg_content write — ` +
+          `pg_alias=${pg_alias} pg_id=${pg_id}`,
+      );
+      return {
+        status: 'refused',
+        reason: 'rag_provenance_refused',
+        pg_alias,
+        pgName,
+        charCount: result.charCount,
+      };
+    }
+
     // Vérifier le contenu existant (anti-régression : ne pas rétrécir)
     const { data: existing } = await this.supabase
       .from('__seo_gamme')
@@ -1452,6 +1476,7 @@ export class AdminKeywordPlannerController {
         | 'skipped_quality'
         | 'skipped_regression'
         | 'dry_run'
+        | 'refused'
         | 'error';
       reason?: string;
     }> = [];
@@ -1494,6 +1519,30 @@ export class AdminKeywordPlannerController {
             quality: gen.quality,
             fields: gen.ragFieldsUsed.length,
             status: 'dry_run',
+          });
+          continue;
+        }
+
+        // ── Provenance refusal (ADR-031/046) — see generate-from-rag ──
+        // gen.html is RAG-sourced (R1ContentFromRagService); refuse the persist
+        // to served __seo_gamme.sg_content until re-sourced from WIKI. dry_run
+        // preview above stays available.
+        const contentProvenance = SOURCE_TIER.RAG_LEGACY;
+        if (isLegacyRagTier(contentProvenance)) {
+          this.logger.warn(
+            `batch-generate-from-rag: REFUSED rag-provenance sg_content write — ` +
+              `pg_alias=${pgAlias} pg_id=${pgId}`,
+          );
+          results.push({
+            pg_id: pgId,
+            pg_alias: pgAlias,
+            pg_name: pgName,
+            charCount: gen.charCount,
+            h2Count: gen.h2Count,
+            quality: gen.quality,
+            fields: gen.ragFieldsUsed.length,
+            status: 'refused',
+            reason: 'rag_provenance_refused',
           });
           continue;
         }
@@ -1574,6 +1623,7 @@ export class AdminKeywordPlannerController {
       skipped_regression: results.filter(
         (r) => r.status === 'skipped_regression',
       ).length,
+      refused: results.filter((r) => r.status === 'refused').length,
       errors: results.filter((r) => r.status === 'error').length,
       avg_chars: Math.round(
         results.reduce((s, r) => s + r.charCount, 0) / (results.length || 1),

--- a/backend/src/modules/admin/services/buying-guide/buying-guide-db.service.test.ts
+++ b/backend/src/modules/admin/services/buying-guide/buying-guide-db.service.test.ts
@@ -1,0 +1,50 @@
+/**
+ * BuyingGuideDbService (R6) — RAG-provenance writes are refused before the served table.
+ *
+ * R6 buying-guide content is sourced from the decommissioned legacy RAG corpus
+ * (ADR-031/046). The WriteGuard CAS on this service is a concurrency/ownership guard
+ * that still writes — NOT a provenance gate. `upsertBuyingGuide()` refuses at method
+ * entry when the payload is stamped `sgpg_source_type = RAG_LEGACY`, so RAG editorial
+ * content never reaches `__seo_gamme_purchase_guide`. The QA-verdict metadata write
+ * (no provenance stamp) is intentionally still allowed, to preserve observability.
+ */
+import { BuyingGuideDbService } from './buying-guide-db.service';
+import { SOURCE_TIER } from '../../../../config/source-provenance.constants';
+import type { ConfigService } from '@nestjs/config';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({})),
+}));
+
+function makeR6(): BuyingGuideDbService {
+  const config = {
+    get: () => 'https://example.supabase.co',
+  } as unknown as ConfigService;
+  return new BuyingGuideDbService(config);
+}
+
+describe('BuyingGuideDbService (R6) — RAG-provenance writes refused', () => {
+  it('refuses a RAG_LEGACY-stamped content payload — never touches the served table', async () => {
+    const service = makeR6();
+
+    // The refusal short-circuits at method entry, before the merge `.select()` and
+    // the final `.update()` — the mocked client ({}) would throw if either ran.
+    await expect(
+      service.upsertBuyingGuide('123', {
+        sgpg_source_type: SOURCE_TIER.RAG_LEGACY,
+        sgpg_how_to_choose: 'x',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does NOT refuse a QA-verdict metadata write (no provenance stamp) — guard is provenance-scoped', async () => {
+    const service = makeR6();
+
+    // No `sgpg_source_type` ⇒ the guard lets it through; it then reaches the mocked
+    // client ({}) and throws — proving the refusal is provenance-scoped, not a blanket
+    // block (the gatekeeper "RAG-incomplete" verdict must still be recorded).
+    await expect(
+      service.upsertBuyingGuide('123', { sgpg_gatekeeper_score: 10 }),
+    ).rejects.toThrow();
+  });
+});

--- a/backend/src/modules/admin/services/buying-guide/buying-guide-db.service.ts
+++ b/backend/src/modules/admin/services/buying-guide/buying-guide-db.service.ts
@@ -6,7 +6,10 @@ import {
   MIN_QUALITY_SCORE,
   FAMILY_MARKERS,
 } from '../../../../config/buying-guide-quality.constants';
-import { SOURCE_TIER } from '../../../../config/source-provenance.constants';
+import {
+  SOURCE_TIER,
+  isLegacyRagTier,
+} from '../../../../config/source-provenance.constants';
 import type { SectionValidationResult } from './buying-guide.types';
 import { BuyingGuideSectionExtractor } from './buying-guide-section-extractor.service';
 import { FeatureFlagsService } from '../../../../config/feature-flags.service';
@@ -176,6 +179,22 @@ export class BuyingGuideDbService extends SupabaseBaseService {
     payload: Record<string, unknown>,
     context?: WriteGuardContext,
   ): Promise<void> {
+    // ── Provenance refusal (ADR-031/046) ──
+    // R6 buying-guide editorial content is sourced from the decommissioned legacy
+    // RAG corpus. A payload stamped provenance=RAG_LEGACY must not reach the served
+    // __seo_gamme_purchase_guide table. The WriteGuard CAS below is a concurrency/
+    // ownership guard, not a provenance gate — it still writes — so the refusal is
+    // enforced here at method entry with the same canonical predicate the
+    // ContentWriteGate applies as its first step. QA-verdict metadata writes carry
+    // no sgpg_source_type and are intentionally allowed (observability is kept).
+    if (isLegacyRagTier(payload.sgpg_source_type as string | undefined)) {
+      this.logger.warn(
+        `WriteGuard: REFUSED rag-provenance buying-guide write — ` +
+          `role=${context?.roleId ?? 'n/a'} pgId=${pgId}`,
+      );
+      return;
+    }
+
     // ── Intelligent merge: enrich, don't replace ──
     // For long text fields, we merge new content INTO existing content
     // instead of replacing it. The rule is:

--- a/backend/src/modules/admin/services/conseil-enricher.service.test.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ConseilEnricherService (R3) — RAG-sourced writes are refused, never reach the served tables.
+ *
+ * R3 enriches conseil pages from the decommissioned legacy RAG corpus (gammes/*.md,
+ * ADR-031/046). Two write paths must stop reaching served `__seo_*` tables:
+ *  - `writeSeoDescripDraft()` → single-row write to `__seo_gamme`; routed through
+ *    ContentWriteGateService stamped `provenance = RAG_LEGACY`, which the gate refuses.
+ *  - `writeSections()` → composite-key (`sgc_pg_id, sgc_section_type`), multi-row
+ *    upsert into `__seo_gamme_conseil` that the single-row gate cannot model; the same
+ *    canonical `isLegacyRagTier` refusal predicate is enforced at the write boundary, so
+ *    no upsert is issued.
+ * writeGate is a required (non-@Optional) dependency — no fail-open direct-write fallback.
+ */
+import { ConseilEnricherService } from './conseil-enricher.service';
+import { SOURCE_TIER } from '../../../config/source-provenance.constants';
+import type { ConfigService } from '@nestjs/config';
+import type { ContentWriteGateService } from '../../../config/content-write-gate.service';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({})),
+}));
+
+function makeR3(writeGate: unknown): ConseilEnricherService {
+  const config = {
+    get: () => 'https://example.supabase.co',
+  } as unknown as ConfigService;
+  return new ConseilEnricherService(
+    config,
+    {} as never, // ragService
+    { briefAwareEnabled: false, writeGuardEnabled: true } as never, // flags
+    { restoreAccents: (s: string) => s } as never, // textUtils
+    {} as never, // yamlParser
+    {} as never, // ragMdMerger
+    writeGate as ContentWriteGateService,
+  );
+}
+
+describe('ConseilEnricherService (R3) — RAG writes refused', () => {
+  it('writeSeoDescripDraft routes through the gate with provenance=RAG_LEGACY (refused)', async () => {
+    const writeToTarget = jest.fn().mockResolvedValue({
+      written: false,
+      reason: 'rag_provenance_refused',
+      fieldsWritten: [],
+      fieldsSkipped: [],
+      fieldsStripped: [],
+      mergeDetails: [],
+    });
+    const service = makeR3({ writeToTarget });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (service as any).writeSeoDescripDraft(
+      '123',
+      {
+        intro: {
+          role: 'Le filtre à huile protège le moteur en retenant les impuretés',
+        },
+      },
+      'freinage',
+      'Filtres à huile',
+    );
+
+    expect(writeToTarget).toHaveBeenCalledTimes(1);
+    expect(writeToTarget.mock.calls[0][0]).toMatchObject({
+      provenance: SOURCE_TIER.RAG_LEGACY,
+      target: 'seo_gamme_main',
+      roleId: 'R3_CONSEILS',
+    });
+  });
+
+  it('writeSeoDescripDraft has NO fail-open fallback — a gate error propagates', async () => {
+    const service = makeR3({
+      writeToTarget: jest.fn().mockRejectedValue(new Error('gate down')),
+    });
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).writeSeoDescripDraft(
+        '1',
+        {
+          intro: {
+            role: 'Le filtre à huile protège le moteur en retenant les impuretés',
+          },
+        },
+        'x',
+        'Filtres',
+      ),
+    ).rejects.toThrow('gate down');
+  });
+
+  it('writeSections refuses RAG-sourced conseil sections — no upsert to the served table', async () => {
+    const service = makeR3({ writeToTarget: jest.fn() });
+    const actions = [
+      { action: 'create', type: 'META', content: 'x', title: 't', order: 1 },
+    ];
+
+    // If the refusal did not short-circuit, `.from()` on the mocked client (`{}`)
+    // would throw — reaching {created:0,updated:0} proves the served table is untouched.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outcome = await (service as any).writeSections(
+      '123',
+      'freinage',
+      actions,
+      new Map(),
+    );
+
+    expect(outcome).toEqual({ created: 0, updated: 0 });
+  });
+});

--- a/backend/src/modules/admin/services/conseil-enricher.service.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.ts
@@ -11,7 +11,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as yaml from 'js-yaml';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
-import { SOURCE_TIER } from '../../../config/source-provenance.constants';
+import {
+  SOURCE_TIER,
+  isLegacyRagTier,
+} from '../../../config/source-provenance.constants';
 import {
   GENERIC_PHRASES as SHARED_GENERIC_PHRASES,
   MIN_R3_SECTION_LENGTH,
@@ -267,12 +270,13 @@ export class ConseilEnricherService extends SupabaseBaseService {
     private readonly textUtils: EnricherTextUtils,
     private readonly yamlParser: EnricherYamlParser,
     private readonly ragMdMerger: RagMdMergerService,
+    // Required (non-@Optional): a RAG-substrate enricher must never fall back to a
+    // direct served-table write when the governed gate is absent (ADR-031/046).
+    private readonly writeGate: ContentWriteGateService,
     @Optional() private readonly aiContentService?: AiContentService,
     @Optional() private readonly pageBriefService?: PageBriefService,
     @Optional()
     private readonly foundationGate?: RagFoundationGateService,
-    @Optional()
-    private readonly writeGate?: ContentWriteGateService,
     @Optional()
     private readonly canonObservability?: CanonObservabilityService,
   ) {
@@ -2117,6 +2121,21 @@ export class ConseilEnricherService extends SupabaseBaseService {
     });
     if (writeActions.length === 0) return { created: 0, updated: 0 };
 
+    // R3 conseil section content is sourced from the decommissioned legacy RAG
+    // corpus (gammes/*.md — ADR-031/046). Until re-sourced from WIKI it must not
+    // reach the served __seo_gamme_conseil table. That table has a composite key
+    // (sgc_pg_id, sgc_section_type) + multi-row upserts, which the single-row
+    // ContentWriteGate cannot model — so the same canonical refusal predicate the
+    // gate applies as its first step is enforced here at the write boundary.
+    const sectionProvenance = SOURCE_TIER.RAG_LEGACY;
+    if (isLegacyRagTier(sectionProvenance)) {
+      this.logger.warn(
+        `WriteGate: REFUSED rag-provenance conseil sections — role=R3_CONSEILS ` +
+          `pgId=${pgId} sections=${writeActions.length}`,
+      );
+      return { created: 0, updated: 0 };
+    }
+
     const upsertRows = writeActions.map((action) => {
       const existingRow = existing.get(action.type);
       const sources: Array<{ type: string; ref: string; field: string }> = [
@@ -2675,45 +2694,26 @@ export class ConseilEnricherService extends SupabaseBaseService {
       }
     }
 
-    // ── P1.5 v2.1: Route through WriteGate (merge intelligent, anti-regression) ──
-    if (this.writeGate && this.flags.writeGuardEnabled) {
-      const result = await this.writeGate.writeToTarget({
-        roleId: RoleId.R3_CONSEILS,
-        target: 'seo_gamme_main' as ResourceGroup,
-        pkValue: parseInt(pgId, 10),
-        payload: {
-          sg_descrip_draft: finalDescrip,
-          sg_draft_source: draftSource,
-          sg_draft_updated_at: new Date().toISOString(),
-          sg_draft_llm_model: llmModel,
-        },
-        correlationId: `r3-descrip-${pgId}-${Date.now().toString(36)}`,
-      });
-      this.logger.log(
-        `sg_descrip_draft via WriteGate for pgId=${pgId}: written=${result.written} ` +
-          `skipped=${result.fieldsSkipped.join(',')} stripped=${result.fieldsStripped.join(',')}`,
-      );
-    } else {
-      // Legacy path
-      const { error } = await this.client
-        .from('__seo_gamme')
-        .update({
-          sg_descrip_draft: finalDescrip,
-          sg_draft_source: draftSource,
-          sg_draft_updated_at: new Date().toISOString(),
-          sg_draft_llm_model: llmModel,
-        })
-        .eq('sg_pg_id', pgId);
-
-      if (error) {
-        this.logger.warn(
-          `Failed to write sg_descrip_draft for pgId=${pgId}: ${error.message}`,
-        );
-      } else {
-        this.logger.log(
-          `sg_descrip_draft written for pgId=${pgId} (${finalDescrip.length} chars, source=${draftSource})`,
-        );
-      }
-    }
+    // ── Route through WriteGate. The descrip draft is composed from the legacy
+    // RAG-sourced PageContract (ADR-031/046): stamped provenance=RAG_LEGACY, the
+    // gate refuses it at its first step (0 rows) before any target/key resolution.
+    // writeGate is required — no fail-open direct-update fallback. ──
+    const result = await this.writeGate.writeToTarget({
+      roleId: RoleId.R3_CONSEILS,
+      target: 'seo_gamme_main' as ResourceGroup,
+      pkValue: parseInt(pgId, 10),
+      payload: {
+        sg_descrip_draft: finalDescrip,
+        sg_draft_source: draftSource,
+        sg_draft_updated_at: new Date().toISOString(),
+        sg_draft_llm_model: llmModel,
+      },
+      correlationId: `r3-descrip-${pgId}-${Date.now().toString(36)}`,
+      provenance: SOURCE_TIER.RAG_LEGACY,
+    });
+    this.logger.log(
+      `sg_descrip_draft via WriteGate for pgId=${pgId}: written=${result.written} ` +
+        `reason=${result.reason ?? 'n/a'}`,
+    );
   }
 }

--- a/backend/src/modules/admin/services/r1-enricher.service.test.ts
+++ b/backend/src/modules/admin/services/r1-enricher.service.test.ts
@@ -1,0 +1,73 @@
+/**
+ * R1EnricherService — RAG-sourced slot writes are refused at the governed gate.
+ *
+ * The R1 enricher reads legacy RAG gamme docs; per ADR-031/046 that content must
+ * not reach the served `__seo_r1_gamme_slots` table. `persistR1Slots()` routes
+ * every write through ContentWriteGateService with `provenance = RAG_LEGACY`,
+ * which the gate refuses (0 rows). There is NO fail-open direct-upsert fallback
+ * (writeGate is a required, non-@Optional dependency).
+ */
+import { R1EnricherService } from './r1-enricher.service';
+import { SOURCE_TIER } from '../../../config/source-provenance.constants';
+import type { ConfigService } from '@nestjs/config';
+import type { ContentWriteGateService } from '../../../config/content-write-gate.service';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({})),
+}));
+
+function makeR1(writeGate: unknown): R1EnricherService {
+  const config = {
+    get: () => 'https://example.supabase.co',
+  } as unknown as ConfigService;
+  return new R1EnricherService(
+    config,
+    {} as never, // textUtils
+    {} as never, // yamlParser
+    writeGate as ContentWriteGateService,
+  );
+}
+
+describe('R1EnricherService — RAG write refused at the gate', () => {
+  it('routes the slot write through the gate with provenance=RAG_LEGACY and surfaces the refusal', async () => {
+    const writeToTarget = jest.fn().mockResolvedValue({
+      written: false,
+      reason: 'rag_provenance_refused',
+      fieldsWritten: [],
+      fieldsSkipped: [],
+      fieldsStripped: [],
+      mergeDetails: [],
+    });
+    const service = makeR1({ writeToTarget });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outcome = await (service as any).persistR1Slots(
+      '123',
+      'freinage',
+      { r1s_micro_seo: 'from RAG' },
+      80,
+      [],
+    );
+
+    expect(writeToTarget).toHaveBeenCalledTimes(1);
+    expect(writeToTarget.mock.calls[0][0]).toMatchObject({
+      provenance: SOURCE_TIER.RAG_LEGACY,
+      target: 'r1_gamme_slots',
+      roleId: 'R1_ROUTER',
+    });
+    // Gate refused ⇒ skipped, zero slots, RAG refusal surfaced (no silent fallback).
+    expect(outcome).toMatchObject({ status: 'skipped', slotsWritten: 0 });
+    expect(outcome.qualityFlags).toContain('RAG_SOURCE_REFUSED');
+  });
+
+  it('has NO fail-open fallback — a gate error propagates, it is not swallowed by a direct upsert', async () => {
+    const service = makeR1({
+      writeToTarget: jest.fn().mockRejectedValue(new Error('gate down')),
+    });
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).persistR1Slots('1', 'x', { r1s_micro_seo: 'y' }, 50, []),
+    ).rejects.toThrow('gate down');
+  });
+});

--- a/backend/src/modules/admin/services/r1-enricher.service.ts
+++ b/backend/src/modules/admin/services/r1-enricher.service.ts
@@ -4,18 +4,18 @@
  * Reads RAG gamme docs + R1 keyword plan, generates transactional
  * content slots and writes to __seo_r1_gamme_slots.
  *
- * Replaces the deleted R1ContentPipelineService (which used Groq LLM).
+ * Replaces the deleted R1ContentPipelineService (which ran on Groq LLM).
  *
  * @see r1-keyword-plan.constants.ts
  * @see execution-registry.constants.ts
  */
 
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { ContentWriteGateService } from '../../../config/content-write-gate.service';
-import { FeatureFlagsService } from '../../../config/feature-flags.service';
 import { RoleId } from '../../../config/role-ids';
+import { SOURCE_TIER } from '../../../config/source-provenance.constants';
 import type { ResourceGroup } from '../../../config/execution-registry.types';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -47,10 +47,9 @@ export class R1EnricherService extends SupabaseBaseService {
 
   constructor(
     configService: ConfigService,
-    private readonly flags: FeatureFlagsService,
     private readonly textUtils: EnricherTextUtils,
     private readonly yamlParser: EnricherYamlParser,
-    @Optional() private readonly writeGate?: ContentWriteGateService,
+    private readonly writeGate: ContentWriteGateService,
   ) {
     super(configService);
   }
@@ -206,40 +205,16 @@ export class R1EnricherService extends SupabaseBaseService {
       slots.r1s_gatekeeper_flags = flags;
       slots.r1s_updated_at = new Date().toISOString();
 
-      // ── Write to __seo_r1_gamme_slots ──
-      if (this.writeGate && this.flags.writeGuardEnabled) {
-        const result = await this.writeGate.writeToTarget({
-          roleId: RoleId.R1_ROUTER,
-          target: 'r1_gamme_slots' as ResourceGroup,
-          pkValue: pgId,
-          payload: slots,
-          correlationId: `r1-${pgAlias}-${Date.now()}`,
-        });
-        if (!result.written) {
-          return {
-            pgId,
-            status: 'skipped',
-            slotsWritten: 0,
-            qualityScore: score,
-            qualityFlags: [...flags, 'WRITE_GATE_BLOCKED'],
-            errorMessage: result.reason,
-          };
-        }
-      } else {
-        const { error } = await this.client
-          .from('__seo_r1_gamme_slots')
-          .upsert({ r1s_pg_id: pgId, ...slots }, { onConflict: 'r1s_pg_id' });
-        if (error) {
-          this.logger.error(`${ctx} Upsert failed: ${error.message}`);
-          return {
-            pgId,
-            status: 'failed',
-            slotsWritten: 0,
-            qualityScore: score,
-            qualityFlags: [...flags, 'UPSERT_FAILED'],
-            errorMessage: error.message,
-          };
-        }
+      // ── Write to __seo_r1_gamme_slots (RAG-sourced ⇒ refused at the governed gate) ──
+      const writeOutcome = await this.persistR1Slots(
+        pgId,
+        pgAlias,
+        slots,
+        score,
+        flags,
+      );
+      if (writeOutcome) {
+        return writeOutcome;
       }
 
       const slotsWritten = Object.keys(slots).filter(
@@ -285,6 +260,50 @@ export class R1EnricherService extends SupabaseBaseService {
       qualityScore: 0,
       qualityFlags: flags,
     };
+  }
+
+  /**
+   * Persist the computed R1 slots through the governed content write gate.
+   *
+   * R1 content is legacy-RAG-sourced (ADR-031/046), so the write is stamped
+   * `provenance: RAG_LEGACY` and the gate refuses it (0 rows, observable). There is
+   * NO fail-open direct-upsert fallback: `writeGate` is a required dependency, so a
+   * missing gate fails at DI boot, not silently at runtime.
+   *
+   * @returns an early-return {@link R1EnrichResult} when the write did not happen
+   *   (skipped/blocked), or `null` when the write succeeded and enrichment continues.
+   */
+  private async persistR1Slots(
+    pgId: string,
+    pgAlias: string,
+    slots: Record<string, unknown>,
+    score: number,
+    flags: string[],
+  ): Promise<R1EnrichResult | null> {
+    const result = await this.writeGate.writeToTarget({
+      roleId: RoleId.R1_ROUTER,
+      target: 'r1_gamme_slots' as ResourceGroup,
+      pkValue: pgId,
+      payload: slots,
+      correlationId: `r1-${pgAlias}-${Date.now()}`,
+      provenance: SOURCE_TIER.RAG_LEGACY,
+    });
+    if (!result.written) {
+      return {
+        pgId,
+        status: 'skipped',
+        slotsWritten: 0,
+        qualityScore: score,
+        qualityFlags: [
+          ...flags,
+          result.reason === 'rag_provenance_refused'
+            ? 'RAG_SOURCE_REFUSED'
+            : 'WRITE_GATE_BLOCKED',
+        ],
+        errorMessage: result.reason,
+      };
+    }
+    return null;
   }
 
   private extractMarkdownSections(content: string): Map<string, string> {

--- a/backend/src/modules/admin/services/r2-enricher.service.test.ts
+++ b/backend/src/modules/admin/services/r2-enricher.service.test.ts
@@ -1,0 +1,74 @@
+/**
+ * R2EnricherService — RAG-sourced keyword-plan writes are refused at the gate.
+ *
+ * R2 reads legacy RAG gamme docs; per ADR-031/046 that content must not reach the
+ * served `__seo_r2_keyword_plan` table. `persistR2KeywordPlan()` routes every write
+ * through ContentWriteGateService with `provenance = RAG_LEGACY`, which the gate
+ * rejects (0 rows). No fail-open direct-upsert fallback (writeGate is required).
+ */
+import { R2EnricherService } from './r2-enricher.service';
+import { SOURCE_TIER } from '../../../config/source-provenance.constants';
+import type { ConfigService } from '@nestjs/config';
+import type { ContentWriteGateService } from '../../../config/content-write-gate.service';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({})),
+}));
+
+function makeR2(writeGate: unknown): R2EnricherService {
+  const config = {
+    get: () => 'https://example.supabase.co',
+  } as unknown as ConfigService;
+  return new R2EnricherService(config, writeGate as ContentWriteGateService);
+}
+
+describe('R2EnricherService — RAG write refused at the gate', () => {
+  it('routes the keyword-plan write through the gate with provenance=RAG_LEGACY and surfaces the refusal', async () => {
+    const writeToTarget = jest.fn().mockResolvedValue({
+      written: false,
+      reason: 'rag_provenance_refused',
+      fieldsWritten: [],
+      fieldsSkipped: [],
+      fieldsStripped: [],
+      mergeDetails: [],
+    });
+    const service = makeR2({ writeToTarget });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outcome = await (service as any).persistR2KeywordPlan(
+      '123',
+      'veh-1',
+      { r2kp_pg_id: '123' },
+      72,
+      3,
+      [],
+    );
+
+    expect(writeToTarget).toHaveBeenCalledTimes(1);
+    expect(writeToTarget.mock.calls[0][0]).toMatchObject({
+      provenance: SOURCE_TIER.RAG_LEGACY,
+      target: 'r2_product_main',
+      roleId: 'R2_PRODUCT',
+    });
+    expect(outcome).toMatchObject({ status: 'skipped', sectionsGenerated: 3 });
+    expect(outcome.qualityFlags).toContain('RAG_SOURCE_REFUSED');
+  });
+
+  it('has NO fail-open fallback — a gate error propagates, not swallowed by a direct upsert', async () => {
+    const service = makeR2({
+      writeToTarget: jest.fn().mockRejectedValue(new Error('gate down')),
+    });
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).persistR2KeywordPlan(
+        '1',
+        undefined,
+        { r2kp_pg_id: '1' },
+        0,
+        0,
+        [],
+      ),
+    ).rejects.toThrow('gate down');
+  });
+});

--- a/backend/src/modules/admin/services/r2-enricher.service.ts
+++ b/backend/src/modules/admin/services/r2-enricher.service.ts
@@ -18,12 +18,12 @@
  *   - R2ValidatorService (contract validation + metrics)
  */
 
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { ContentWriteGateService } from '../../../config/content-write-gate.service';
-import { FeatureFlagsService } from '../../../config/feature-flags.service';
 import { RoleId } from '../../../config/role-ids';
+import { SOURCE_TIER } from '../../../config/source-provenance.constants';
 import type { ResourceGroup } from '../../../config/execution-registry.types';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -48,8 +48,7 @@ export class R2EnricherService extends SupabaseBaseService {
 
   constructor(
     configService: ConfigService,
-    private readonly flags: FeatureFlagsService,
-    @Optional() private readonly writeGate?: ContentWriteGateService,
+    private readonly writeGate: ContentWriteGateService,
   ) {
     super(configService);
   }
@@ -181,43 +180,17 @@ export class R2EnricherService extends SupabaseBaseService {
         r2kp_updated_at: new Date().toISOString(),
       };
 
-      if (this.writeGate && this.flags.writeGuardEnabled) {
-        // ── WriteGate path (merge + anti-regression + receipt) ──
-        const result = await this.writeGate.writeToTarget({
-          roleId: RoleId.R2_PRODUCT,
-          target: 'r2_product_main' as ResourceGroup,
-          pkValue: pgId,
-          payload,
-          correlationId: `r2-${pgId}-${Date.now().toString(36)}`,
-        });
-
-        this.logger.log(
-          `${ctx} WriteGate: written=${result.written} ` +
-            `fields=${result.fieldsWritten.length} skipped=${result.fieldsSkipped.length}`,
-        );
-
-        if (!result.written) {
-          flags.push('WRITE_GATE_BLOCKED');
-        }
-      } else {
-        // ── Legacy upsert path ──
-        const { error } = await this.client
-          .from('__seo_r2_keyword_plan')
-          .upsert(payload, { onConflict: 'r2kp_pg_id' });
-
-        if (error) {
-          this.logger.error(`${ctx} Upsert failed: ${error.message}`);
-          return {
-            pgId,
-            vehicleKey,
-            status: 'failed',
-            phase: 'write',
-            qualityScore: 0,
-            qualityFlags: ['UPSERT_FAILED'],
-            sectionsGenerated,
-            errorMessage: error.message,
-          };
-        }
+      // ── Write to __seo_r2_keyword_plan (RAG-sourced ⇒ refused at the governed gate) ──
+      const writeOutcome = await this.persistR2KeywordPlan(
+        pgId,
+        vehicleKey,
+        payload,
+        qualityScore,
+        sectionsGenerated,
+        flags,
+      );
+      if (writeOutcome) {
+        return writeOutcome;
       }
 
       this.logger.log(
@@ -247,5 +220,53 @@ export class R2EnricherService extends SupabaseBaseService {
         errorMessage: msg,
       };
     }
+  }
+
+  /**
+   * Persist the R2 keyword-plan through the governed write gate.
+   *
+   * R2 content is sourced from legacy RAG gamme docs (ADR-031/046): it must never
+   * reach the served `__seo_r2_keyword_plan` table. The write is stamped
+   * `provenance = RAG_LEGACY`, which the gate refuses (0 rows) — there is no
+   * fail-open direct-upsert fallback (writeGate is a required dependency). Returns
+   * a `skipped` result on refusal, or `null` when the gate accepted the write
+   * (the caller then continues to the success path).
+   */
+  private async persistR2KeywordPlan(
+    pgId: string,
+    vehicleKey: string | undefined,
+    payload: Record<string, unknown>,
+    qualityScore: number,
+    sectionsGenerated: number,
+    flags: string[],
+  ): Promise<R2EnrichResult | null> {
+    const result = await this.writeGate.writeToTarget({
+      roleId: RoleId.R2_PRODUCT,
+      target: 'r2_product_main' as ResourceGroup,
+      pkValue: pgId,
+      payload,
+      correlationId: `r2-${pgId}-${Date.now().toString(36)}`,
+      provenance: SOURCE_TIER.RAG_LEGACY,
+    });
+
+    if (!result.written) {
+      return {
+        pgId,
+        vehicleKey,
+        status: 'skipped',
+        phase: 'write',
+        qualityScore,
+        qualityFlags: [
+          ...flags,
+          result.reason === 'rag_provenance_refused'
+            ? 'RAG_SOURCE_REFUSED'
+            : 'WRITE_GATE_BLOCKED',
+        ],
+        sectionsGenerated,
+        errorMessage: result.reason,
+      };
+    }
+
+    return null;
   }
 }

--- a/log.md
+++ b/log.md
@@ -507,3 +507,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `worktree-rag-seo-served-write-pr1`
 - **Décision** : feat(write-guard): fail-closed RAG-provenance refusal at write gate
 - **Sortie** : PR aucune | commits 3b3282eee
+
+## 2026-07-05 — worktree-rag-seo-served-write-pr1 (auto)
+
+- **Branche** : `worktree-rag-seo-served-write-pr1`
+- **Décision** : feat(r1-enricher): route slot writes through gate, refuse RAG (+2 other commits)
+- **Sortie** : PR aucune | commits b50d60d95 b20d1263a 3b3282eee

--- a/log.md
+++ b/log.md
@@ -501,3 +501,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `docs/claude-md-slim`
 - **Décision** : docs(claude-md): slim referential sections into pointers (P1/P3 token lever)
 - **Sortie** : PR aucune | commits e34d4ee5c
+
+## 2026-07-04 — worktree-rag-seo-served-write-pr1 (auto)
+
+- **Branche** : `worktree-rag-seo-served-write-pr1`
+- **Décision** : feat(write-guard): fail-closed RAG-provenance refusal at write gate
+- **Sortie** : PR aucune | commits 3b3282eee


### PR DESCRIPTION
## RAG → served-`__seo_*` write closure (Layer-1, app-level)

Per ADR-031/046, RAG is a **consumer**, never a content source. This PR stops RAG-sourced
editorial content from reaching **served/indexed** `__seo_*` tables. Inert until merged; nothing live.

### Mechanism (Layer-1)
`ContentWriteGateService.writeToTarget()` gains an optional `provenance: SourceTier`; a
first-step `isLegacyRagTier(provenance)` check refuses (`written:false` / `rag_provenance_refused`
/ **0 rows**, `logger.warn`) **before** any target/key resolution — so composite-key tables never
need executor changes. The same canonical `isLegacyRagTier` predicate is reused at no-gate /
composite-key boundaries.

### Served-editorial sinks closed (5)
| Role | Sink | Served table | How |
|------|------|--------------|-----|
| R1 | `persistR1Slots` | `__seo_r1_gamme_slots` | gate + `RAG_LEGACY`; writeGate now **required** |
| R2 | `persistR2KeywordPlan` | `__seo_r2_keyword_plan` | gate + `RAG_LEGACY`; writeGate **required** |
| R3 | `writeSeoDescripDraft` / `writeSections` | `__seo_gamme` / `__seo_gamme_conseil` | gate (descrip) + boundary refusal (composite-key sections) |
| R6 | `upsertBuyingGuide` | `__seo_gamme_purchase_guide` | entry refusal on `payload.sgpg_source_type`; QA-verdict metadata write kept (observability) |
| — | `generate-from-rag` + `batch-generate-from-rag` | `__seo_gamme.sg_content` | refuse persist; `dry_run` preview kept |

**15 tests RED→GREEN, tsc 0, eslint 0, role-purity clean.** `writeGate` made required where it
killed a latent fail-open (R1/R2/R3). `else`/fail-open direct-write branches deleted.

### Deliberately NOT refused (verified in code — would be harmful over-refusal)
- **R8 `r8-vehicle-enricher`** — structural-first (identity / compatibility / tech-specs / catalog
  = templates + DB facts). RAG contributes only the gamme editorial anchor, already covered by the
  owner's existing `r8OwnedEditorialEnabled` migration flag. Blanket refusal would freeze ~53k
  structural vehicle pages. Correct closure = advance the owned-editorial flag (owner-gated).
- **`__seo_r1_image_prompts` / `__seo_r3_image_prompts` / `__seo_r1_keyword_plan`** — internal
  generation-input artifacts (image *prompts*, SEO structure hints), not served editorial. The
  gamme response serves only human-approved images (`rip_status='approved'`), never the RAG prompt
  text. Cover systemically (Layer-2/3), not per-sink.

### Remaining (deferred)
- **Layer-2** ast-grep guard — warning-first; a broad served-write rule flags ~31 writers → needs
  careful allowlisting; scoped follow-up.
- **Layer-3** DB REVOKE (anon/authenticated) + provenance-checked DEFINER RPCs — **owner-gated**
  (DB grants/migrations). Runbook in `audit/rag-seo-served-write-closure-design-2026-07-04.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
