### PR TITLE
feat(audit): attribution-write-gap runtime-truth runner + __gov_m11 RPC (#695 class)

### DIFF
--- a/backend/supabase/migrations/20260705_gov_m11_attribution_columns_rpc.down.sql
+++ b/backend/supabase/migrations/20260705_gov_m11_attribution_columns_rpc.down.sql
@@ -1,0 +1,3 @@
+-- Rollback for 20260705_gov_m11_attribution_columns_rpc.sql
+-- Drops the read-only attribution-columns introspection RPC. No data touched.
+drop function if exists public.__gov_m11_attribution_columns();

--- a/backend/supabase/migrations/20260705_gov_m11_attribution_columns_rpc.sql
+++ b/backend/supabase/migrations/20260705_gov_m11_attribution_columns_rpc.sql
@@ -1,0 +1,63 @@
+-- =====================================================
+-- __gov_m11_attribution_columns — read-only introspection RPC
+-- Date: 2026-07-05
+-- Refs: __gov_m1..m10 (governed introspection family — same pattern)
+--       .claude/skills/runtime-truth-audit/checks/attribution-write-gap.md (logic source)
+--       #695 (orl_website_url attribution orpheline en runtime, 2026-05-22)
+-- =====================================================
+--
+-- Why: the deterministic `attribution-write-gap` runner must list attribution /
+-- tracking columns (by naming convention) and their table write-traffic to detect
+-- columns declared in schema but never written by runtime code. information_schema
+-- + pg_stat_user_tables are NOT reachable via PostgREST, so we EXTEND the governed
+-- __gov_* family with one read-only function. Per-column writer detection is done
+-- by the runner via a repo grep of backend/src; this RPC provides the candidate
+-- set + table-level insert/update counters (n_tup_ins / n_tup_upd) as anti-false-
+-- positive corroboration (a grep-missed dynamic writer still bumps n_tup_ins).
+--
+-- Returns one row per public BASE-TABLE column whose name matches an attribution
+-- convention (ends with _url/_referrer/_source/_campaign, or contains utm_ /
+-- attribution), with its table's live insert/update counters.
+--
+-- Security: EXECUTE restricted to service_role. Report-only; no mutation.
+
+set lock_timeout = '2s';
+set statement_timeout = '10s';
+
+create or replace function public.__gov_m11_attribution_columns()
+  returns table (table_name text, column_name text, n_tup_ins bigint, n_tup_upd bigint)
+  language sql
+  stable
+  security definer
+  set search_path to 'public'
+as $function$
+  select c.table_name::text,
+         c.column_name::text,
+         coalesce(s.n_tup_ins, 0)::bigint as n_tup_ins,
+         coalesce(s.n_tup_upd, 0)::bigint as n_tup_upd
+  from information_schema.columns c
+  join information_schema.tables t
+    on t.table_schema = c.table_schema
+   and t.table_name = c.table_name
+   and t.table_type = 'BASE TABLE'
+  left join pg_stat_user_tables s
+    on s.schemaname = c.table_schema
+   and s.relname = c.table_name
+  where c.table_schema = 'public'
+    and (
+      c.column_name ~ '(_url|_referrer|_source|_campaign)$'
+      or c.column_name ~ '(^|_)utm_'
+      or c.column_name like '%attribution%'
+    )
+  order by c.table_name, c.column_name;
+$function$;
+
+revoke all on function public.__gov_m11_attribution_columns() from public;
+-- Supabase ALTER DEFAULT PRIVILEGES grants EXECUTE to anon/authenticated on every new
+-- public function; `revoke ... from public` does NOT remove those direct grants, so we
+-- must revoke them explicitly to actually reach service_role-only (verified 2026-07-01).
+revoke execute on function public.__gov_m11_attribution_columns() from anon, authenticated;
+grant execute on function public.__gov_m11_attribution_columns() to service_role;
+
+comment on function public.__gov_m11_attribution_columns() is
+  'Read-only introspection (Trust Ledger B0a): public base-table columns matching attribution naming conventions + their table insert/update traffic (#695 orphan-attribution class). Consumed by scripts/audit/runtime-truth/attribution-write-gap.ts. service_role only.';

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "audit:db-usage": "node scripts/audit/build-db-usage-map.js",
     "audit:inventory": "node scripts/audit/build-deep-inventory.js && node scripts/audit/build-db-usage-map.js",
     "audit:inventory:check": "npm run audit:inventory && git diff --exit-code -- audit/*.json",
-    "audit:runtime-truth": "for c in pg-stable-write partition-cron-gap rpc-registry-drift rpc-overload-ambiguity bull-repeatable-drift; do tsx scripts/audit/runtime-truth/$c.ts; done",
+    "audit:runtime-truth": "for c in pg-stable-write partition-cron-gap rpc-registry-drift rpc-overload-ambiguity bull-repeatable-drift attribution-write-gap; do tsx scripts/audit/runtime-truth/$c.ts; done",
     "registry:build:files": "node scripts/registry/build-files-registry.js",
     "registry:build:runtime": "node scripts/registry/build-runtime-registry.js",
     "registry:build:deps": "node scripts/registry/build-deps-registry.js",

--- a/scripts/audit/runtime-truth/attribution-write-gap.test.ts
+++ b/scripts/audit/runtime-truth/attribution-write-gap.test.ts
@@ -1,0 +1,143 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyAttributionGaps,
+  grepWriterCounts,
+  runAttributionWriteGap,
+  CHECK_NAME,
+  type AttrColumnRow,
+} from "./attribution-write-gap.ts";
+import { validateResult } from "./contract.ts";
+import { type RpcClient } from "./runner.ts";
+
+const NOW = "2026-07-05T12:00:00.000Z";
+const COMMIT = "abc1234";
+
+const rows: AttrColumnRow[] = [
+  { table_name: "___order_lines", column_name: "orl_website_url", n_tup_ins: 0, n_tup_upd: 0 },
+  { table_name: "___xtr_order", column_name: "ord_utm_source", n_tup_ins: 1200, n_tup_upd: 0 },
+  { table_name: "___xtr_customer", column_name: "cst_referrer", n_tup_ins: 500, n_tup_upd: 3 },
+];
+
+const allWritten: Record<string, number> = {
+  orl_website_url: 2,
+  ord_utm_source: 1,
+  cst_referrer: 1,
+};
+// orl_website_url: no writer + no traffic ⇒ no_runtime_writer (high)
+// ord_utm_source: no writer + traffic     ⇒ unknown_writer (medium)
+// cst_referrer:   has writer              ⇒ not a gap
+const withGaps: Record<string, number> = {
+  orl_website_url: 0,
+  ord_utm_source: 0,
+  cst_referrer: 4,
+};
+
+function stubClient(data: unknown, error: { message: string } | null = null): RpcClient {
+  return { rpc: async () => ({ data, error }) };
+}
+
+test("classify: all columns written ⇒ no findings, candidate/gap counts", () => {
+  const { findings, evidence } = classifyAttributionGaps(rows, allWritten);
+  assert.equal(findings.length, 0);
+  assert.deepEqual(evidence, { candidates: 3, no_writer: 0, unknown_writer: 0 });
+});
+
+test("classify: gaps ⇒ high (no traffic) + medium (traffic), sorted by table.column", () => {
+  const { findings, evidence } = classifyAttributionGaps(rows, withGaps);
+  assert.equal(findings.length, 2);
+  assert.deepEqual(evidence, { candidates: 3, no_writer: 1, unknown_writer: 1 });
+  // ___order_lines.orl_website_url sorts before ___xtr_order.ord_utm_source
+  assert.deepEqual(
+    findings.map((f) => f.id),
+    ["attr-no-writer:___order_lines.orl_website_url", "attr-unknown-writer:___xtr_order.ord_utm_source"],
+  );
+  assert.equal(findings[0].severity, "high");
+  assert.equal(findings[0].detail.category, "no_runtime_writer");
+  assert.equal(findings[1].severity, "medium");
+  assert.equal(findings[1].detail.category, "unknown_writer");
+  assert.equal(findings[1].detail.n_tup_ins, 1200);
+});
+
+test("run: clean DB ⇒ PASS, RECURRING, contract-valid, deterministic generated_at", async () => {
+  const r = await runAttributionWriteGap({
+    client: stubClient(rows),
+    writerCounts: () => allWritten,
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+  });
+  assert.ok("result" in r);
+  const res = r.result;
+  assert.equal(res.check_name, CHECK_NAME);
+  assert.equal(res.coverage_status, "RECURRING");
+  assert.equal(res.health_status, "PASS");
+  assert.equal(res.generated_at, NOW);
+  assert.equal(res.source_commit, COMMIT);
+  assert.equal(res.findings.length, 0);
+  assert.ok(validateResult(res).ok, "result must satisfy the contract");
+});
+
+test("run: gaps ⇒ FAIL (a high finding) with contract-valid result", async () => {
+  const r = await runAttributionWriteGap({
+    client: stubClient(rows),
+    writerCounts: () => withGaps,
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+  });
+  assert.ok("result" in r);
+  assert.equal(r.result.health_status, "FAIL");
+  assert.equal(r.result.findings.length, 2);
+  assert.ok(validateResult(r.result).ok);
+});
+
+test("run: RPC error (migration not applied) ⇒ UNKNOWN, never crash", async () => {
+  const r = await runAttributionWriteGap({
+    client: stubClient(null, { message: "function __gov_m11_attribution_columns() does not exist" }),
+    writerCounts: () => ({}),
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+  });
+  assert.ok("result" in r);
+  assert.equal(r.result.health_status, "UNKNOWN");
+  assert.equal(r.result.coverage_status, "RECURRING");
+  assert.match(String((r.result.evidence as { error: string }).error), /does not exist/);
+  assert.ok(validateResult(r.result).ok);
+});
+
+test("run: no client (no creds) ⇒ skipped", async () => {
+  const r = await runAttributionWriteGap({ client: null, nowIso: NOW, sourceCommit: COMMIT });
+  assert.ok("skipped" in r);
+  assert.equal((r as { skipped: string }).skipped, "no-creds");
+});
+
+test("grepWriterCounts: write-call file counts; type decl + select read do not", () => {
+  const root = mkdtempSync(join(tmpdir(), "attr-wg-"));
+  const src = join(root, "backend/src");
+  mkdirSync(src, { recursive: true });
+  // Real writer: an insert that keys the column.
+  writeFileSync(
+    join(src, "writer.service.ts"),
+    `await this.supabase.from("t").insert({ orl_website_url: url, note: n });\n`,
+  );
+  // Type-only declaration (keys the column but never inserts/updates) → must NOT count.
+  writeFileSync(
+    join(src, "types.ts"),
+    `export interface OrderLine { orl_website_url: string; cst_referrer: string | null; }\n`,
+  );
+  // Read only (.select) → must NOT count.
+  writeFileSync(
+    join(src, "reader.service.ts"),
+    `const { data } = await this.supabase.from("t").select("cst_referrer");\n`,
+  );
+  try {
+    const counts = grepWriterCounts(root, ["orl_website_url", "cst_referrer", "ord_utm_source"]);
+    assert.equal(counts.orl_website_url, 1, "written via insert payload");
+    assert.equal(counts.cst_referrer, 0, "only declared in a type + read via select");
+    assert.equal(counts.ord_utm_source, 0, "absent from code");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/audit/runtime-truth/attribution-write-gap.ts
+++ b/scripts/audit/runtime-truth/attribution-write-gap.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env tsx
+/**
+ * attribution-write-gap — deterministic runtime-truth runner (Trust Ledger PR-B0a).
+ *
+ * Detects attribution / tracking columns declared in the schema but never written
+ * by runtime code (incident #695: `___order_lines.orl_website_url` written by 0
+ * services). Faithful deterministic port of
+ * `.claude/skills/runtime-truth-audit/checks/attribution-write-gap.md` (the skill
+ * is the source of logic; this is SQL + targeted grep, NOT the LLM skill in CI).
+ *
+ * Two signals, intersected:
+ *   1. Candidate columns + table write-traffic (n_tup_ins/n_tup_upd) via the
+ *      governed read-only RPC `__gov_m11_attribution_columns()` (extends `__gov_*`).
+ *   2. Per-column writer detection via a targeted grep of backend/src: a column
+ *      counts as "written" only when a file that calls .insert/.update/.upsert ALSO
+ *      keys that column — so pure type declarations and .select() reads never mask
+ *      a real gap.
+ *
+ * Classification is PURE (testable without a live DB). Report-only: emits a
+ * contract JSON, writes nothing to the DB. RPC absent (migration not yet applied)
+ * ⇒ health UNKNOWN, never a crash.
+ */
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  getServiceClient,
+  gitSourceCommit,
+  makeResult,
+  writeResult,
+  type RpcClient,
+} from "./runner.ts";
+import {
+  healthFromFindings,
+  type RuntimeTruthFinding,
+  type RuntimeTruthResult,
+} from "./contract.ts";
+
+export const CHECK_NAME = "attribution-write-gap";
+const GOV_RPC = "__gov_m11_attribution_columns";
+
+/** One row of `__gov_m11_attribution_columns()`. */
+export interface AttrColumnRow {
+  table_name: string;
+  column_name: string;
+  n_tup_ins: number;
+  n_tup_upd: number;
+}
+
+/**
+ * PURE: classify RPC rows + per-column writer counts → findings + evidence.
+ * Deterministic (sorted by table.column). A column with ≥1 writer is not a gap.
+ * Gap with table traffic (n_tup_ins>0) ⇒ `unknown_writer` (medium: trigger /
+ * extension / dynamic payload may write it). Gap with no traffic ⇒
+ * `no_runtime_writer` (high: the #695 orphan class).
+ */
+export function classifyAttributionGaps(
+  rows: AttrColumnRow[],
+  writerCounts: Record<string, number>,
+): { findings: RuntimeTruthFinding[]; evidence: Record<string, unknown> } {
+  const gaps = rows
+    .filter((r) => (writerCounts[r.column_name] ?? 0) === 0)
+    .slice()
+    .sort((a, b) =>
+      `${a.table_name}.${a.column_name}`.localeCompare(`${b.table_name}.${b.column_name}`),
+    );
+
+  let noWriter = 0;
+  let unknownWriter = 0;
+  const findings: RuntimeTruthFinding[] = gaps.map((r) => {
+    if (r.n_tup_ins > 0) {
+      unknownWriter++;
+      return {
+        id: `attr-unknown-writer:${r.table_name}.${r.column_name}`,
+        severity: "medium" as const,
+        title: `${r.table_name}.${r.column_name} — attribution column receives inserts (n_tup_ins=${r.n_tup_ins}) but no backend writer keys it`,
+        detail: {
+          table: r.table_name,
+          column: r.column_name,
+          category: "unknown_writer",
+          grep_count: 0,
+          n_tup_ins: r.n_tup_ins,
+          n_tup_upd: r.n_tup_upd,
+        },
+        fix_hint: `Rows arrive but no backend/src writer references it — confirm a DB trigger / extension / dynamic payload writes it, else wire an explicit writer.`,
+      };
+    }
+    noWriter++;
+    return {
+      id: `attr-no-writer:${r.table_name}.${r.column_name}`,
+      severity: "high" as const,
+      title: `${r.table_name}.${r.column_name} — attribution column with no runtime writer (grep=0, n_tup_ins=0)`,
+      detail: {
+        table: r.table_name,
+        column: r.column_name,
+        category: "no_runtime_writer",
+        grep_count: 0,
+        n_tup_ins: 0,
+        n_tup_upd: r.n_tup_upd,
+      },
+      fix_hint: `Wire the write (#695 class) or DROP COLUMN if the signal is no longer collected.`,
+    };
+  });
+
+  return {
+    findings,
+    evidence: { candidates: rows.length, no_writer: noWriter, unknown_writer: unknownWriter },
+  };
+}
+
+/** Impure: files under `dir` (recursive, *.ts) matching an ERE pattern. */
+function grepFiles(dir: string, pattern: string): Set<string> {
+  try {
+    const out = execFileSync("grep", ["-rlE", "--include=*.ts", pattern, dir], {
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    return new Set(out.split("\n").filter(Boolean));
+  } catch {
+    return new Set(); // grep exit 1 = no match (or dir absent)
+  }
+}
+
+/**
+ * Impure: per-column writer count over backend/src. A column is "written" iff a
+ * file that calls .insert/.update/.upsert ALSO uses it as an object-literal key
+ * (`col:` / `"col":` / `'col':`). Intersecting write-call files with key files
+ * ignores pure type declarations and .select() reads → conservative, low-FP.
+ */
+export function grepWriterCounts(repoRoot: string, columnNames: string[]): Record<string, number> {
+  const dir = join(repoRoot, "backend/src");
+  const writeFiles = grepFiles(dir, "\\.(insert|update|upsert)\\(");
+  const counts: Record<string, number> = {};
+  for (const col of [...new Set(columnNames)]) {
+    if (writeFiles.size === 0) {
+      counts[col] = 0;
+      continue;
+    }
+    const keyFiles = grepFiles(dir, `(^|[^A-Za-z0-9_])${col}['"]?[[:space:]]*:`);
+    let n = 0;
+    for (const f of keyFiles) if (writeFiles.has(f)) n++;
+    counts[col] = n;
+  }
+  return counts;
+}
+
+export interface RunOpts {
+  repoRoot?: string;
+  nowIso?: string;
+  /** Inject for tests; default = env-gated live service client. */
+  client?: RpcClient | null;
+  sourceCommit?: string;
+  /** Inject for tests; default = real backend/src grep. */
+  writerCounts?: (columnNames: string[]) => Record<string, number>;
+}
+
+export async function runAttributionWriteGap(
+  opts: RunOpts = {},
+): Promise<{ result: RuntimeTruthResult } | { skipped: "no-creds" }> {
+  const repoRoot = opts.repoRoot ?? process.env.REPO_ROOT ?? process.cwd();
+  const nowIso = opts.nowIso ?? new Date().toISOString();
+  const sourceCommit = opts.sourceCommit ?? gitSourceCommit(repoRoot);
+  const client = opts.client === undefined ? await getServiceClient() : opts.client;
+
+  if (!client) return { skipped: "no-creds" };
+
+  const { data, error } = await client.rpc(GOV_RPC);
+  if (error) {
+    // RPC absent (migration not yet applied) or transient — emit UNKNOWN, never crash.
+    return {
+      result: makeResult({
+        check_name: CHECK_NAME,
+        generated_at: nowIso,
+        source_commit: sourceCommit,
+        coverage_status: "RECURRING",
+        health_status: "UNKNOWN",
+        findings: [],
+        freshness: "live",
+        evidence: { error: error.message, hint: `apply migration adding ${GOV_RPC}()` },
+      }),
+    };
+  }
+
+  const rows = (Array.isArray(data) ? data : []) as AttrColumnRow[];
+  const countFn = opts.writerCounts ?? ((cols: string[]) => grepWriterCounts(repoRoot, cols));
+  const writerCounts = countFn(rows.map((r) => r.column_name));
+  const { findings, evidence } = classifyAttributionGaps(rows, writerCounts);
+  return {
+    result: makeResult({
+      check_name: CHECK_NAME,
+      generated_at: nowIso,
+      source_commit: sourceCommit,
+      coverage_status: "RECURRING",
+      health_status: healthFromFindings(findings),
+      findings,
+      freshness: "live",
+      evidence,
+    }),
+  };
+}
+
+// ── CLI entry ──────────────────────────────────────────────────────────────
+const isMain =
+  typeof process.argv[1] === "string" && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  runAttributionWriteGap()
+    .then((r) => {
+      if ("skipped" in r) {
+        console.error(`::warning::${CHECK_NAME} skipped (${r.skipped}) — no SUPABASE creds`);
+        process.exit(0);
+      }
+      const path = writeResult(process.env.REPO_ROOT ?? process.cwd(), r.result);
+      console.log(
+        `✓ ${CHECK_NAME}: health=${r.result.health_status} findings=${r.result.findings.length} → ${path}`,
+      );
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(`::warning::${CHECK_NAME} caught: ${err?.message}`);
+      process.exit(0);
+    });
+}


### PR DESCRIPTION
## Summary

Adds the **6th deterministic runtime-truth runner** (Trust Ledger PR-B0a): `attribution-write-gap`. It detects attribution / tracking columns declared in the schema but **never written by runtime code** — the **#695** orphan class (`___order_lines.orl_website_url` written by 0 services). Faithful deterministic port of the existing skill check `.claude/skills/runtime-truth-audit/checks/attribution-write-gap.md` (the skill remains the source of logic; this is SQL + targeted grep, not an LLM run in CI).

### Files
- **`backend/supabase/migrations/20260705_gov_m11_attribution_columns_rpc.sql`** (+ `.down.sql`) — read-only `SECURITY DEFINER` RPC `__gov_m11_attribution_columns()` **extending the governed `__gov_m1..m10` family**. Returns attribution-named public base-table columns + their table `n_tup_ins` / `n_tup_upd`. `revoke all from public` + `revoke execute from anon, authenticated` + `grant execute to service_role` only; `search_path` pinned; `lock_timeout`/`statement_timeout` set. **APPLYING this migration to the shared DB is OWNER-GATED** (migrations are not auto-applied — see `.claude/rules/deployment.md` axis 4).
- **`scripts/audit/runtime-truth/attribution-write-gap.ts`** — PURE classifier + targeted `backend/src` writer grep. A column counts as *written* only when a file that calls `.insert/.update/.upsert` **also** keys it (`col:`), so pure type declarations and `.select()` reads never mask a real gap. RPC-absent-tolerant ⇒ health `UNKNOWN` (never crashes).
- **`scripts/audit/runtime-truth/attribution-write-gap.test.ts`** — 7 tests: pure classifier (clean / gap fixtures), all `run()` paths, and a hermetic grep-intersection test on a temp dir.
- **`package.json`** — wired into `audit:runtime-truth`.

### Classification
| Condition | Finding | Severity |
|---|---|---|
| grep=0 **and** `n_tup_ins=0` | `no_runtime_writer` (the #695 orphan) | high |
| grep=0 **and** table has inserts | `unknown_writer` (trigger / extension / dynamic payload?) | medium |
| ≥1 writer | — (not a gap) | — |

## Improvement Check

- **Problem:** `runtime-truth-p0` had 5 deterministic runners; the attribution-write-gap check (incident #695 class) existed only as a skill spec, not a runnable runner. No standing detection for schema columns with no runtime writer.
- **Evidence before:** `audit:runtime-truth` ran 5 runners; no coverage of the attribution orphan class; `__gov_*` family had no attribution-column introspection.
- **Expected gain:** recurring, deterministic detection of the #695 class via a governed read-only RPC + testable pure classifier.
- **Risk:** *Low.* RPC is read-only `SECURITY DEFINER`, `service_role`-only. Migration APPLY is owner-gated and inert until applied (runner emits `UNKNOWN`). Grep heuristic can false-negative on generic column names (accepted FPR per the skill spec); informational only (`autofixable=false`). **Rollback:** `.down.sql` drops the function; revert the PR for the code (no DB state).
- **Test:** `tsx --test scripts/audit/runtime-truth/attribution-write-gap.test.ts` → **7/7**. `tsc --noEmit` → **0 errors in the new files** (residual `contract.ts` zod-4 note is pre-existing and identical for the committed sibling `pg-stable-write.ts`). Live CLI against the real DB (service-role) → **`UNKNOWN`** with hint `apply migration adding __gov_m11_attribution_columns()`.
- **Evidence after:** runner reproducible, RPC-absent-tolerant, report gitignored (`audit-reports/`). No CI job runs these runners → merge introduces no new check.
- **Verdict:** `GO` (code + inert migration file). Migration APPLY → separate `OWNER_DECISION`.
- **Next action:** **Owner** applies `20260705_gov_m11_attribution_columns_rpc.sql` to the shared Supabase (owner-gated), then `npm run audit:runtime-truth` promotes the runner from `UNKNOWN` to real findings.

### Post-fix simplification
```
DELETE     — none (no workaround/dead path obsoleted; extends __gov_* family)
REUSE      — runner.ts harness, contract.ts schema, __gov_m10 migration template, getServiceClient env-gate
MERGE      — none
KEEP       — separate __gov_m11 RPC (information_schema + pg_stat not PostgREST-reachable; one responsibility per __gov_m*)
SOT IMPACT — NONE (new governed introspection surface; no second representation of existing truth)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
