### PR TITLE
fix(seo/metadata): admin-guard all served-metadata write endpoints (P0 broken access control)

### DIFF
--- a/backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts
+++ b/backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts
@@ -11,11 +11,21 @@
  * ✅ POST /api/breadcrumb/cache/clear     → Nettoyage cache
  */
 
-import { Controller, Get, Post, Body, Query, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
 import {
   OptimizedBreadcrumbService,
   BreadcrumbItem,
 } from '../services/optimized-breadcrumb.service';
+import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { IsAdminGuard } from '@auth/is-admin.guard';
 import { OperationFailedException } from '@common/exceptions';
 import { SplatPath } from '@common/decorators';
 
@@ -143,6 +153,7 @@ export class OptimizedBreadcrumbController {
    * POST /api/breadcrumb/:path
    */
   @Post('{*path}')
+  @UseGuards(AuthenticatedGuard, IsAdminGuard)
   async updateBreadcrumb(
     @SplatPath() path: string,
     @Body() breadcrumbData: any,

--- a/backend/src/modules/metadata/controllers/optimized-metadata.controller.ts
+++ b/backend/src/modules/metadata/controllers/optimized-metadata.controller.ts
@@ -9,12 +9,22 @@
  * ✅ DELETE /api/metadata/:path  → Supprimer métadonnées
  */
 
-import { Controller, Get, Put, Delete, Body, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Put,
+  Delete,
+  Body,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
 import {
   OptimizedMetadataService,
   PageMetadata,
   MetadataUpdateData,
 } from '../services/optimized-metadata.service';
+import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { IsAdminGuard } from '@auth/is-admin.guard';
 import { OperationFailedException } from '@common/exceptions';
 import { SplatPath } from '@common/decorators';
 
@@ -61,6 +71,7 @@ export class OptimizedMetadataController {
    * PUT /api/metadata/:path
    */
   @Put('{*path}')
+  @UseGuards(AuthenticatedGuard, IsAdminGuard)
   async updateMetadata(
     @SplatPath() path: string,
     @Body() updateData: MetadataUpdateData,
@@ -95,6 +106,7 @@ export class OptimizedMetadataController {
    * DELETE /api/metadata/:path
    */
   @Delete('{*path}')
+  @UseGuards(AuthenticatedGuard, IsAdminGuard)
   async deleteMetadata(
     @SplatPath() path: string,
   ): Promise<{ success: boolean; message: string }> {

--- a/backend/src/modules/seo/seo.controller.ts
+++ b/backend/src/modules/seo/seo.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { SeoService } from './seo.service';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { IsAdminGuard } from '@auth/is-admin.guard';
 import { UrlCompatibilityService } from './validation/url-compatibility.service';
 import { SeoKpisService } from './services/seo-kpis.service';
 import { OperationFailedException } from '@common/exceptions';
@@ -83,7 +84,7 @@ export class SeoController {
    * PUT /seo/metadata - Met à jour les métadonnées SEO d'une page
    */
   @Put('metadata')
-  @UseGuards(AuthenticatedGuard)
+  @UseGuards(AuthenticatedGuard, IsAdminGuard)
   async updateMetadata(@Body() metadataDto: MetadataDto) {
     try {
       const result = await this.seoService.updateMetadata(
@@ -222,7 +223,7 @@ export class SeoController {
    * POST /seo/batch-update - Met à jour les métadonnées en lot
    */
   @Post('batch-update')
-  @UseGuards(AuthenticatedGuard)
+  @UseGuards(AuthenticatedGuard, IsAdminGuard)
   async batchUpdateMetadata(@Body() metadataList: MetadataDto[]) {
     try {
       const results = [];

--- a/backend/tests/unit/route-splat-characterization.test.ts
+++ b/backend/tests/unit/route-splat-characterization.test.ts
@@ -35,6 +35,7 @@ import { SeoService } from '../../src/modules/seo/seo.service';
 import { UrlCompatibilityService } from '../../src/modules/seo/validation/url-compatibility.service';
 import { SeoKpisService } from '../../src/modules/seo/services/seo-kpis.service';
 import { AuthenticatedGuard } from '../../src/auth/authenticated.guard';
+import { IsAdminGuard } from '../../src/auth/is-admin.guard';
 
 describe('Route splat characterization (PR-9f URL contract)', () => {
   let app: INestApplication;
@@ -72,6 +73,12 @@ describe('Route splat characterization (PR-9f URL contract)', () => {
       ],
     })
       .overrideGuard(AuthenticatedGuard)
+      .useValue({ canActivate: () => true })
+      // Metadata PUT/DELETE + breadcrumb POST are admin-guarded (served-metadata
+      // write authz P0). This suite characterizes URL decoding, not authz, so we
+      // bypass the admin boundary too — enforcement is covered by
+      // tests/unit/seo-metadata-authz.test.ts.
+      .overrideGuard(IsAdminGuard)
       .useValue({ canActivate: () => true })
       .compile();
 

--- a/backend/tests/unit/seo-metadata-authz.test.ts
+++ b/backend/tests/unit/seo-metadata-authz.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Served-metadata write authorization — broken-access-control P0.
+ *
+ * All HTTP-reachable mutators of the SERVED `___meta_tags_ariane` table must
+ * require an admin session (isAdmin === true OR level >= 7), i.e. the canonical
+ * `@UseGuards(AuthenticatedGuard, IsAdminGuard)` boundary already used on ~40
+ * admin-write controllers (incl. the sibling `BreadcrumbAdminController` that
+ * writes this exact table).
+ *
+ * Before the fix:
+ *   - `PUT /api/seo/metadata` + `POST /api/seo/batch-update` were guarded by
+ *     `AuthenticatedGuard` ONLY → any logged-in customer (self-register grants a
+ *     level-1 account) could rewrite served meta_title/description/H1/robots.
+ *   - `PUT /api/metadata/{*path}`, `DELETE /api/metadata/{*path}` and
+ *     `POST /api/breadcrumb/{*path}` had NO guard at all → fully anonymous.
+ *
+ * This test asserts the security CONTRACT (anon refused · non-admin refused ·
+ * admin preserved) by evaluating the guards ACTUALLY APPLIED to each handler —
+ * so it fails RED until every mutator wires the canonical admin boundary.
+ *
+ * @see backend/src/modules/seo/seo.controller.ts
+ * @see backend/src/modules/metadata/controllers/optimized-metadata.controller.ts
+ * @see backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts
+ * @see backend/src/auth/is-admin.guard.ts
+ * @see backend/src/auth/authenticated.guard.ts
+ */
+import { ExecutionContext, Type } from '@nestjs/common';
+
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { SeoController } from '../../src/modules/seo/seo.controller';
+import { OptimizedMetadataController } from '../../src/modules/metadata/controllers/optimized-metadata.controller';
+import { OptimizedBreadcrumbController } from '../../src/modules/metadata/controllers/optimized-breadcrumb.controller';
+
+// NestJS stores `@UseGuards(...)` classes under this reflection key
+// (`GUARDS_METADATA` from `@nestjs/common/constants` — stable literal).
+const GUARDS_METADATA = '__guards__';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Same minimal ExecutionContext mock shape as `tests/unit/auth-guards.test.ts`. */
+function createMockExecutionContext(request: any): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => ({}),
+    }),
+    getHandler: () => jest.fn(),
+    getClass: () => jest.fn(),
+  } as unknown as ExecutionContext;
+}
+
+/**
+ * Effective guard chain for a route = class-level guards ++ method-level guards
+ * (both must pass in NestJS). Returns the guard CLASSES as applied by @UseGuards.
+ */
+function effectiveGuards(
+  controller: Type<any>,
+  method: string,
+): Array<Type<any>> {
+  const classGuards: Array<Type<any>> =
+    Reflect.getMetadata(GUARDS_METADATA, controller) || [];
+  const methodGuards: Array<Type<any>> =
+    Reflect.getMetadata(GUARDS_METADATA, controller.prototype[method]) || [];
+  return [...classGuards, ...methodGuards];
+}
+
+/**
+ * Runs the applied guard chain against a request. Denied if ANY guard returns
+ * non-true or throws. An empty chain (no guards) => allowed — which is exactly
+ * how an unguarded endpoint lets anyone through.
+ */
+function isAllowed(guards: Array<Type<any>>, request: any): boolean {
+  const ctx = createMockExecutionContext(request);
+  for (const Guard of guards) {
+    const instance = new Guard();
+    let result: unknown;
+    try {
+      result = instance.canActivate(ctx);
+    } catch {
+      return false; // guard threw (e.g. UnauthorizedException) => denied
+    }
+    if (result !== true) return false;
+  }
+  return true;
+}
+
+// ─── Principals ───────────────────────────────────────────────────────────────
+
+const anonymous = () => ({
+  path: '/x',
+  isAuthenticated: () => false,
+  user: undefined,
+});
+
+// A logged-in NON-admin customer — exactly what public self-register grants.
+const nonAdminCustomer = () => ({
+  path: '/x',
+  isAuthenticated: () => true,
+  user: { email: 'customer@test.com', isAdmin: false, level: '1' },
+});
+
+const admin = () => ({
+  path: '/x',
+  isAuthenticated: () => true,
+  user: { email: 'admin@test.com', isAdmin: true, level: '9' },
+});
+
+// ─── The complete served-metadata mutator surface ─────────────────────────────
+
+const WRITE_ENDPOINTS: Array<{
+  label: string;
+  controller: Type<any>;
+  method: string;
+}> = [
+  { label: 'PUT /api/seo/metadata', controller: SeoController, method: 'updateMetadata' },
+  { label: 'POST /api/seo/batch-update', controller: SeoController, method: 'batchUpdateMetadata' },
+  { label: 'PUT /api/metadata/{*path}', controller: OptimizedMetadataController, method: 'updateMetadata' },
+  { label: 'DELETE /api/metadata/{*path}', controller: OptimizedMetadataController, method: 'deleteMetadata' },
+  { label: 'POST /api/breadcrumb/{*path}', controller: OptimizedBreadcrumbController, method: 'updateBreadcrumb' },
+];
+
+describe('served-metadata write endpoints enforce the admin boundary (P0 broken access control)', () => {
+  describe.each(WRITE_ENDPOINTS)('$label', ({ controller, method }) => {
+    it('wires the canonical AuthenticatedGuard + IsAdminGuard', () => {
+      const guards = effectiveGuards(controller, method);
+      expect(guards).toContain(AuthenticatedGuard);
+      expect(guards).toContain(IsAdminGuard);
+    });
+
+    it('refuses anonymous requests', () => {
+      expect(isAllowed(effectiveGuards(controller, method), anonymous())).toBe(false);
+    });
+
+    it('refuses authenticated non-admin (level 1) requests', () => {
+      expect(isAllowed(effectiveGuards(controller, method), nonAdminCustomer())).toBe(false);
+    });
+
+    it('allows admin (isAdmin / level >= 7) — existing behavior preserved', () => {
+      expect(isAllowed(effectiveGuards(controller, method), admin())).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## P0 — Broken access control on served-metadata mutations

Surfaced by Tranche B1a (served-output-first audit). **Every** HTTP-reachable mutator of the served `___meta_tags_ariane` table (consumed by R8 meta/title/breadcrumbs/robots) was under-guarded:

| Endpoint | Module | Guard before | Guard after |
|----------|--------|--------------|-------------|
| `PUT /api/seo/metadata` | seo | `AuthenticatedGuard` | `AuthenticatedGuard, IsAdminGuard` |
| `POST /api/seo/batch-update` | seo | `AuthenticatedGuard` | `AuthenticatedGuard, IsAdminGuard` |
| `PUT /api/metadata/{*path}` | metadata | **none (anonymous)** | `AuthenticatedGuard, IsAdminGuard` |
| `DELETE /api/metadata/{*path}` | metadata | **none (anonymous)** | `AuthenticatedGuard, IsAdminGuard` |
| `POST /api/breadcrumb/{*path}` | metadata | **none (anonymous)** | `AuthenticatedGuard, IsAdminGuard` |

**Impact:** the two `/api/seo/*` routes accepted any logged-in customer — and public self-register (`POST /auth/register`) grants a level-1 account — so any visitor could rewrite served `meta_title` / `description` / `H1` / `content` / `robots` (flip `noindex`) on arbitrary URLs. The three `/api/metadata` + `/api/breadcrumb` routes required **no authentication at all** (anonymous write/delete). `MetadataModule` is mounted (`app.module.ts:252`).

## Fix

Reuse the **canonical existing admin boundary** — `@UseGuards(AuthenticatedGuard, IsAdminGuard)` — already applied to ~40 admin-write controllers, including the sibling `BreadcrumbAdminController` (`admin/breadcrumbs`) that writes this exact table. **No new guard.** Applied method-level to the 5 write handlers only; every `@Get` read is unchanged (mission = served-metadata *mutations*).

Scope confirmed complete: these 5 are the entire HTTP-reachable write surface of `___meta_tags_ariane` (`seoService.updateMetadata` → `upsert`; `optimizedMetadata.update/deletePageMetadata` → `upsertWithoutReturn`/`deleteByAlias`; `breadcrumb.updateBreadcrumb` → `insert`/`updateById`). The service methods `deleteMetadata`/`getAllMetadata` are reachable only via the already-admin-guarded `BreadcrumbAdminController`. No frontend caller writes `/api/metadata` or `/api/breadcrumb`; the admin SEO page (`admin.seo.tsx`) writes `/api/seo/*` as an admin, so behavior is preserved.

## Tests (RED → GREEN → adversarial)

- **New** `tests/unit/seo-metadata-authz.test.ts` — evaluates the guards *actually applied* to each of the 5 handlers against 3 principals (anonymous / non-admin level-1 / admin). Contract: anon refused · non-admin refused · admin preserved · wiring present.
  - **RED** (pre-fix): 13 failing assertions — seo routes let the level-1 customer through; metadata/breadcrumb routes let anonymous through.
  - **GREEN** (post-fix): 20/20.
  - **Mutation-verified**: reverting `IsAdminGuard` on the anonymous `DELETE` route re-fails exactly that route's non-admin + wiring assertions.
- **Updated** `tests/unit/route-splat-characterization.test.ts` — this URL-decode characterization suite now also `.overrideGuard(IsAdminGuard)` (it isolates routing, not authz).
- `tsc --noEmit` clean. Affected suites: 47/47 pass.

## Out of scope (deferred, not mixed in)

Payload/business validation of metadata bodies; RAG→served closure; `ContentWriteGate`; ast-grep contract; R8 outbox; B1b; migrations. `POST /api/breadcrumb/cache/clear` (cache-invalidation, not a served-content write) left as-is.

## ⚠️ Draft — owner-gated

No merge / flag / PROD / migration. Awaiting owner review + nominal GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)