### PR TITLE
ci(registry): self-heal deps.json + modernization inventory on main (ADR-058/062)

### DIFF
--- a/.github/workflows/registry-deps-self-heal.yml
+++ b/.github/workflows/registry-deps-self-heal.yml
@@ -1,0 +1,185 @@
+name: ♻️ Registry deps self-heal (main)
+
+# ADR-058/062 Repository Control Plane — the HEALING counterpart to the DETECTION
+# freshness gates (dependency-registry-freshness.yml + dependency-modernization-fresh.yml).
+#
+# WHY THIS EXISTS
+# ---------------
+# Two dependency-update paths write the workspace manifests with ASYMMETRIC
+# registry handling:
+#   - dependency-family-bump.yml (internal) regenerates deps.json + the PR-9
+#     modernization inventory in the SAME PR (its "Regenerate ..." steps).
+#   - Dependabot bumps a manifest but NEVER regenerates those projections.
+# So every Dependabot PR — and any manual bump — lands a manifest change without
+# refreshing the two deterministic projections:
+#     audit/registry/deps.json
+#     audit/dependencies/dependency-modernization-inventory.json
+# The freshness gates DETECT this drift but do not repair it, and neither is a
+# REQUIRED status check, so the drift can reach `main` ("green but wrong"). This
+# workflow closes the source→projection freshness loop on `main` for ALL bump
+# sources by regenerating the two projections from the live manifests and
+# committing them back. Root finding: audit/p0-rag-runtime-and-version-truth-2026-07-04.md §3.1.
+#
+# SCOPE (deliberately minimal — no scope creep)
+# ---------------------------------------------
+#   - Regenerates ONLY the two projections the freshness gates check, via the
+#     SAME governed scripts the family-bump uses:
+#       npm run registry:build:deps                  -> audit/registry/deps.json
+#       npm run audit:pr-9-modernization-inventory   -> audit/dependencies/dependency-modernization-inventory.json
+#   - Does NOT regenerate canonical.json / REPO_MAP.md — separate blast radius:
+#     a deps bump must not drag the unified L3 projection (memory
+#     feedback_canonical_json_unified_projection_separate_blast_radius).
+#   - Idempotent: a run on an already-fresh tree stages nothing -> no commit, no noise.
+#   - Scope-guarded: fails loud if regeneration touched ANY file other than the
+#     two projections (mirrors dependency-family-bump.yml's scope-dirty gate).
+#     No silent fallback — CLAUDE.md "No silent fallback".
+#
+# PUSH MODEL
+# ----------
+# `main` has no "require a pull request" rule (branch protection
+# required_pull_request_reviews absent) and no push restrictions, so a direct
+# push with the default GITHUB_TOKEN (contents: write) is permitted. The commit
+# touches only the two projection files (NOT in this workflow's trigger paths),
+# and commits made with GITHUB_TOKEN do not spawn new workflow runs, so it
+# cannot loop. If a future branch-protection change rejects the push, this job
+# FAILS LOUDLY — switch to a peter-evans/create-pull-request self-heal PR
+# (canon-sync.yml pattern; a registry-only PR passes the freshness gates itself).
+# >>> FIRST-RUN VERIFICATION: dispatch this workflow once on main and confirm the
+#     push is accepted before relying on it (runtime-verification doctrine).
+#
+# SUPPLY-CHAIN
+# ------------
+# Runs on `main` AFTER human review of the merge; `npm ci --ignore-scripts`
+# neutralizes package lifecycle scripts. The builders are pure fs/crypto and
+# never execute the bumped dependency's code.
+#
+# WHERE IT RUNS: `runs-on: ubuntu-latest` = GitHub CLOUD runner, never the DEV
+# machine. Works with DEV off (proof: diag-canon-slugs-export.yml, same runner).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - "backend/package.json"
+      - "frontend/package.json"
+      - "packages/*/package.json"
+      - "package-lock.json"
+      - "scripts/registry/build-deps-registry.js"
+      - "scripts/registry/lib/**"
+      - "scripts/audit/build-dependency-modernization-inventory.ts"
+      - "scripts/audit/dependency-modernization.schema.ts"
+      - "audit/dependencies/family-overlay.yaml"
+  schedule:
+    # Daily 02:30 UTC backstop — catches drift the push trigger missed (e.g.
+    # Dependabot auto-merges landed via GITHUB_TOKEN, which does not re-trigger
+    # push workflows). After diag-canon (02:00) / wiki-exports (02:15).
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+# Least privilege: only what the direct push needs.
+permissions:
+  contents: write
+
+concurrency:
+  # Serialize self-heal runs so two cannot race on the same commit.
+  group: registry-deps-self-heal
+  cancel-in-progress: false
+
+jobs:
+  self-heal:
+    name: Regenerate deps.json + modernization inventory on main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: true
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install (no lifecycle scripts — supply-chain safe)
+        run: npm ci --ignore-scripts
+
+      - name: Regenerate L1 deps registry from live manifests
+        run: npm run registry:build:deps
+
+      - name: Regenerate PR-9 modernization inventory
+        run: npm run audit:pr-9-modernization-inventory
+
+      - name: Scope-guard + stage the two projections
+        id: stage
+        run: |
+          set -euo pipefail
+          DEPS="audit/registry/deps.json"
+          INV="audit/dependencies/dependency-modernization-inventory.json"
+
+          # Every tracked file changed by regeneration (working tree vs HEAD).
+          CHANGED="$(git diff --name-only HEAD -- . | sort -u)"
+          UNEXPECTED="$(printf '%s\n' "$CHANGED" \
+            | grep -vE '^(audit/registry/deps\.json|audit/dependencies/dependency-modernization-inventory\.json)$' \
+            || true)"
+          if [ -n "$UNEXPECTED" ]; then
+            {
+              echo "## ❌ Registry self-heal touched unexpected files"
+              echo ""
+              echo "Regeneration must change ONLY the two projections. Unexpected:"
+              echo '```'
+              printf '%s\n' "$UNEXPECTED"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::self-heal changed files outside the two allowlisted projections — aborting (no commit)."
+            exit 1
+          fi
+
+          git add -- "$DEPS" "$INV"
+          if git diff --cached --quiet -- "$DEPS" "$INV"; then
+            echo "status=identical" >> "$GITHUB_OUTPUT"
+            echo "✓ deps.json + inventory already fresh — idempotent no-op."
+          else
+            echo "status=changed" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --cached --stat -- "$DEPS" "$INV"
+          fi
+
+      - name: Commit + push to main
+        if: steps.stage.outputs.status == 'changed'
+        # Hardening: trusted GitHub context values are passed via env (never
+        # interpolated directly into the shell) per workflow-injection guidance.
+        env:
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "automecanik-bot"
+          git config user.email "automecanik-bot@users.noreply.github.com"
+          git commit \
+            -m "chore(registry): self-heal deps.json + modernization inventory" \
+            -m "Auto-generated by .github/workflows/registry-deps-self-heal.yml (run ${RUN_ID})." \
+            -m "Regenerated from live workspace manifests via 'npm run registry:build:deps' + 'npm run audit:pr-9-modernization-inventory'." \
+            -m "Trigger: ${EVENT_NAME} @ ${COMMIT_SHA}." \
+            -m "DO NOT EDIT manually — projections derived from package.json (ADR-058/062)."
+          # Rebase onto the latest main in case it advanced since checkout.
+          git pull --rebase origin main
+          git push origin HEAD:main
+
+      - name: Summary
+        if: always()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RESULT: ${{ steps.stage.outputs.status || 'aborted-or-error' }}
+        run: |
+          {
+            echo "# ♻️ Registry deps self-heal"
+            echo ""
+            echo "- Trigger: \`${EVENT_NAME}\`"
+            echo "- Result: \`${RESULT}\`"
+            echo ""
+            echo "_Regenerates audit/registry/deps.json + audit/dependencies/dependency-modernization-inventory.json from the live manifests. Idempotent, scope-guarded, direct-push to main (GITHUB_TOKEN)._"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problème (structurel, exposé par la PR Dependabot #1101)

Deux chemins de mise à jour de dépendances écrivent les manifests avec un traitement registry **asymétrique** :

| Chemin | Régénère les projections registry ? |
|--------|-------------------------------------|
| `dependency-family-bump.yml` (interne) | **OUI** — [lignes 90-100](https://github.com/ak125/nestjs-remix-monorepo/blob/main/.github/workflows/dependency-family-bump.yml#L90-L100) |
| **Dependabot** | **NON** — bump manifeste seulement |

Résultat : toute PR Dependabot (et tout bump manuel) fait dériver les 2 projections déterministes :
- `audit/registry/deps.json`
- `audit/dependencies/dependency-modernization-inventory.json`

Les gates de fraîcheur (`dependency-registry-freshness.yml`, `dependency-modernization-fresh.yml`) **détectent** la dérive mais ne la **réparent** pas, et **aucun des deux n'est un required check** → la dérive peut atterrir sur `main` (*green-but-wrong*). C'est le défaut « pas de fermeture source→projection » de `audit/p0-rag-runtime-and-version-truth-2026-07-04.md` §3.1.

## Fix — le pendant *HEALING* des gates de *DETECTION*

Un workflow `push:main` (manifests/lockfile) **+ `schedule` quotidien (filet)** **+ `workflow_dispatch`** qui régénère les 2 projections via **les mêmes scripts gouvernés** que le family-bump, et les recommit sur `main`.

- **Portée minimale** : seulement les 2 projections que les gates vérifient. **Ne touche PAS** `canonical.json`/`REPO_MAP.md` (blast radius séparé).
- **Idempotent** : no-op sur un arbre déjà frais.
- **Scope-guardé** : échoue *loud* si la régénération touche tout autre fichier (miroir du scope-dirty gate du family-bump). Pas de silent fallback.
- **Supply-chain safe** : tourne sur `main` **après** revue humaine ; `npm ci --ignore-scripts` ; les builders sont fs/crypto purs, n'exécutent jamais le code de la dépendance bumpée.
- **Couvre toutes les sources** : Dependabot (minor auto-merge & major humain), family-bump, bump manuel.

## Preuves (exécutées, pas déduites)

1. **Idempotence** : `node scripts/registry/build-deps-registry.js` sur `origin/main` (c79bac177) → **zéro diff**. Self-heal = no-op propre sur main inchangé.
2. **End-to-end** : en simulant l'état post-merge de #1101 (manifeste → `^29.15.4`), le builder régénère `deps.json` avec un diff **identique byte-for-byte** à celui que la CI de #1101 attendait (mêmes hashes d'index `4ee488ba1..b795bd1d1`, même hunk). → le self-heal réparerait bien la dérive de #1101.
3. YAML validé (triggers/permissions/steps cohérents).

## Modèle de push + ⚠️ vérification 1er run

`main` n'a **pas** de règle « require a pull request » (branch protection `required_pull_request_reviews` absent) ni de restriction de push → push direct via `GITHUB_TOKEN` (`contents: write`) autorisé. Le commit ne touche que les 2 projections (hors trigger paths) et les commits `GITHUB_TOKEN` ne re-déclenchent pas de workflow → pas de boucle.

> **À valider au 1er run** (doctrine runtime-verification) : `workflow_dispatch` sur `main` une fois et confirmer que le push est accepté. Si une future branch-protection le refuse, le job **échoue loud** → basculer vers une self-heal PR `peter-evans` (pattern `canon-sync.yml` ; une PR registry-only passe les gates de fraîcheur elle-même).

## Effet sur #1101

Une fois ce workflow en place, #1101 (major dev-dep **safe** — peer eslint `^8.57.1` ✅, tous les 13 required checks verts) peut être mergé par l'owner ; `main` s'auto-répare au push (ou au filet quotidien). Plus jamais de push manuel one-off sur une branche bot.

## Non-goals

- ❌ Ne modifie pas la branch protection (câbler l'inventory gate comme *required* = décision owner séparée).
- ❌ Ne régénère pas `canonical.json` (blast radius séparé).
- ❌ N'auto-merge pas #1101 (major = décision owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)