### PR TITLE
chore(registry): heal deps.json + modernization inventory for eslint-plugin-jest@29 (#1101)

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:f99e660b1ea68bd8d5696738e2f815311c8041c12496d89134a0bb0f3b7a0e82",
+  "artifact_immutability_hash": "sha256:1191d1aa57a138a21d9265aed75300caaead03629f18af01a24b72450f32c497",
   "divergences": [
     {
       "kind": "resolved",
@@ -3722,9 +3722,9 @@
   ],
   "generatedFrom": {
     "deps_registry": "audit/registry/deps.json",
-    "deps_registry_sha": "sha256:a580f64acf4bb9bea3d25c935e014765913150f69ac4073803b4f650b2c35b72",
+    "deps_registry_sha": "sha256:0a5ec75ceca9c462dce64d4d53db9a93feafeb7b699e1aedb82a2da59e2b2a24",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:dc7c5bd4696d0359ce2883ef4c195ae1316ac725c5de79360f5779b0b29874b5",
+    "lockfile_sha": "sha256:d786acd4ed9e319b7b3cc3e1b18684c1ab54502bce59e7715c746a19befa949e",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:f5b19e7c0c73a75b55e4c0a620e0d01c6665dfcfffe8b00a77d5c8928bb05117"
   },
@@ -5257,12 +5257,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^28.14.0",
+          "specifier": "^29.15.4",
           "workspace": "@fafa/frontend"
         }
       ],
       "resolved_versions": [
-        "28.14.0"
+        "29.15.4"
       ]
     },
     {

--- a/audit/registry/deps.json
+++ b/audit/registry/deps.json
@@ -2094,14 +2094,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:eslint-plugin-jest@^28.14.0",
+      "id": "npm:eslint-plugin-jest@^29.15.4",
       "name": "eslint-plugin-jest",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^28.14.0",
+      "version": "^29.15.4",
       "workspaces": [
         "@fafa/frontend"
       ]


### PR DESCRIPTION
## Quoi

Régénère les 2 projections registry déterministes après le merge de #1101 (`eslint-plugin-jest` 28→29). Dependabot bump le manifeste mais ne régénère jamais `audit/registry/deps.json` + `audit/dependencies/dependency-modernization-inventory.json` → `main` était en *green-but-wrong*.

Produit par `npm run registry:build:deps` + `npm run audit:pr-9-modernization-inventory`. Diff = **2 fichiers, 7/7 lignes** (portée stricte).

## Pourquoi une PR manuelle et pas le self-heal (#1240)

Le self-heal a **tourné mais échoué au push** : `enforce_admins:true` + 13 required status checks → `main` refuse tout push direct dont le commit n'a pas ses checks (`GH006: protected branch hook declined`). Une identité bot (GitHub App/PAT) est requise pour automatiser — décision owner (voir fil de session). Cette PR, poussée normalement, **fait tourner la CI** → les gates de fraîcheur passent au vert (la PR contient les projections fraîches).

## Vérif

- Diff = exactement les 2 projections, deps.json = `eslint-plugin-jest@^29.15.4`.
- Les gates `deps.json fresh` + `Modernization Inventory determinism` doivent passer **verts** sur cette PR (contrairement à #1101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)