### PR TITLE
chore(registry): heal deps.json + modernization inventory for tiptap 3.27.3 (#1249)

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:1191d1aa57a138a21d9265aed75300caaead03629f18af01a24b72450f32c497",
+  "artifact_immutability_hash": "sha256:562a89ba928dc1d1143cac5f36916a0c251851e7bb3db8452536226732b71044",
   "divergences": [
     {
       "kind": "resolved",
@@ -3722,9 +3722,9 @@
   ],
   "generatedFrom": {
     "deps_registry": "audit/registry/deps.json",
-    "deps_registry_sha": "sha256:0a5ec75ceca9c462dce64d4d53db9a93feafeb7b699e1aedb82a2da59e2b2a24",
+    "deps_registry_sha": "sha256:6f667991be593e37b2798c4ca0f0689d89c412731aa2bdf50000248da9f2c5bd",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:d786acd4ed9e319b7b3cc3e1b18684c1ab54502bce59e7715c746a19befa949e",
+    "lockfile_sha": "sha256:573155a005ff858ad576d8cef1aa827c5a1131449ee09b1ad83823d86f152e45",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:f5b19e7c0c73a75b55e4c0a620e0d01c6665dfcfffe8b00a77d5c8928bb05117"
   },
@@ -4387,12 +4387,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^3.26.1",
+          "specifier": "^3.27.3",
           "workspace": "@fafa/frontend"
         }
       ],
       "resolved_versions": [
-        "3.27.1"
+        "3.27.3"
       ]
     },
     {
@@ -4402,12 +4402,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^3.26.1",
+          "specifier": "^3.27.3",
           "workspace": "@fafa/frontend"
         }
       ],
       "resolved_versions": [
-        "3.27.1"
+        "3.27.3"
       ]
     },
     {
@@ -4422,7 +4422,7 @@
         }
       ],
       "resolved_versions": [
-        "3.27.1"
+        "3.27.3"
       ]
     },
     {
@@ -4432,12 +4432,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^3.26.1",
+          "specifier": "^3.27.3",
           "workspace": "@fafa/frontend"
         }
       ],
       "resolved_versions": [
-        "3.27.1"
+        "3.27.3"
       ]
     },
     {
@@ -4447,12 +4447,12 @@
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^3.26.1",
+          "specifier": "^3.27.3",
           "workspace": "@fafa/frontend"
         }
       ],
       "resolved_versions": [
-        "3.27.1"
+        "3.27.3"
       ]
     },
     {

--- a/audit/registry/deps.json
+++ b/audit/registry/deps.json
@@ -980,14 +980,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@tiptap/extension-bold@^3.26.1",
+      "id": "npm:@tiptap/extension-bold@^3.27.3",
       "name": "@tiptap/extension-bold",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^3.26.1",
+      "version": "^3.27.3",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -996,14 +996,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@tiptap/extension-italic@^3.26.1",
+      "id": "npm:@tiptap/extension-italic@^3.27.3",
       "name": "@tiptap/extension-italic",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^3.26.1",
+      "version": "^3.27.3",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -1028,14 +1028,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@tiptap/react@^3.26.1",
+      "id": "npm:@tiptap/react@^3.27.3",
       "name": "@tiptap/react",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^3.26.1",
+      "version": "^3.27.3",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -1044,14 +1044,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@tiptap/starter-kit@^3.26.1",
+      "id": "npm:@tiptap/starter-kit@^3.27.3",
       "name": "@tiptap/starter-kit",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^3.26.1",
+      "version": "^3.27.3",
       "workspaces": [
         "@fafa/frontend"
       ]


### PR DESCRIPTION
Même heal mécanique que #1242 : #1249 (groupe tiptap ×5, auto-mergé) a bumpé les manifests sans régénérer les 2 projections registry. Régénéré via `npm run registry:build:deps` + `npm run audit:pr-9-modernization-inventory`. Diff = 2 fichiers, 20/20 lignes. Les gates de fraîcheur doivent passer verts sur cette PR. Récurrent tant que la GitHub App (#1244) n'est pas provisionnée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)