### PR TITLE
fix(checkout): tunnel paiement — redirect Paybox depuis la réponse du POST (SEV1 leg 1) + resume email

### DIFF
--- a/backend/src/modules/orders/controllers/orders.controller.ts
+++ b/backend/src/modules/orders/controllers/orders.controller.ts
@@ -360,7 +360,14 @@ export class OrdersController {
         const existing = await this.checkIdempotency(idempotencyKey, fp);
         if (existing) {
           const resumeToken = await this.generateResumeToken(existing.existing);
-          return { ord_id: existing.existing, resumeToken };
+          // Même shape que le happy path : le checkout construit le redirect
+          // Paybox depuis CETTE réponse (total + customer.cst_mail), sans
+          // re-GET /api/orders/:id — le cookie de l'action peut être invalide
+          // après régénération de session (INC tunnel paiement 2026-05→07).
+          const existingOrder = await this.ordersService.getOrderById(
+            existing.existing,
+          );
+          return { ...existingOrder, resumeToken };
         }
       }
 
@@ -453,7 +460,14 @@ export class OrdersController {
         const existing = await this.checkIdempotency(idempotencyKey, fp);
         if (existing) {
           const resumeToken = await this.generateResumeToken(existing.existing);
-          return { ord_id: existing.existing, resumeToken };
+          // Même shape que le happy path : le checkout construit le redirect
+          // Paybox depuis CETTE réponse (total + customer.cst_mail), sans
+          // re-GET /api/orders/:id — le cookie de l'action peut être invalide
+          // après régénération de session (INC tunnel paiement 2026-05→07).
+          const existingOrder = await this.ordersService.getOrderById(
+            existing.existing,
+          );
+          return { ...existingOrder, resumeToken };
         }
       }
 
@@ -582,6 +596,11 @@ export class OrdersController {
         resumeToken = await this.generateResumeToken(finalOrderId);
       }
 
+      // La régénération de session ci-dessus invalide le cookie que porte le
+      // fetch SSR de l'action checkout : cette réponse doit donc contenir tout
+      // le nécessaire au redirect Paybox (ord_total_ttc + customer.cst_mail,
+      // déjà présents via getOrderById) — aucun GET /api/orders/:id ne peut
+      // suivre avec ce cookie (INC tunnel paiement 2026-05→07).
       return { ...(order as object), resumeToken };
     } catch (error) {
       this.logger.error('Error in guest checkout:', error);
@@ -747,11 +766,17 @@ export class OrdersController {
     }
 
     // Récupérer l'email du client
-    const { data: customer } = await supabase
-      .from('___customer')
+    const { data: customer, error: customerError } = await supabase
+      .from('___xtr_customer')
       .select('cst_mail')
       .eq('cst_id', order.ord_cst_id)
       .single();
+    if (customerError || !customer?.cst_mail) {
+      // Email vide ⇒ /api/paybox/redirect répondra 400 — échec observable ici
+      this.logger.warn(
+        `Resume token: cst_mail introuvable pour ${order.ord_cst_id} (order ${order.ord_id})`,
+      );
+    }
 
     // Marquer used_at seulement quand on redirige (pas sur check)
     // Le frontend gère la distinction via ?check=1

--- a/frontend/app/routes/checkout.resume.tsx
+++ b/frontend/app/routes/checkout.resume.tsx
@@ -74,6 +74,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
       };
     }
 
+    // Email vide ⇒ /api/paybox/redirect répond 400 « Paramètres manquants » :
+    // échouer ici de façon observable plutôt que rediriger vers un échec sûr
+    // (INC tunnel paiement 2026-05→07, retries 12/07 avec email= vide).
+    if (!customerEmail) {
+      logger.error("[Resume] customerEmail vide pour la commande:", orderId);
+      throw new Response(
+        "Impossible de récupérer l'email de la commande — contactez le support.",
+        { status: 500 },
+      );
+    }
+
     // Rediriger vers Paybox (le token sera marqué used_at par le backend)
     const redirectUrl = buildPayboxRedirectUrl(
       orderId,

--- a/frontend/app/routes/checkout.tsx
+++ b/frontend/app/routes/checkout.tsx
@@ -56,16 +56,15 @@ import {
   parseCheckoutFormData,
   validateCheckoutClient,
 } from "~/schemas/checkout.schemas";
-import { serverObservabilityContext } from "~/utils/load-context";
 import {
   buildOrderLines,
   buildPayboxRedirectUrl,
   createCheckoutOrder,
-  getOrderForPayment,
 } from "~/services/order.server";
 import { getUserProfile } from "~/services/profile.server";
 import { type PaymentMethod } from "~/types/payment";
 import { trackBeginCheckout, trackAddPaymentInfo } from "~/utils/analytics";
+import { serverObservabilityContext } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
 import { reportLoaderError } from "~/utils/observability.server";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
@@ -311,26 +310,19 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
     const { orderId } = orderResult;
 
-    // 6. Recuperer les details pour Paybox
-    const orderDetails = await getOrderForPayment(request, orderId);
-
-    if (!orderDetails) {
-      logger.error("[Checkout] getOrderForPayment returned null for:", orderId);
-      return data(
-        {
-          ok: false,
-          error: "Commande creee mais impossible de recuperer les details.",
-          code: "PAYMENT_UNAVAILABLE",
-        } satisfies CheckoutActionError,
-        { status: 500 },
-      );
-    }
-
-    if (orderDetails.isPaid) {
+    // 6. Details Paybox lus depuis la reponse du POST de creation — PAS de
+    // GET /api/orders/:id ici : le POST guest regenere la session backend et
+    // le cookie de cette action devient invalide (INC tunnel paiement
+    // 2026-05→07 : ce GET repondait 404 et bloquait le client avant Paybox).
+    if (orderResult.isPaid) {
       return redirect(`/account/orders/${orderId}`);
     }
 
-    if (orderDetails.totalTTC <= 0) {
+    if (orderResult.totalTTC <= 0) {
+      logger.error(
+        "[Checkout] Montant invalide dans la reponse de creation:",
+        orderId,
+      );
       return data(
         {
           ok: false,
@@ -341,7 +333,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
       );
     }
 
-    const customerEmail = orderDetails.customerEmail || guestEmail || "";
+    const customerEmail = orderResult.customerEmail || guestEmail || "";
     if (!customerEmail) {
       return data(
         {
@@ -355,13 +347,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
     logger.log("[Checkout] Order created, building Paybox redirect:", {
       orderId,
-      totalTTC: orderDetails.totalTTC,
+      totalTTC: orderResult.totalTTC,
     });
 
     // 7. Build Paybox redirect URL
     const redirectUrl = buildPayboxRedirectUrl(
       orderId,
-      orderDetails.totalTTC,
+      orderResult.totalTTC,
       customerEmail,
     );
 

--- a/frontend/app/services/order.server.ts
+++ b/frontend/app/services/order.server.ts
@@ -45,7 +45,14 @@ export interface CreateCheckoutOrderPayload {
 }
 
 export type CreateOrderResult =
-  | { success: true; orderId: string; resumeToken?: string }
+  | {
+      success: true;
+      orderId: string;
+      resumeToken?: string;
+      totalTTC: number;
+      customerEmail: string;
+      isPaid: boolean;
+    }
   | {
       success: false;
       error: string;
@@ -54,13 +61,6 @@ export type CreateOrderResult =
       conflictEmail?: string;
       redirect?: string;
     };
-
-export interface OrderPaymentDetails {
-  orderId: string;
-  totalTTC: number;
-  isPaid: boolean;
-  customerEmail: string;
-}
 
 // -- Service functions --
 
@@ -79,7 +79,6 @@ export function buildOrderLines(items: CartItem[]) {
     consigne_unit: item.consigne_unit || 0,
     has_consigne: item.has_consigne || false,
     website_url: item.website_url, // F1 attribution : source d'ajout par-ligne
-
   }));
 }
 
@@ -158,7 +157,12 @@ export async function createCheckoutOrder(
     }
 
     const resumeToken = order.resumeToken || order.resume_token;
-    return { success: true, orderId, resumeToken };
+    return {
+      success: true,
+      orderId,
+      resumeToken,
+      ...extractPaymentFieldsFromCreateOrderResponse(order),
+    };
   } catch (error) {
     logger.error("[Checkout] Order creation error:", error);
     return {
@@ -171,45 +175,28 @@ export async function createCheckoutOrder(
 }
 
 /**
- * Recupere les details d'une commande necessaires pour construire le redirect Paybox.
+ * Extrait de la reponse des POST /api/orders(/guest) les champs necessaires
+ * au redirect Paybox. Le montant/email DOIVENT venir de cette reponse : le
+ * POST guest regenere la session cote backend, donc le cookie porte par
+ * l'action est invalide pour tout fetch ulterieur (INC tunnel paiement
+ * 2026-05→07 : GET /api/orders/:id → 404 → client jamais envoye vers Paybox).
  */
-export async function getOrderForPayment(
-  request: Request,
-  orderId: string,
-): Promise<OrderPaymentDetails | null> {
-  const cookieHeader = request.headers.get("Cookie") || "";
-
-  try {
-    const response = await fetch(
-      getInternalApiUrlFromRequest(`/api/orders/${orderId}`, request),
-      {
-        headers: {
-          Cookie: cookieHeader,
-          "Internal-Call": "true",
-        },
-      },
-    );
-
-    if (!response.ok) {
-      logger.error(
-        `[Checkout] Failed to fetch order ${orderId}: ${response.status}`,
-      );
-      return null;
-    }
-
-    const orderData = await response.json();
-    const details = orderData.data;
-
-    return {
-      orderId,
-      totalTTC: parseFloat(details.ord_total_ttc || "0"),
-      isPaid: parseInt(details.ord_is_pay || "0") !== 0,
-      customerEmail: details.customer?.cst_mail || "",
-    };
-  } catch (error) {
-    logger.error("[Checkout] Error fetching order for payment:", error);
-    return null;
-  }
+export function extractPaymentFieldsFromCreateOrderResponse(
+  order: Record<string, unknown>,
+): { totalTTC: number; customerEmail: string; isPaid: boolean } {
+  const data = (order?.data ?? {}) as Record<string, unknown>;
+  const customer = (order?.customer ?? data?.customer ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const rawTotal = order?.ord_total_ttc ?? data?.ord_total_ttc ?? "0";
+  const rawIsPay = order?.ord_is_pay ?? data?.ord_is_pay ?? "0";
+  return {
+    totalTTC: parseFloat(String(rawTotal)) || 0,
+    customerEmail:
+      typeof customer?.cst_mail === "string" ? customer.cst_mail : "",
+    isPaid: rawIsPay === true || String(rawIsPay) === "1",
+  };
 }
 
 /**

--- a/frontend/tests/unit/checkout.action.test.ts
+++ b/frontend/tests/unit/checkout.action.test.ts
@@ -1,0 +1,140 @@
+import  { type ActionFunctionArgs } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { action } from "~/routes/checkout";
+
+vi.mock("~/utils/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), log: vi.fn(), debug: vi.fn() },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// INC tunnel paiement 2026-05→07 : le POST /api/orders/guest régénère la
+// session backend, donc le cookie porté par l'action est mort pour tout fetch
+// ultérieur. Ce test d'intégration de l'action grave l'invariant : le happy
+// path checkout ne fait AUCUN fetch après le POST de création — le redirect
+// Paybox est construit depuis la réponse du POST.
+function stubFetchRouter(overrides?: { orderResponse?: Record<string, unknown> }) {
+  const calls: Array<{ url: string; method: string }> = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({ url, method });
+
+    if (url.includes("/api/cart")) {
+      return new Response(
+        JSON.stringify({
+          user_id: "guest-session",
+          items: [
+            {
+              id: "i1",
+              product_id: "12345",
+              product_name: "Plaquettes de frein",
+              product_sku: "REF-123",
+              quantity: 1,
+              price: 62.35,
+            },
+          ],
+          totals: { total_items: 1, total: 62.35, subtotal: 62.35 },
+          metadata: {},
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (url.endsWith("/api/orders/guest") && method === "POST") {
+      return new Response(
+        JSON.stringify(
+          overrides?.orderResponse ?? {
+            ord_id: "ORD-42",
+            ord_total_ttc: "62.35",
+            ord_is_pay: "0",
+            customer: { cst_mail: "client@example.com" },
+            resumeToken: "tok-1",
+          },
+        ),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Tout autre fetch (dont GET /api/orders/:id) = régression → échec net
+    throw new Error(`Fetch inattendu dans le happy path checkout: ${method} ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, calls };
+}
+
+function makeGuestCheckoutRequest(): Request {
+  const form = new FormData();
+  form.set("guestEmail", "client@example.com");
+  form.set("civility", "M.");
+  form.set("firstName", "Jean");
+  form.set("lastName", "Testeur");
+  form.set("address", "12 rue de la Paix");
+  form.set("zipCode", "75001");
+  form.set("city", "Paris");
+  form.set("country", "France");
+  form.set("phone", "0601020304");
+  form.set("paymentMethod", "cyberplus");
+  form.set("acceptTerms", "on");
+  return new Request("http://localhost/checkout", {
+    method: "POST",
+    headers: { Cookie: "connect.sid=abc" },
+    body: form,
+  });
+}
+
+const contextStub = {
+  get: () => undefined,
+} as unknown as ActionFunctionArgs["context"];
+
+describe("checkout action — happy path guest sans re-GET (INC 2026-05→07)", () => {
+  it("retourne ok + redirectUrl Paybox construit depuis la réponse du POST", async () => {
+    const { calls } = stubFetchRouter();
+
+    const result = (await action({
+      request: makeGuestCheckoutRequest(),
+      context: contextStub,
+      params: {},
+    } as ActionFunctionArgs)) as Record<string, unknown>;
+
+    expect(result).toMatchObject({
+      ok: true,
+      orderId: "ORD-42",
+      resumeToken: "tok-1",
+    });
+    expect(result.redirectUrl).toBe(
+      "/api/paybox/redirect?orderId=ORD-42&amount=62.35&email=client%40example.com",
+    );
+
+    // Exactement 2 fetches : cart + POST création. Aucun GET /api/orders/:id.
+    const orderGets = calls.filter(
+      (c) => c.method === "GET" && /\/api\/orders\/ORD-/.test(c.url),
+    );
+    expect(orderGets).toEqual([]);
+    expect(calls.some((c) => c.url.endsWith("/api/orders/guest"))).toBe(true);
+  });
+
+  it("email absent de la réponse du POST → fallback sur guestEmail du formulaire", async () => {
+    stubFetchRouter({
+      orderResponse: {
+        ord_id: "ORD-43",
+        ord_total_ttc: "62.35",
+        ord_is_pay: "0",
+        // pas de customer.cst_mail
+        resumeToken: "tok-2",
+      },
+    });
+
+    const result = (await action({
+      request: makeGuestCheckoutRequest(),
+      context: contextStub,
+      params: {},
+    } as ActionFunctionArgs)) as Record<string, unknown>;
+
+    expect(result).toMatchObject({ ok: true, orderId: "ORD-43" });
+    expect(String(result.redirectUrl)).toContain("email=client%40example.com");
+  });
+});

--- a/frontend/tests/unit/order.server.test.ts
+++ b/frontend/tests/unit/order.server.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createCheckoutOrder,
+  extractPaymentFieldsFromCreateOrderResponse,
+  type CreateCheckoutOrderPayload,
+} from "~/services/order.server";
+
+vi.mock("~/utils/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), log: vi.fn(), debug: vi.fn() },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// INC tunnel paiement 2026-05→07 : le POST /api/orders/guest régénère la
+// session backend, donc l'action checkout ne peut PAS re-GET la commande avec
+// son cookie. Tout ce qu'il faut pour le redirect Paybox doit sortir de la
+// réponse du POST — ces tests figent ce contrat.
+describe("extractPaymentFieldsFromCreateOrderResponse", () => {
+  it("lit total/email/isPaid depuis la shape plate getOrderById", () => {
+    expect(
+      extractPaymentFieldsFromCreateOrderResponse({
+        ord_id: "ORD-1",
+        ord_total_ttc: "62.35",
+        ord_is_pay: "0",
+        customer: { cst_mail: "client@example.com" },
+      }),
+    ).toEqual({
+      totalTTC: 62.35,
+      customerEmail: "client@example.com",
+      isPaid: false,
+    });
+  });
+
+  it("lit la shape enveloppée { data: ... } (défensif, idiome existant)", () => {
+    expect(
+      extractPaymentFieldsFromCreateOrderResponse({
+        data: {
+          ord_total_ttc: "41.12",
+          ord_is_pay: "1",
+          customer: { cst_mail: "x@y.fr" },
+        },
+      }),
+    ).toEqual({ totalTTC: 41.12, customerEmail: "x@y.fr", isPaid: true });
+  });
+
+  it("champs absents → totalTTC 0 / email vide / isPaid false (échec visible en aval, pas de devinette)", () => {
+    expect(extractPaymentFieldsFromCreateOrderResponse({})).toEqual({
+      totalTTC: 0,
+      customerEmail: "",
+      isPaid: false,
+    });
+  });
+});
+
+describe("createCheckoutOrder — contrat redirect Paybox sans re-GET", () => {
+  function makeRequest(): Request {
+    return new Request("http://localhost/checkout", {
+      method: "POST",
+      headers: { Cookie: "connect.sid=abc" },
+    });
+  }
+
+  const payload = {
+    guestEmail: "client@example.com",
+    orderLines: [],
+    billingAddress: {},
+    shippingAddress: {},
+    customerNote: "",
+    shippingMethod: "colissimo",
+  } as unknown as CreateCheckoutOrderPayload;
+
+  it("porte totalTTC + customerEmail + isPaid depuis la réponse du POST", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ord_id: "ORD-42",
+            ord_total_ttc: "200.36",
+            ord_is_pay: "0",
+            customer: { cst_mail: "client@example.com" },
+            resumeToken: "tok-1",
+          }),
+          { status: 201 },
+        ),
+      ),
+    );
+
+    const result = await createCheckoutOrder(makeRequest(), payload);
+    expect(result).toEqual({
+      success: true,
+      orderId: "ORD-42",
+      resumeToken: "tok-1",
+      totalTTC: 200.36,
+      customerEmail: "client@example.com",
+      isPaid: false,
+    });
+  });
+
+  it("un seul fetch (POST) — aucun GET /api/orders/:id ne doit suivre", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ord_id: "ORD-43",
+          ord_total_ttc: "10.00",
+          ord_is_pay: "0",
+          customer: { cst_mail: "a@b.fr" },
+        }),
+        { status: 201 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createCheckoutOrder(makeRequest(), payload);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/orders/guest");
+  });
+});

--- a/log.md
+++ b/log.md
@@ -525,3 +525,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tranche-b1b-no-new-unowned-served-write`
 - **Décision** : fix(audit): close 3 ratchet gaps — occurrence-count, removed=fail, SQL DELETE/TRUNCATE (Tranche B1b, #1238 review) (+2 other commits)
 - **Sortie** : PR #1238 | commits fe47346d4 a534d23b6 149bb3a10
+
+## 2026-07-14 — fix/payment-tunnel-guest-session (auto)
+
+- **Branche** : `fix/payment-tunnel-guest-session`
+- **Décision** : fix(checkout): redirect Paybox depuis la réponse du POST — plus de re-GET au cookie invalidé
+- **Sortie** : PR #1256 | commits 67833d2b5

--- a/log.md
+++ b/log.md
@@ -531,3 +531,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/payment-tunnel-guest-session`
 - **Décision** : fix(checkout): redirect Paybox depuis la réponse du POST — plus de re-GET au cookie invalidé
 - **Sortie** : PR #1256 | commits 67833d2b5
+
+## 2026-07-14 — fix/payment-tunnel-guest-session (auto)
+
+- **Branche** : `fix/payment-tunnel-guest-session`
+- **Décision** : test(checkout): intégration action guest — invariant zéro re-GET après le POST (+2 other commits)
+- **Sortie** : PR #1256 | commits 0de18a874 6a877c503 67833d2b5


### PR DESCRIPTION
## Contexte — SEV1 tunnel paiement (0 paiement depuis le 2026-05-19)

Evidence pack complet : `audit/payment-tunnel-sev1-investigation-2026-07-14.md` (§7 = confirmation logs PROD).

**Root cause (leg 1, confirmée par les logs PROD du 11/07)** : l'action `/checkout` crée la commande via un fetch SSR `POST /api/orders/guest`, qui **régénère la session** (l'ancien sid est détruit, le nouveau part dans un `Set-Cookie` que le fetch SSR jette). Le `GET /api/orders/:id` suivant porte donc un cookie mort → 404 (`Unauthenticated access attempt`) → `PAYMENT_UNAVAILABLE` → **le client n'est jamais envoyé vers Paybox** → zéro IPN. L'endpoint guest réutilisant les comptes par email, les clients « enregistrés » non connectés (53353, 50356) sont touchés aussi.

## Changements

1. **`frontend/app/services/order.server.ts` + `checkout.tsx`** — l'action lit `totalTTC` / `customerEmail` / `isPaid` **depuis la réponse du POST de création** (le controller spread déjà `getOrderById` : `ord_total_ttc` + `customer.cst_mail`). Le `GET /api/orders/:id` du happy path est supprimé (`getOrderForPayment` retiré — seul appelant). Le montant reste server-authoritative : `/api/paybox/redirect` re-lit la DB (inchangé).
2. **`backend/.../orders.controller.ts`** — les 2 early-returns d'idempotence renvoyaient `{ord_id, resumeToken}` seulement ; ils renvoient désormais la même shape complète que le happy path (`getOrderById` + `resumeToken`), sinon un double-submit retombait dans le trou.
3. **Bug reprise (hits `email=` vide → 400, 12/07 16:48-16:51)** — `validateResumeToken` interrogeait une table **inexistante `___customer`** (erreur avalée → email toujours vide) → fix `___xtr_customer` + warn observable ; le loader `checkout.resume` échoue désormais fail-loud si l'email reste vide au lieu de rediriger vers un 400 certain.

## Vérifications

- Backend : `tsc` ✅ · eslint ✅ (module payments **non touché**)
- Frontend : `react-router typegen && tsc` ✅ · eslint ✅ (1 warning import/order préexistant sur main) · **vitest 53 fichiers / 430 tests ✅** dont 5 nouveaux (`tests/unit/order.server.test.ts`) qui figent le contrat « un seul fetch, tout depuis le POST »
- DB (read-only) : les 4 `cst_id` victimes ont `cst_mail` renseigné dans `___xtr_customer` → le fix resume résout réellement l'email
- **Gate POST-MERGE requis** (2-gates) : après sync DEV:3000, checkout guest complet → l'action doit retourner `redirectUrl` non-null et la page `/api/paybox/redirect` s'afficher ; puis **canary payment** (procédure incident avril) avant toute clôture

## ⚠️ Ne ferme PAS le SEV1

Le **leg 2 (IPN Paybox→backend)** reste ouvert : le 12/07 le client a atteint la page de redirection Paybox 2× (formulaire PROD vérifié valide) et **aucun IPN n'est arrivé, pas même un refus**. À trancher côté **BO Paybox** (journal depuis le 19/05 — clients débités ?) et **Cloudflare** (Security Events `/api/paybox` + Audit Log 19-22/05). Actions owner listées dans l'audit §7.

Merge = owner. Un merge déploie PREPROD uniquement ; PROD = tag `v*` sur GO nominatif distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)