### PR TITLE
perf(pieces): modale fiche produit → <dialog> natif (INP tap carte, -50% lab)

### DIFF
--- a/frontend/app/components/pieces/PieceDetailModal.tsx
+++ b/frontend/app/components/pieces/PieceDetailModal.tsx
@@ -1,20 +1,21 @@
 /**
- * Modal Detail Piece - Radix Dialog
+ * Modal Detail Piece - <dialog> natif (top-layer)
  *
  * Modal qui s'ouvre au clic sur une piece pour afficher les details
  * Sans changer de page (comme PHP legacy)
  *
- * Utilise Radix Dialog pour :
- * - Portal automatique (pas de createPortal custom)
- * - Focus trap
- * - Scroll lock
- * - Fermeture Escape
- * - Accessibilite (aria-modal, role=dialog)
+ * <dialog> natif via useNativeDialog (meme pattern que le menu Navbar et le
+ * panier CartSidebarSimple, PR #799) : focus-trap, Echap, aria-modal et
+ * scroll-lock fournis par la plateforme. L'ouverture d'un Radix Dialog
+ * executait react-remove-scroll + FocusScope (lectures layout → reflow force
+ * du document) dans le handler du tap carte produit — interaction dominante
+ * de l'INP mobile /pieces (attribution RUM : p75 500ms, max 976ms).
  */
 
-import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { ShoppingCart, ClipboardList, Shield, X } from "lucide-react";
 import { memo, useEffect, useState } from "react";
+
+import { useNativeDialog } from "~/hooks/useNativeDialog";
 
 import { logger } from "~/utils/logger";
 import { useCart } from "../../hooks/useCart";
@@ -98,6 +99,9 @@ export const PieceDetailModal = memo(function PieceDetailModal({
     const fetchPieceDetail = async () => {
       setLoading(true);
       setError(null);
+      // Réouverture sur une autre pièce : purge l'ancienne pour que l'aria-label
+      // du <dialog> n'annonce pas le nom de la pièce précédente pendant le fetch.
+      setPiece(null);
 
       try {
         const response = await fetch(`/api/catalog/pieces/${pieceId}`, {
@@ -140,9 +144,12 @@ export const PieceDetailModal = memo(function PieceDetailModal({
 
   const isOpen = !!pieceId;
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open) onClose();
-  };
+  // Dialog natif pilote par la prop controlee `pieceId` (cf. CartSidebarSimple).
+  const { open, close, dialogProps } = useNativeDialog({ onClose });
+  useEffect(() => {
+    if (isOpen) open();
+    else close();
+  }, [isOpen, open, close]);
 
   const handleAddToCart = async () => {
     if (!piece) return;
@@ -172,433 +179,272 @@ export const PieceDetailModal = memo(function PieceDetailModal({
   };
 
   return (
-    <DialogPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-neutral-900/60 backdrop-blur-xs data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-200" />
-        <DialogPrimitive.Content
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 focus:outline-none"
-          aria-describedby={undefined}
-        >
-          {/* Clic sur la zone vide ferme le modal */}
-          <div className="absolute inset-0" onClick={onClose} />
+    <dialog
+      {...dialogProps}
+      aria-label={
+        piece
+          ? `${piece.nom} - ${piece.marque} ${piece.reference}`
+          : "Detail piece"
+      }
+      className="modal-pop fixed inset-0 m-0 h-full max-h-none w-full max-w-none bg-transparent p-4 backdrop:bg-neutral-900/60 open:flex items-center justify-center"
+    >
+      {/* Contenu pré-rendu (display:none fermé) → showModal() instantané.
+          Clic sur le gutter p-4 ou le backdrop = cible <dialog> → fermeture
+          via dialogProps (remplace l'ancien overlay onClick). */}
+      <div className="relative z-10 w-full max-w-6xl max-h-[90vh] bg-white rounded-2xl shadow-2xl overflow-hidden">
+        {/* Header avec bouton fermer */}
+        <div className="absolute top-4 right-4 z-20">
+          <button
+            type="button"
+            onClick={close}
+            className="w-10 h-10 rounded-full bg-white/90 backdrop-blur-xs shadow-lg hover:bg-gray-100 transition-colors flex items-center justify-center group"
+            aria-label="Fermer"
+          >
+            <X className="w-6 h-6 text-gray-600 group-hover:text-gray-900" />
+          </button>
+        </div>
 
-          {/* Modal content */}
-          <div className="relative z-10 w-full max-w-6xl max-h-[90vh] bg-white rounded-2xl shadow-2xl overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200">
-            {/* Titre accessible (sr-only) */}
-            <DialogPrimitive.Title className="sr-only">
-              {piece
-                ? `${piece.nom} - ${piece.marque} ${piece.reference}`
-                : "Detail piece"}
-            </DialogPrimitive.Title>
-
-            {/* Header avec bouton fermer */}
-            <div className="absolute top-4 right-4 z-20">
-              <DialogPrimitive.Close
-                className="w-10 h-10 rounded-full bg-white/90 backdrop-blur-xs shadow-lg hover:bg-gray-100 transition-colors flex items-center justify-center group"
-                aria-label="Fermer"
-              >
-                <X className="w-6 h-6 text-gray-600 group-hover:text-gray-900" />
-              </DialogPrimitive.Close>
+        {/* Contenu scrollable */}
+        <div className="overflow-y-auto max-h-[90vh] custom-scrollbar">
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-500 border-t-transparent"></div>
             </div>
+          ) : error ? (
+            <div className="p-8 text-center">
+              <p className="text-red-600 mb-4">{error}</p>
+              <button
+                onClick={close}
+                className="text-blue-600 hover:text-blue-700 font-medium"
+              >
+                Fermer
+              </button>
+            </div>
+          ) : piece ? (
+            <div className="p-8">
+              {/* Header avec logo, marque et titre - Pleine largeur */}
+              <div className="flex items-start gap-4 mb-6">
+                <BrandLogo
+                  logoPath={piece.marque_logo || null}
+                  brandName={piece.marque}
+                  type="equipementier"
+                  size={64}
+                />
+                <div className="flex-1">
+                  <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                    {piece.nom}
+                  </h2>
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-bold text-gray-600 uppercase">
+                      {piece.marque}
+                    </span>
+                    <span className="text-base font-mono font-bold text-blue-700">
+                      {piece.reference}
+                    </span>
+                  </div>
+                </div>
+              </div>
 
-            {/* Contenu scrollable */}
-            <div className="overflow-y-auto max-h-[90vh] custom-scrollbar">
-              {loading ? (
-                <div className="flex items-center justify-center py-20">
-                  <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-500 border-t-transparent"></div>
-                </div>
-              ) : error ? (
-                <div className="p-8 text-center">
-                  <p className="text-red-600 mb-4">{error}</p>
-                  <button
-                    onClick={onClose}
-                    className="text-blue-600 hover:text-blue-700 font-medium"
-                  >
-                    Fermer
-                  </button>
-                </div>
-              ) : piece ? (
-                <div className="p-8">
-                  {/* Header avec logo, marque et titre - Pleine largeur */}
-                  <div className="flex items-start gap-4 mb-6">
-                    <BrandLogo
-                      logoPath={piece.marque_logo || null}
-                      brandName={piece.marque}
-                      type="equipementier"
-                      size={64}
-                    />
-                    <div className="flex-1">
-                      <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                        {piece.nom}
-                      </h2>
-                      <div className="flex items-baseline gap-2">
-                        <span className="text-sm font-bold text-gray-600 uppercase">
-                          {piece.marque}
-                        </span>
-                        <span className="text-base font-mono font-bold text-blue-700">
-                          {piece.reference}
-                        </span>
-                      </div>
+              {/* Badges qualite */}
+              <div className="flex items-center gap-3 mb-6">
+                {piece.qualite === "OES" && (
+                  <span className="bg-gradient-to-r from-amber-400 to-orange-500 text-white text-sm font-bold px-3 py-1.5 rounded-full shadow-sm">
+                    Qualite OES
+                  </span>
+                )}
+                {piece.nb_stars && piece.nb_stars > 0 && (
+                  <StarRating
+                    rating={piece.nb_stars}
+                    size="md"
+                    showNumber={false}
+                  />
+                )}
+              </div>
+
+              {/* Layout 2 colonnes: Images + Donnees techniques */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-6">
+                {/* Colonne gauche - Images */}
+                <div>
+                  <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl p-8 mb-4">
+                    <div className="aspect-square overflow-hidden rounded-lg">
+                      <img
+                        src={
+                          selectedImage
+                            ? getRackImageUrl(selectedImage)
+                            : piece.image
+                              ? getRackImageUrl(piece.image)
+                              : "/images/no.png"
+                        }
+                        alt={piece.nom}
+                        width={400}
+                        height={400}
+                        className="w-full h-full object-contain hover:scale-110 transition-transform duration-300"
+                        loading="lazy"
+                        decoding="async"
+                        // Defense-in-depth (INC-2026-015 / ADR-078) — see PiecesGrid.tsx
+                        onError={(e) => {
+                          const img = e.currentTarget;
+                          if (img.src.endsWith("/images/no.png")) return;
+                          img.src = "/images/no.png";
+                        }}
+                      />
                     </div>
                   </div>
 
-                  {/* Badges qualite */}
-                  <div className="flex items-center gap-3 mb-6">
-                    {piece.qualite === "OES" && (
-                      <span className="bg-gradient-to-r from-amber-400 to-orange-500 text-white text-sm font-bold px-3 py-1.5 rounded-full shadow-sm">
-                        Qualite OES
-                      </span>
-                    )}
-                    {piece.nb_stars && piece.nb_stars > 0 && (
-                      <StarRating
-                        rating={piece.nb_stars}
-                        size="md"
-                        showNumber={false}
-                      />
-                    )}
-                  </div>
-
-                  {/* Layout 2 colonnes: Images + Donnees techniques */}
-                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-6">
-                    {/* Colonne gauche - Images */}
-                    <div>
-                      <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl p-8 mb-4">
-                        <div className="aspect-square overflow-hidden rounded-lg">
+                  {piece.images && piece.images.length > 0 && (
+                    <div className="grid grid-cols-5 gap-2">
+                      {piece.images.map((img, idx) => (
+                        <button
+                          key={idx}
+                          onClick={() => setSelectedImage(img)}
+                          className={`aspect-square bg-white rounded-lg p-2 border-2 transition-all hover:scale-105 ${
+                            selectedImage === img
+                              ? "border-blue-500 shadow-md"
+                              : "border-gray-200 hover:border-gray-300"
+                          }`}
+                        >
                           <img
-                            src={
-                              selectedImage
-                                ? getRackImageUrl(selectedImage)
-                                : piece.image
-                                  ? getRackImageUrl(piece.image)
-                                  : "/images/no.png"
-                            }
-                            alt={piece.nom}
-                            width={400}
-                            height={400}
-                            className="w-full h-full object-contain hover:scale-110 transition-transform duration-300"
+                            src={getRackImageUrl(img)}
+                            alt={`Vue ${idx + 1}`}
+                            width={64}
+                            height={64}
+                            className="w-full h-full object-contain"
                             loading="lazy"
                             decoding="async"
-                            // Defense-in-depth (INC-2026-015 / ADR-078) — see PiecesGrid.tsx
+                            // Defense-in-depth (INC-2026-015 / ADR-078)
                             onError={(e) => {
-                              const img = e.currentTarget;
-                              if (img.src.endsWith('/images/no.png')) return;
-                              img.src = '/images/no.png';
+                              const t = e.currentTarget;
+                              if (t.src.endsWith("/images/no.png")) return;
+                              t.src = "/images/no.png";
                             }}
                           />
-                        </div>
-                      </div>
-
-                      {piece.images && piece.images.length > 0 && (
-                        <div className="grid grid-cols-5 gap-2">
-                          {piece.images.map((img, idx) => (
-                            <button
-                              key={idx}
-                              onClick={() => setSelectedImage(img)}
-                              className={`aspect-square bg-white rounded-lg p-2 border-2 transition-all hover:scale-105 ${
-                                selectedImage === img
-                                  ? "border-blue-500 shadow-md"
-                                  : "border-gray-200 hover:border-gray-300"
-                              }`}
-                            >
-                              <img
-                                src={getRackImageUrl(img)}
-                                alt={`Vue ${idx + 1}`}
-                                width={64}
-                                height={64}
-                                className="w-full h-full object-contain"
-                                loading="lazy"
-                                decoding="async"
-                                // Defense-in-depth (INC-2026-015 / ADR-078)
-                                onError={(e) => {
-                                  const t = e.currentTarget;
-                                  if (t.src.endsWith('/images/no.png')) return;
-                                  t.src = '/images/no.png';
-                                }}
-                              />
-                            </button>
-                          ))}
-                        </div>
-                      )}
+                        </button>
+                      ))}
                     </div>
+                  )}
+                </div>
 
-                    {/* Colonne droite - Donnees techniques */}
-                    {/* Mobile: Accordion collapsible */}
-                    <div className="md:hidden">
-                      <Accordion
-                        type="single"
-                        collapsible
-                        className="bg-gray-50 rounded-xl"
-                      >
-                        <AccordionItem value="specs" className="border-none">
-                          <AccordionTrigger className="px-5 py-4 hover:no-underline">
-                            <div className="flex items-center gap-2">
-                              <ClipboardList className="w-5 h-5 text-blue-600" />
-                              <span className="text-lg font-bold text-gray-900">
-                                Donnees techniques
-                                {piece.criteresTechniques &&
-                                  piece.criteresTechniques.length > 0 && (
-                                    <span className="ml-2 text-sm font-normal text-gray-500">
-                                      ({piece.criteresTechniques.length})
-                                    </span>
-                                  )}
-                              </span>
-                            </div>
-                          </AccordionTrigger>
-                          <AccordionContent className="px-5 pb-5">
+                {/* Colonne droite - Donnees techniques */}
+                {/* Mobile: Accordion collapsible */}
+                <div className="md:hidden">
+                  <Accordion
+                    type="single"
+                    collapsible
+                    className="bg-gray-50 rounded-xl"
+                  >
+                    <AccordionItem value="specs" className="border-none">
+                      <AccordionTrigger className="px-5 py-4 hover:no-underline">
+                        <div className="flex items-center gap-2">
+                          <ClipboardList className="w-5 h-5 text-blue-600" />
+                          <span className="text-lg font-bold text-gray-900">
+                            Donnees techniques
                             {piece.criteresTechniques &&
-                            piece.criteresTechniques.length > 0 ? (
-                              <div className="space-y-2 max-h-[300px] overflow-y-auto custom-scrollbar">
-                                {piece.criteresTechniques
-                                  .sort(
-                                    (a, b) => (a.level || 5) - (b.level || 5),
-                                  )
-                                  .map((critere) => (
-                                    <div
-                                      key={critere.id}
-                                      className="bg-white rounded-lg px-4 py-3 border border-gray-200"
-                                    >
-                                      <div className="flex justify-between items-start gap-3">
-                                        <span className="text-sm font-semibold text-gray-700 shrink-0">
-                                          {critere.name}
-                                        </span>
-                                        <span className="text-sm text-gray-900 font-medium text-right">
-                                          {critere.value} {critere.unit}
-                                        </span>
-                                      </div>
-                                    </div>
-                                  ))}
-                              </div>
-                            ) : (
-                              <p className="text-gray-500 text-sm">
-                                Aucune donnee technique disponible
-                              </p>
-                            )}
-                          </AccordionContent>
-                        </AccordionItem>
-                      </Accordion>
-                    </div>
-
-                    {/* Desktop: Always visible */}
-                    <div className="hidden md:block bg-gray-50 rounded-xl p-5">
-                      <h3 className="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
-                        <ClipboardList className="w-5 h-5 text-blue-600" />
-                        Donnees techniques
-                      </h3>
-
-                      {piece.criteresTechniques &&
-                      piece.criteresTechniques.length > 0 ? (
-                        <div className="space-y-2 max-h-[500px] overflow-y-auto custom-scrollbar pr-2">
-                          {piece.criteresTechniques
-                            .sort((a, b) => (a.level || 5) - (b.level || 5))
-                            .map((critere) => (
-                              <div
-                                key={critere.id}
-                                className="bg-white rounded-lg px-4 py-3 hover:shadow-md transition-shadow border border-gray-200"
-                              >
-                                <div className="flex justify-between items-start gap-3">
-                                  <span className="text-sm font-semibold text-gray-700 shrink-0">
-                                    {critere.name}
-                                  </span>
-                                  <span className="text-sm text-gray-900 font-medium text-right">
-                                    {critere.value} {critere.unit}
-                                  </span>
-                                </div>
-                              </div>
-                            ))}
-                        </div>
-                      ) : (
-                        <p className="text-gray-500 text-sm">
-                          Aucune donnee technique disponible
-                        </p>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Prix, disponibilite et bouton panier */}
-                  <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
-                    <div className="bg-gradient-to-r from-blue-50 rounded-xl p-6">
-                      <div className="text-sm text-gray-600 mb-2">Prix TTC</div>
-                      <div className="flex items-baseline gap-2">
-                        <span className="text-4xl font-black text-blue-600">
-                          {piece.prix_ttc.toFixed(2)}
-                        </span>
-                        <span className="text-2xl font-bold text-gray-500">
-                          €
-                        </span>
-                      </div>
-                    </div>
-
-                    <div className="bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl p-6 flex items-center justify-center">
-                      {piece.dispo ? (
-                        <div className="flex items-center gap-2 text-green-600 font-medium text-base">
-                          <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
-                          <span>En stock - Livraison rapide</span>
-                        </div>
-                      ) : (
-                        <div className="flex items-center gap-2 text-orange-600 font-medium text-base">
-                          <div className="w-3 h-3 bg-orange-500 rounded-full"></div>
-                          <span>Sur commande - Delai 2-5 jours</span>
-                        </div>
-                      )}
-                    </div>
-
-                    <button
-                      onClick={handleAddToCart}
-                      disabled={addingToCart}
-                      className="bg-gradient-to-r from-blue-600 hover:from-blue-700 hover: disabled:from-gray-400 disabled:to-gray-500 text-white font-bold py-4 px-6 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center gap-2"
-                    >
-                      {addingToCart ? (
-                        <>
-                          <svg
-                            className="w-5 h-5 animate-spin"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                          >
-                            <circle
-                              className="opacity-25"
-                              cx="12"
-                              cy="12"
-                              r="10"
-                              stroke="currentColor"
-                              strokeWidth="4"
-                            ></circle>
-                            <path
-                              className="opacity-75"
-                              fill="currentColor"
-                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                            ></path>
-                          </svg>
-                          <span className="hidden sm:inline">Ajout...</span>
-                        </>
-                      ) : (
-                        <>
-                          <ShoppingCart className="w-5 h-5" />
-                          <span className="hidden sm:inline">
-                            Ajouter au panier
+                              piece.criteresTechniques.length > 0 && (
+                                <span className="ml-2 text-sm font-normal text-gray-500">
+                                  ({piece.criteresTechniques.length})
+                                </span>
+                              )}
                           </span>
-                          <span className="sm:hidden">Panier</span>
-                        </>
-                      )}
-                    </button>
-                  </div>
-
-                  {/* References OEM constructeurs */}
-                  {piece.referencesOem &&
-                    Object.keys(piece.referencesOem).length > 0 &&
-                    (() => {
-                      const filteredOemEntries = Object.entries(
-                        piece.referencesOem,
-                      ).filter(
-                        ([marque]) =>
-                          !vehicleMarque ||
-                          marque.toUpperCase() === vehicleMarque.toUpperCase(),
-                      );
-
-                      if (filteredOemEntries.length === 0) return null;
-
-                      const totalRefs = filteredOemEntries.reduce(
-                        (acc, [, refs]) => acc + refs.length,
-                        0,
-                      );
-
-                      return (
-                        <>
-                          {/* Mobile: Accordion */}
-                          <div className="md:hidden mb-6">
-                            <Accordion
-                              type="single"
-                              collapsible
-                              className="bg-gradient-to-br from-green-50 to-emerald-50 rounded-xl border border-green-200"
-                            >
-                              <AccordionItem
-                                value="oem"
-                                className="border-none"
-                              >
-                                <AccordionTrigger className="px-5 py-4 hover:no-underline">
-                                  <div className="flex items-center gap-2">
-                                    <Shield className="w-5 h-5 text-green-600" />
-                                    <span className="text-lg font-bold text-gray-900">
-                                      Ref. OEM{" "}
-                                      {vehicleMarque || "Constructeurs"}
-                                      <span className="ml-2 text-sm font-normal text-gray-500">
-                                        ({totalRefs})
-                                      </span>
-                                    </span>
-                                  </div>
-                                </AccordionTrigger>
-                                <AccordionContent className="px-5 pb-5">
-                                  <div className="space-y-3">
-                                    {filteredOemEntries.map(
-                                      ([marque, refs]) => (
-                                        <div
-                                          key={marque}
-                                          className="bg-white rounded-lg p-3 border border-green-100"
-                                        >
-                                          <div className="font-bold text-gray-900 mb-2 uppercase text-sm">
-                                            {marque}
-                                          </div>
-                                          <div className="flex flex-wrap gap-2">
-                                            {refs.map((ref, idx) => (
-                                              <span
-                                                key={idx}
-                                                className="inline-block bg-green-100 text-green-800 text-xs font-mono font-semibold px-2.5 py-1 rounded"
-                                              >
-                                                {ref}
-                                              </span>
-                                            ))}
-                                          </div>
-                                        </div>
-                                      ),
-                                    )}
-                                  </div>
-                                </AccordionContent>
-                              </AccordionItem>
-                            </Accordion>
-                          </div>
-
-                          {/* Desktop: Always visible */}
-                          <div className="hidden md:block bg-gradient-to-br from-green-50 to-emerald-50 rounded-xl p-5 mb-6 border border-green-200">
-                            <h3 className="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
-                              <Shield className="w-5 h-5 text-green-600" />
-                              Ref. OEM {vehicleMarque || "Constructeurs"}
-                            </h3>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                              {filteredOemEntries.map(([marque, refs]) => (
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent className="px-5 pb-5">
+                        {piece.criteresTechniques &&
+                        piece.criteresTechniques.length > 0 ? (
+                          <div className="space-y-2 max-h-[300px] overflow-y-auto custom-scrollbar">
+                            {piece.criteresTechniques
+                              .sort((a, b) => (a.level || 5) - (b.level || 5))
+                              .map((critere) => (
                                 <div
-                                  key={marque}
-                                  className="bg-white rounded-lg p-3 border border-green-100"
+                                  key={critere.id}
+                                  className="bg-white rounded-lg px-4 py-3 border border-gray-200"
                                 >
-                                  <div className="font-bold text-gray-900 mb-2 uppercase text-sm">
-                                    {marque}
-                                  </div>
-                                  <div className="flex flex-wrap gap-2">
-                                    {refs.map((ref, idx) => (
-                                      <span
-                                        key={idx}
-                                        className="inline-block bg-green-100 text-green-800 text-xs font-mono font-semibold px-2.5 py-1 rounded"
-                                      >
-                                        {ref}
-                                      </span>
-                                    ))}
+                                  <div className="flex justify-between items-start gap-3">
+                                    <span className="text-sm font-semibold text-gray-700 shrink-0">
+                                      {critere.name}
+                                    </span>
+                                    <span className="text-sm text-gray-900 font-medium text-right">
+                                      {critere.value} {critere.unit}
+                                    </span>
                                   </div>
                                 </div>
                               ))}
+                          </div>
+                        ) : (
+                          <p className="text-gray-500 text-sm">
+                            Aucune donnee technique disponible
+                          </p>
+                        )}
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </div>
+
+                {/* Desktop: Always visible */}
+                <div className="hidden md:block bg-gray-50 rounded-xl p-5">
+                  <h3 className="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
+                    <ClipboardList className="w-5 h-5 text-blue-600" />
+                    Donnees techniques
+                  </h3>
+
+                  {piece.criteresTechniques &&
+                  piece.criteresTechniques.length > 0 ? (
+                    <div className="space-y-2 max-h-[500px] overflow-y-auto custom-scrollbar pr-2">
+                      {piece.criteresTechniques
+                        .sort((a, b) => (a.level || 5) - (b.level || 5))
+                        .map((critere) => (
+                          <div
+                            key={critere.id}
+                            className="bg-white rounded-lg px-4 py-3 hover:shadow-md transition-shadow border border-gray-200"
+                          >
+                            <div className="flex justify-between items-start gap-3">
+                              <span className="text-sm font-semibold text-gray-700 shrink-0">
+                                {critere.name}
+                              </span>
+                              <span className="text-sm text-gray-900 font-medium text-right">
+                                {critere.value} {critere.unit}
+                              </span>
                             </div>
                           </div>
-                        </>
-                      );
-                    })()}
+                        ))}
+                    </div>
+                  ) : (
+                    <p className="text-gray-500 text-sm">
+                      Aucune donnee technique disponible
+                    </p>
+                  )}
                 </div>
-              ) : null}
-            </div>
+              </div>
 
-            {/* Mobile Sticky CTA with Price */}
-            {piece && (
-              <div className="md:hidden sticky bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 pb-safe shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]">
+              {/* Prix, disponibilite et bouton panier */}
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+                <div className="bg-gradient-to-r from-blue-50 rounded-xl p-6">
+                  <div className="text-sm text-gray-600 mb-2">Prix TTC</div>
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-4xl font-black text-blue-600">
+                      {piece.prix_ttc.toFixed(2)}
+                    </span>
+                    <span className="text-2xl font-bold text-gray-500">€</span>
+                  </div>
+                </div>
+
+                <div className="bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl p-6 flex items-center justify-center">
+                  {piece.dispo ? (
+                    <div className="flex items-center gap-2 text-green-600 font-medium text-base">
+                      <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
+                      <span>En stock - Livraison rapide</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2 text-orange-600 font-medium text-base">
+                      <div className="w-3 h-3 bg-orange-500 rounded-full"></div>
+                      <span>Sur commande - Delai 2-5 jours</span>
+                    </div>
+                  )}
+                </div>
+
                 <button
                   onClick={handleAddToCart}
                   disabled={addingToCart}
-                  className="w-full bg-gradient-to-r from-blue-600 hover:from-blue-700 hover: disabled:from-gray-400 disabled:to-gray-500 text-white font-bold py-4 px-6 rounded-xl shadow-lg flex items-center justify-center gap-3 touch-target-lg"
+                  className="bg-gradient-to-r from-blue-600 hover:from-blue-700 hover: disabled:from-gray-400 disabled:to-gray-500 text-white font-bold py-4 px-6 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center gap-2"
                 >
                   {addingToCart ? (
                     <>
@@ -614,30 +460,175 @@ export const PieceDetailModal = memo(function PieceDetailModal({
                           r="10"
                           stroke="currentColor"
                           strokeWidth="4"
-                        />
+                        ></circle>
                         <path
                           className="opacity-75"
                           fill="currentColor"
                           d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                        />
+                        ></path>
                       </svg>
-                      <span>Ajout...</span>
+                      <span className="hidden sm:inline">Ajout...</span>
                     </>
                   ) : (
                     <>
                       <ShoppingCart className="w-5 h-5" />
-                      <span>Ajouter au panier</span>
-                      <span className="font-bold">
-                        · {piece.prix_ttc.toFixed(2)}€
+                      <span className="hidden sm:inline">
+                        Ajouter au panier
                       </span>
+                      <span className="sm:hidden">Panier</span>
                     </>
                   )}
                 </button>
               </div>
-            )}
+
+              {/* References OEM constructeurs */}
+              {piece.referencesOem &&
+                Object.keys(piece.referencesOem).length > 0 &&
+                (() => {
+                  const filteredOemEntries = Object.entries(
+                    piece.referencesOem,
+                  ).filter(
+                    ([marque]) =>
+                      !vehicleMarque ||
+                      marque.toUpperCase() === vehicleMarque.toUpperCase(),
+                  );
+
+                  if (filteredOemEntries.length === 0) return null;
+
+                  const totalRefs = filteredOemEntries.reduce(
+                    (acc, [, refs]) => acc + refs.length,
+                    0,
+                  );
+
+                  return (
+                    <>
+                      {/* Mobile: Accordion */}
+                      <div className="md:hidden mb-6">
+                        <Accordion
+                          type="single"
+                          collapsible
+                          className="bg-gradient-to-br from-green-50 to-emerald-50 rounded-xl border border-green-200"
+                        >
+                          <AccordionItem value="oem" className="border-none">
+                            <AccordionTrigger className="px-5 py-4 hover:no-underline">
+                              <div className="flex items-center gap-2">
+                                <Shield className="w-5 h-5 text-green-600" />
+                                <span className="text-lg font-bold text-gray-900">
+                                  Ref. OEM {vehicleMarque || "Constructeurs"}
+                                  <span className="ml-2 text-sm font-normal text-gray-500">
+                                    ({totalRefs})
+                                  </span>
+                                </span>
+                              </div>
+                            </AccordionTrigger>
+                            <AccordionContent className="px-5 pb-5">
+                              <div className="space-y-3">
+                                {filteredOemEntries.map(([marque, refs]) => (
+                                  <div
+                                    key={marque}
+                                    className="bg-white rounded-lg p-3 border border-green-100"
+                                  >
+                                    <div className="font-bold text-gray-900 mb-2 uppercase text-sm">
+                                      {marque}
+                                    </div>
+                                    <div className="flex flex-wrap gap-2">
+                                      {refs.map((ref, idx) => (
+                                        <span
+                                          key={idx}
+                                          className="inline-block bg-green-100 text-green-800 text-xs font-mono font-semibold px-2.5 py-1 rounded"
+                                        >
+                                          {ref}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            </AccordionContent>
+                          </AccordionItem>
+                        </Accordion>
+                      </div>
+
+                      {/* Desktop: Always visible */}
+                      <div className="hidden md:block bg-gradient-to-br from-green-50 to-emerald-50 rounded-xl p-5 mb-6 border border-green-200">
+                        <h3 className="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
+                          <Shield className="w-5 h-5 text-green-600" />
+                          Ref. OEM {vehicleMarque || "Constructeurs"}
+                        </h3>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                          {filteredOemEntries.map(([marque, refs]) => (
+                            <div
+                              key={marque}
+                              className="bg-white rounded-lg p-3 border border-green-100"
+                            >
+                              <div className="font-bold text-gray-900 mb-2 uppercase text-sm">
+                                {marque}
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                {refs.map((ref, idx) => (
+                                  <span
+                                    key={idx}
+                                    className="inline-block bg-green-100 text-green-800 text-xs font-mono font-semibold px-2.5 py-1 rounded"
+                                  >
+                                    {ref}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </>
+                  );
+                })()}
+            </div>
+          ) : null}
+        </div>
+
+        {/* Mobile Sticky CTA with Price */}
+        {piece && (
+          <div className="md:hidden sticky bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 pb-safe shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]">
+            <button
+              onClick={handleAddToCart}
+              disabled={addingToCart}
+              className="w-full bg-gradient-to-r from-blue-600 hover:from-blue-700 hover: disabled:from-gray-400 disabled:to-gray-500 text-white font-bold py-4 px-6 rounded-xl shadow-lg flex items-center justify-center gap-3 touch-target-lg"
+            >
+              {addingToCart ? (
+                <>
+                  <svg
+                    className="w-5 h-5 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  <span>Ajout...</span>
+                </>
+              ) : (
+                <>
+                  <ShoppingCart className="w-5 h-5" />
+                  <span>Ajouter au panier</span>
+                  <span className="font-bold">
+                    · {piece.prix_ttc.toFixed(2)}€
+                  </span>
+                </>
+              )}
+            </button>
           </div>
-        </DialogPrimitive.Content>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
+        )}
+      </div>
+    </dialog>
   );
 });

--- a/frontend/app/global.css
+++ b/frontend/app/global.css
@@ -437,6 +437,46 @@
     }
   }
 
+  /* Native <dialog> modal centré (fiche produit PieceDetailModal) : fade+zoom,
+     même dégradation gracieuse que .navdrawer (navigateurs sans allow-discrete
+     ouvrent instantanément). Remplace Radix Dialog dont l'ouverture exécutait
+     react-remove-scroll + FocusScope (reflow forcé) dans le tap carte produit
+     — interaction dominante de l'INP mobile /pieces (RUM p75 500ms). */
+  .modal-pop {
+    opacity: 0;
+    scale: 0.96;
+    transition:
+      opacity 0.2s ease,
+      scale 0.2s ease,
+      overlay 0.2s ease allow-discrete,
+      display 0.2s ease allow-discrete;
+  }
+  .modal-pop[open] {
+    opacity: 1;
+    scale: 1;
+  }
+  @starting-style {
+    .modal-pop[open] {
+      opacity: 0;
+      scale: 0.96;
+    }
+  }
+  .modal-pop::backdrop {
+    opacity: 0;
+    transition:
+      opacity 0.2s ease,
+      overlay 0.2s ease allow-discrete,
+      display 0.2s ease allow-discrete;
+  }
+  .modal-pop[open]::backdrop {
+    opacity: 1;
+  }
+  @starting-style {
+    .modal-pop[open]::backdrop {
+      opacity: 0;
+    }
+  }
+
   .animate-shimmer {
     animation: shimmer 3s ease-in-out infinite;
     will-change: transform;

--- a/frontend/app/hooks/useNativeDialog.ts
+++ b/frontend/app/hooks/useNativeDialog.ts
@@ -25,6 +25,11 @@ interface UseNativeDialogOptions {
 
 export function useNativeDialog({ onClose }: UseNativeDialogOptions = {}) {
   const ref = useRef<HTMLDialogElement>(null);
+  // Quand mousedown et mouseup ciblent des éléments différents, le navigateur
+  // dispatch le click sur leur ancêtre commun — qui EST le <dialog> si un geste
+  // commence dans le contenu et relâche sur le backdrop/gutter (ex. sélection
+  // de texte qui déborde). Sans ce garde, la sélection fermerait le dialog.
+  const pointerDownOnBackdrop = useRef(false);
 
   const lockScroll = (locked: boolean) => {
     if (typeof document !== "undefined") {
@@ -55,9 +60,13 @@ export function useNativeDialog({ onClose }: UseNativeDialogOptions = {}) {
       lockScroll(false);
       onClose?.();
     },
-    // Clic sur le backdrop (la cible est l'élément <dialog> lui-même) = fermeture.
+    onPointerDown: (e: React.PointerEvent<HTMLDialogElement>) => {
+      pointerDownOnBackdrop.current = e.target === ref.current;
+    },
+    // Clic sur le backdrop (la cible est l'élément <dialog> lui-même) = fermeture,
+    // seulement si le geste a AUSSI commencé sur le backdrop (cf. garde ci-dessus).
     onClick: (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === ref.current) close();
+      if (e.target === ref.current && pointerDownOnBackdrop.current) close();
     },
   };
 

--- a/frontend/tests/unit/piece-detail-modal.test.tsx
+++ b/frontend/tests/unit/piece-detail-modal.test.tsx
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { PieceDetailModal } from "~/components/pieces/PieceDetailModal";
+
+/**
+ * PieceDetailModal — contrat <dialog> natif (fix INP tap carte produit).
+ *
+ * L'ouverture du Radix Dialog exécutait react-remove-scroll + FocusScope
+ * (reflow forcé) dans le handler du tap carte produit = interaction dominante
+ * de l'INP mobile /pieces (RUM p75 500ms, lab 296ms @6x). Migré sur
+ * useNativeDialog (pattern Navbar/CartSidebarSimple, PR #799). Comme pour
+ * use-native-dialog.test.tsx : jsdom n'implémente pas showModal()/close(),
+ * on stub ; le gain INP réel est prouvé par sonde Playwright — ces tests
+ * verrouillent le CONTRAT (dialog natif piloté par pieceId, fetch détail,
+ * fermeture) et l'absence de retour à Radix Dialog.
+ */
+vi.mock("~/hooks/useCart", () => ({
+  useCart: () => ({ addToCart: vi.fn().mockResolvedValue(true) }),
+}));
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("~/utils/analytics", () => ({
+  trackViewItem: vi.fn(),
+  trackAddToCart: vi.fn(),
+}));
+vi.mock("~/components/ui/BrandLogo", () => ({ BrandLogo: () => null }));
+
+const pieceFixture = {
+  id: 123,
+  nom: "Compresseur de climatisation",
+  marque: "LIZARTE",
+  reference: "71.10.60.005",
+  prix_ttc: 249.9,
+  image: "260/6216001.JPG",
+  dispo: true,
+};
+
+describe("PieceDetailModal — <dialog> natif", () => {
+  let showModal: ReturnType<typeof vi.fn>;
+  let closeFn: ReturnType<typeof vi.fn>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    document.body.style.overflow = "";
+    showModal = vi.fn(function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    // Fidèle au navigateur : close() retire [open] ET dispatch l'event close.
+    closeFn = vi.fn(function (this: HTMLDialogElement) {
+      this.removeAttribute("open");
+      this.dispatchEvent(new Event("close"));
+    });
+    (
+      HTMLDialogElement.prototype as unknown as Record<string, unknown>
+    ).showModal = showModal;
+    (HTMLDialogElement.prototype as unknown as Record<string, unknown>).close =
+      closeFn;
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: pieceFixture }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.style.overflow = "";
+  });
+
+  it("pieceId=null → <dialog> natif présent mais fermé, aucun fetch", () => {
+    const { container } = render(
+      <PieceDetailModal pieceId={null} onClose={vi.fn()} />,
+    );
+
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(showModal).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("pieceId défini → showModal() + fetch du détail + rendu du contenu", async () => {
+    render(<PieceDetailModal pieceId={123} onClose={vi.fn()} />);
+
+    expect(showModal).toHaveBeenCalledTimes(1);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/catalog/pieces/123",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Compresseur de climatisation")).toBeTruthy(),
+    );
+  });
+
+  it("event close natif (Échap) → onClose appelé + scroll déverrouillé", async () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <PieceDetailModal pieceId={123} onClose={onClose} />,
+    );
+
+    const dialog = container.querySelector("dialog")!;
+    fireEvent(dialog, new Event("close"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("bouton Fermer → dialog.close() natif", async () => {
+    render(<PieceDetailModal pieceId={123} onClose={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Fermer" })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Fermer" }));
+
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("réouverture 123 → null → 456 : close puis re-fetch + re-showModal", async () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <PieceDetailModal pieceId={123} onClose={onClose} />,
+    );
+    expect(showModal).toHaveBeenCalledTimes(1);
+
+    rerender(<PieceDetailModal pieceId={null} onClose={onClose} />);
+    expect(closeFn).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1); // event close natif, une seule fois
+
+    rerender(<PieceDetailModal pieceId={456} onClose={onClose} />);
+    expect(showModal).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/catalog/pieces/456",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("erreur fetch → état erreur affiché, son bouton Fermer passe par close() (onClose une seule fois)", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("réseau"));
+    const onClose = vi.fn();
+    render(<PieceDetailModal pieceId={123} onClose={onClose} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Impossible de charger les details de la piece"),
+      ).toBeTruthy(),
+    );
+
+    // Deux boutons matchent le nom "Fermer" (X via aria-label + bouton texte) :
+    // cibler le bouton texte de l'état erreur.
+    fireEvent.click(screen.getByText("Fermer", { selector: "button" }));
+
+    expect(closeFn).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("verrou anti-régression : plus aucun import @radix-ui/react-dialog", () => {
+    // vitest tourne avec cwd=frontend ; import.meta.url est http: sous jsdom.
+    const source = readFileSync(
+      resolve(process.cwd(), "app/components/pieces/PieceDetailModal.tsx"),
+      "utf-8",
+    );
+    expect(source).not.toContain("@radix-ui/react-dialog");
+    expect(source).toContain("useNativeDialog");
+  });
+});

--- a/frontend/tests/unit/use-native-dialog.test.tsx
+++ b/frontend/tests/unit/use-native-dialog.test.tsx
@@ -1,5 +1,9 @@
 import { renderHook, act } from "@testing-library/react";
-import { type MouseEvent, type MutableRefObject } from "react";
+import {
+  type MouseEvent,
+  type MutableRefObject,
+  type PointerEvent,
+} from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { useNativeDialog } from "~/hooks/useNativeDialog";
@@ -83,17 +87,40 @@ describe("useNativeDialog", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("clic sur le backdrop (cible = l'élément dialog) ferme", () => {
+  it("clic sur le backdrop (pointerdown + click ciblent le dialog) ferme", () => {
     const { result } = renderHook(() => useNativeDialog());
     const dialog = attachDialog(result.current.ref, true);
 
-    act(() =>
+    act(() => {
+      result.current.dialogProps.onPointerDown({
+        target: dialog,
+      } as unknown as PointerEvent<HTMLDialogElement>);
       result.current.dialogProps.onClick({
         target: dialog,
-      } as unknown as MouseEvent<HTMLDialogElement>),
-    );
+      } as unknown as MouseEvent<HTMLDialogElement>);
+    });
 
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("geste commencé DANS le contenu et relâché sur le backdrop ne ferme pas (sélection de texte)", () => {
+    // mousedown enfant + mouseup backdrop → le navigateur retarget le click
+    // sur l'ancêtre commun (le dialog) ; le garde pointerdown doit l'ignorer.
+    const { result } = renderHook(() => useNativeDialog());
+    const dialog = attachDialog(result.current.ref, true);
+    const child = document.createElement("span");
+    dialog.appendChild(child);
+
+    act(() => {
+      result.current.dialogProps.onPointerDown({
+        target: child,
+      } as unknown as PointerEvent<HTMLDialogElement>);
+      result.current.dialogProps.onClick({
+        target: dialog,
+      } as unknown as MouseEvent<HTMLDialogElement>);
+    });
+
+    expect(close).not.toHaveBeenCalled();
   });
 
   it("clic à l'intérieur (cible ≠ dialog) ne ferme pas", () => {


### PR DESCRIPTION
## Pourquoi

Le rapport CrUX/GSC « INP > 500 ms mobile » sur le groupe `/pieces/*` (1 426 URLs, p75 541 ms) est **réel** et **n'était pas** une régression des fixs de mai (#692/#694/#799, tous intacts + servis en PROD). L'audit `web-vitals-audit` + l'attribution RUM first-party (`__seo_cwv_raw`) désignent l'interaction dominante restante :

> **le tap sur l'image d'une carte produit** → target `picture>img.object-contain`, **p75 500 ms, max 976 ms (n=35)** — tous les autres targets n=1-2.

Ce tap ouvre **`PieceDetailModal`** (quick-view), resté sur **Radix Dialog brut** (`@radix-ui/react-dialog`). Son ouverture exécute `react-remove-scroll` + `FocusScope` (lectures layout → **reflow forcé du document**) dans le handler du tap — exactement la cause racine réparée pour le menu/panier en mai (#799). Ce composant (créé 2025-11) n'avait jamais été migré et est monté **inconditionnellement** sur toutes les pages véhicule R1 (le gros du groupe CrUX).

## Le changement

- `PieceDetailModal` migré sur le hook **partagé `useNativeDialog`** (élément `<dialog>` natif top-layer : focus-trap / Échap / `aria-modal` / scroll-lock fournis par la plateforme, contenu pré-rendu → `showModal()` quasi-instantané). Même pattern que Navbar + CartSidebarSimple.
- Nouvel utilitaire CSS **`.modal-pop`** (fade+zoom + `::backdrop`, `@starting-style`/`allow-discrete`), cohérent avec `.navdrawer` existant.
- Radix Dialog sort du **chemin d'exécution** du tap. Gain = **exécution INP**, pas de baisse de bundle (le chunk `app-ui-primitives` reste partagé par `sheet`/`dialog`/`alert-dialog` de l'admin).

## Preuve (A/B lab @6× CPU, méthodo #799)

`react-router-serve` local, build pré-fix vs build fix, page R1 réelle, tap image carte :

| | pré-fix | fix |
|---|---|---|
| INP tap carte | 264 / 272 / 296 ms | **128 / 136 / 136 ms** |
| processing | 192-221 ms | **~90 ms** |

**−50 %.** Modale ouverte + Échap OK 3/3. Baseline PROD live identique au pré-fix (264-296 ms). Screenshots mobile+desktop OK (centrage, backdrop, bouton X).

## Review adversariale (15 agents) — 3 findings confirmés corrigés

1. **`useNativeDialog` — garde `pointerdown`** : une sélection de texte débordant sur le backdrop retargait le `click` vers `<dialog>` et fermait la modale. On ne ferme désormais que si le geste a **commencé** sur le backdrop. Bénéficie aussi à Navbar + CartSidebarSimple. Prouvé par sonde Playwright (backdrop-click ferme ✓ ; drag-out garde ouvert ✓) + tests unitaires.
2. **Bouton Fermer de l'état erreur** : `close()` au lieu d'un `onClose()` direct (supprime un double appel `onClose` latent, symétrie avec X/Échap/backdrop).
3. **`setPiece(null)` au (re)fetch** : l'`aria-label` du `<dialog>` n'annonce plus le nom de la pièce précédente pendant le chargement d'une réouverture.

Findings rejetés après vérification : dégradation `<dialog>` sur vieux navigateurs (le bloc CSS est dans `@layer` → même seuil de support que `<dialog>`, dégrade identiquement à `.navdrawer`) ; `prefers-reduced-motion` (déjà couvert globalement, `animations.css`).

## Tests & gates

- **`piece-detail-modal.test.tsx`** (7 tests) : dialog piloté par `pieceId`, fetch, close natif, bouton Fermer, **réouverture 123→null→456** (re-fetch + re-showModal), **erreur-fetch** (onClose une seule fois), **verrou anti-`@radix-ui/react-dialog`**.
- **`use-native-dialog.test.tsx`** (+2) : backdrop `pointerdown`-gated, drag-out ne ferme pas.
- `tsc` 0 erreur · eslint clean · **433/433** unit · build Rolldown OK.

Note : `PieceDetailModal.tsx` re-indenté par prettier (un niveau de nesting Radix retiré) → gros diff visuel, **diff logique réel = +46/−55** (`git diff -w`).

## Déploiement

Merge `main` → PREPROD CI uniquement. **PROD = décision owner** (tag `v*`). Validation terrain = attribution RUM `__seo_cwv_raw` sur `picture>img.object-contain` mobile après déploiement (le lab montre −50 %, le p75 CrUX suivra sur la fenêtre 28 j).

🤖 Generated with [Claude Code](https://claude.com/claude-code)