### PR TITLE
feat(media-factory): Fafa compositions — brand palette align + configurable problem text (revive #805)

### DIFF
--- a/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
+++ b/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
@@ -37,6 +37,8 @@ interface NeChangePasTropViteProps {
   hook?: string;
   symptom?: string;
   pieceWrong?: string;
+  /** Optionnel : remplace le texte du bloc Problème (ex. cadrage compatibilité). Défaut = cadrage diagnostic. */
+  problemText?: string;
   causes?: Cause[];
   advice?: string;
   cta?: string;
@@ -49,6 +51,7 @@ export const NeChangePasTropVite: React.FC<NeChangePasTropViteProps> = ({
   hook = 'Perte de puissance ? Ne change pas ta pièce trop vite.',
   symptom = 'Perte de puissance',
   pieceWrong = 'vanne EGR',
+  problemText,
   causes = [
     { cause: 'Filtre à air bouché', check_suggestion: 'Inspection visuelle' },
     { cause: 'Débitmètre fatigué', check_suggestion: 'Test multimètre' },
@@ -87,6 +90,7 @@ export const NeChangePasTropVite: React.FC<NeChangePasTropViteProps> = ({
         startFrame={HOOK_END}
         endFrame={PROBLEM_END}
         pieceWrong={pieceWrong}
+        problemText={problemText}
       />
 
       <CausesSection
@@ -174,7 +178,8 @@ const ProblemSection: React.FC<{
   startFrame: number;
   endFrame: number;
   pieceWrong: string;
-}> = ({ frame, startFrame, endFrame, pieceWrong }) => {
+  problemText?: string;
+}> = ({ frame, startFrame, endFrame, pieceWrong, problemText }) => {
   if (frame < startFrame || frame >= endFrame) return null;
   const local = frame - startFrame;
   const fadeIn = interpolate(local, [0, 20], [0, 1], { extrapolateRight: 'clamp' });
@@ -189,9 +194,15 @@ const ProblemSection: React.FC<{
     >
       <div style={{ transform: `translateY(${slideY}px)`, textAlign: 'center', maxWidth: 900 }}>
         <div style={{ color: 'rgba(255,255,255,0.85)', fontSize: 44, lineHeight: 1.5 }}>
-          Changer directement{' '}
-          <span style={{ color: '#F97316', fontWeight: 'bold' }}>la {pieceWrong}</span>, c’est
-          tentant. Mais si la vraie cause est ailleurs, tu paies pour rien.
+          {problemText ? (
+            problemText
+          ) : (
+            <>
+              Changer directement{' '}
+              <span style={{ color: '#F97316', fontWeight: 'bold' }}>la {pieceWrong}</span>, c’est
+              tentant. Mais si la vraie cause est ailleurs, tu paies pour rien.
+            </>
+          )}
         </div>
       </div>
     </AbsoluteFill>

--- a/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
+++ b/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
@@ -20,7 +20,7 @@ import {
  *   Advice   (870-1050)  : conseil de vérification ordonné
  *   Closer   (1050-1140) : brand + CTA
  *
- * Palette: #1a1a2e bg, #e94560 accent, #16213e panel, Liberation Sans.
+ * Palette: #0F1E38 bg, #F97316 accent, #0F4C81 panel, Liberation Sans.
  * Aucun visuel n'est une preuve (G6) — texte animé + schéma stylisé uniquement.
  */
 
@@ -73,7 +73,7 @@ export const NeChangePasTropVite: React.FC<NeChangePasTropViteProps> = ({
   return (
     <AbsoluteFill
       style={{
-        backgroundColor: '#1a1a2e',
+        backgroundColor: '#0F1E38',
         fontFamily: 'Liberation Sans, Arial, sans-serif',
         overflow: 'hidden',
       }}
@@ -114,7 +114,7 @@ export const NeChangePasTropVite: React.FC<NeChangePasTropViteProps> = ({
           left: 0,
           width: `${progress * 100}%`,
           height: 4,
-          backgroundColor: '#e94560',
+          backgroundColor: '#F97316',
         }}
       />
     </AbsoluteFill>
@@ -141,7 +141,7 @@ const HookSection: React.FC<{
     <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 28,
           fontWeight: 'bold',
           letterSpacing: 4,
@@ -190,7 +190,7 @@ const ProblemSection: React.FC<{
       <div style={{ transform: `translateY(${slideY}px)`, textAlign: 'center', maxWidth: 900 }}>
         <div style={{ color: 'rgba(255,255,255,0.85)', fontSize: 44, lineHeight: 1.5 }}>
           Changer directement{' '}
-          <span style={{ color: '#e94560', fontWeight: 'bold' }}>la {pieceWrong}</span>, c’est
+          <span style={{ color: '#F97316', fontWeight: 'bold' }}>la {pieceWrong}</span>, c’est
           tentant. Mais si la vraie cause est ailleurs, tu paies pour rien.
         </div>
       </div>
@@ -240,8 +240,8 @@ const CausesSection: React.FC<{
               style={{
                 opacity: reveal,
                 transform: `translateX(${slideX}px)`,
-                backgroundColor: '#16213e',
-                borderLeft: '6px solid #e94560',
+                backgroundColor: '#0F4C81',
+                borderLeft: '6px solid #F97316',
                 borderRadius: 12,
                 padding: '28px 32px',
                 display: 'flex',
@@ -249,7 +249,7 @@ const CausesSection: React.FC<{
                 gap: 24,
               }}
             >
-              <span style={{ color: '#e94560', fontSize: 52, fontWeight: 'bold', lineHeight: 1 }}>
+              <span style={{ color: '#F97316', fontSize: 52, fontWeight: 'bold', lineHeight: 1 }}>
                 {i + 1}
               </span>
               <div>
@@ -312,7 +312,7 @@ const CloserSection: React.FC<{
     <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 80,
           fontWeight: 'bold',
           letterSpacing: 5,

--- a/services/remotion-renderer/src/compositions/PieceExpliquee.tsx
+++ b/services/remotion-renderer/src/compositions/PieceExpliquee.tsx
@@ -20,7 +20,7 @@ import {
  *   WhenChange (720-960)   : critère objectif (km / signe critique)
  *   Closer     (960-1200)  : brand + CTA
  *
- * Palette: #1a1a2e bg, #e94560 accent, #16213e panel, Liberation Sans.
+ * Palette: #0F1E38 bg, #F97316 accent, #0F4C81 panel, Liberation Sans.
  * Claim safety (ex. freinage compromis) → validation humaine obligatoire (G2 STRICT).
  */
 
@@ -46,8 +46,8 @@ interface PieceExpliqueeProps {
 
 const SEVERITY_COLOR: Record<string, string> = {
   low: 'rgba(255,255,255,0.4)',
-  medium: '#f0a500',
-  high: '#e94560',
+  medium: '#D68910',
+  high: '#F97316',
 };
 
 export const PieceExpliquee: React.FC<PieceExpliqueeProps> = ({
@@ -78,7 +78,7 @@ export const PieceExpliquee: React.FC<PieceExpliqueeProps> = ({
   return (
     <AbsoluteFill
       style={{
-        backgroundColor: '#1a1a2e',
+        backgroundColor: '#0F1E38',
         fontFamily: 'Liberation Sans, Arial, sans-serif',
         overflow: 'hidden',
       }}
@@ -123,7 +123,7 @@ export const PieceExpliquee: React.FC<PieceExpliqueeProps> = ({
           left: 0,
           width: `${progress * 100}%`,
           height: 4,
-          backgroundColor: '#e94560',
+          backgroundColor: '#F97316',
         }}
       />
     </AbsoluteFill>
@@ -202,7 +202,7 @@ const LabelSection: React.FC<{
     >
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 30,
           fontWeight: 'bold',
           letterSpacing: 3,
@@ -232,14 +232,14 @@ const LabelSection: React.FC<{
             display: 'inline-flex',
             alignItems: 'center',
             gap: 10,
-            backgroundColor: '#16213e',
+            backgroundColor: '#0F4C81',
             color: 'rgba(255,255,255,0.6)',
             fontSize: 24,
             padding: '12px 24px',
             borderRadius: 8,
           }}
         >
-          {footLabel && <span style={{ color: '#e94560', fontWeight: 'bold' }}>{footLabel}:</span>}
+          {footLabel && <span style={{ color: '#F97316', fontWeight: 'bold' }}>{footLabel}:</span>}
           {footnote}
         </div>
       )}
@@ -262,7 +262,7 @@ const WearSignsSection: React.FC<{
     <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 50px' }}>
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 30,
           fontWeight: 'bold',
           letterSpacing: 3,
@@ -290,7 +290,7 @@ const WearSignsSection: React.FC<{
               style={{
                 opacity: reveal,
                 transform: `translateX(${slideX}px)`,
-                backgroundColor: '#16213e',
+                backgroundColor: '#0F4C81',
                 borderRadius: 12,
                 padding: '26px 30px',
                 display: 'flex',
@@ -328,7 +328,7 @@ const CloserSection: React.FC<{
     <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 80,
           fontWeight: 'bold',
           letterSpacing: 5,

--- a/services/remotion-renderer/src/compositions/SymptomeTroisCauses.tsx
+++ b/services/remotion-renderer/src/compositions/SymptomeTroisCauses.tsx
@@ -20,7 +20,7 @@ import {
  *   Cause 3  (630-870) : cause moins fréquente mais sérieuse
  *   Closer   (870-990) : brand + CTA
  *
- * Palette: #1a1a2e bg, #e94560 accent, #16213e panel, Liberation Sans.
+ * Palette: #0F1E38 bg, #F97316 accent, #0F4C81 panel, Liberation Sans.
  * Photos pièces autorisées en illustration (G6) — jamais comme preuve diagnostic.
  */
 
@@ -67,7 +67,7 @@ export const SymptomeTroisCauses: React.FC<SymptomeTroisCausesProps> = ({
   return (
     <AbsoluteFill
       style={{
-        backgroundColor: '#1a1a2e',
+        backgroundColor: '#0F1E38',
         fontFamily: 'Liberation Sans, Arial, sans-serif',
         overflow: 'hidden',
       }}
@@ -99,7 +99,7 @@ export const SymptomeTroisCauses: React.FC<SymptomeTroisCausesProps> = ({
           left: 0,
           width: `${progress * 100}%`,
           height: 4,
-          backgroundColor: '#e94560',
+          backgroundColor: '#F97316',
         }}
       />
     </AbsoluteFill>
@@ -137,7 +137,7 @@ const SymptomSection: React.FC<{
       <div
         style={{
           marginTop: 28,
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 34,
           letterSpacing: 2,
           opacity: subOpacity,
@@ -180,7 +180,7 @@ const CauseSection: React.FC<{
               width: 14,
               height: 14,
               borderRadius: '50%',
-              backgroundColor: d === index ? '#e94560' : 'rgba(255,255,255,0.25)',
+              backgroundColor: d === index ? '#F97316' : 'rgba(255,255,255,0.25)',
             }}
           />
         ))}
@@ -188,7 +188,7 @@ const CauseSection: React.FC<{
 
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 96,
           fontWeight: 'bold',
           lineHeight: 1,
@@ -229,7 +229,7 @@ const DetailRow: React.FC<{ label: string; value: string }> = ({ label, value })
       display: 'flex',
       alignItems: 'center',
       gap: 18,
-      backgroundColor: '#16213e',
+      backgroundColor: '#0F4C81',
       borderRadius: 10,
       padding: '18px 24px',
       marginBottom: 16,
@@ -237,7 +237,7 @@ const DetailRow: React.FC<{ label: string; value: string }> = ({ label, value })
   >
     <span
       style={{
-        color: '#e94560',
+        color: '#F97316',
         fontSize: 22,
         fontWeight: 'bold',
         textTransform: 'uppercase',
@@ -271,7 +271,7 @@ const CloserSection: React.FC<{
     <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
       <div
         style={{
-          color: '#e94560',
+          color: '#F97316',
           fontSize: 80,
           fontWeight: 'bold',
           letterSpacing: 5,


### PR DESCRIPTION
## Contexte — ravivage de #805

PR #805 (même contenu) a été **auto-fermée par le stale-bot le 2026-06-21** (21 jours d'inactivité), branche `worktree-fafa-palette-align` préservée. Cette PR rejoue ses 2 commits (cherry-pick) sur `origin/main` actuel, conformément à la consigne du bot (« create a fresh one from the same branch »).

## Contenu (identique à #805)

- **Palette charte** : les 3 compositions Fafa (`NeChangePasTropVite`, `PieceExpliquee`, `SymptomeTroisCauses`) abandonnent les hex hors-charte (`#1a1a2e`/`#e94560`/`#16213e`/`#f0a500`) pour les tokens charte (`#0F1E38` primary, `#F97316` action, `#0F4C81` secondary, `#D68910` warning) — valeurs vérifiées dans `packages/design-tokens/src/styles/tokens.css`.
- **Prop `problemText?`** (NeChangePasTropVite) : permet le cadrage compatibilité (vs diagnostic par défaut). Pré-requis du pilote `fafa-plaquettes-frein-001` (ravivage de #806, PR séparée).

## Résolution du conflit de rebase (1 seul, trivial)

Le bloc d'interface props de `NeChangePasTropVite.tsx` : #1089 a rendu les props optionnelles sur main après la fermeture de #805. Résolution = **props optionnelles de main conservées** + ajout `problemText?: string`. Aucun autre écart vs #805.

## Vérification

- `npm ci && npm run build` (tsc) dans `services/remotion-renderer` : **OK, 0 erreur**.
- Still render frame 240 (section Problème) avec `problemText` custom via `npx remotion still` : rendu correct — fond `#0F1E38`, accent `#F97316`, texte custom affiché, disclaimer présent.
- Pré-existant hors scope : warning Remotion « zod installed 3.25.76, required 4.3.6 » (lockfile main, non introduit ici).

## Limites connues (héritées de #805, inchangées à dessein)

- Les hex restent **en dur** (alignés sur les valeurs tokens) — la consommation directe de `@fafa/design-tokens` par le renderer standalone est un chantier séparé (DT-1), hors scope de ce ravivage.

Refs : #805 (original), #806 (pilote dépendant, ravivage séparé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)