### PR TITLE
perf(lcp): stop high-priority preload of below-fold images (home + pieces R2)

### DIFF
--- a/frontend/app/components/home/CatalogueSection.tsx
+++ b/frontend/app/components/home/CatalogueSection.tsx
@@ -59,7 +59,6 @@ const CatalogFamilyCard = memo(function CatalogFamilyCard({
               alt={`Pièces ${cat.n} — catalogue AutoMecanik`}
               className="w-full h-full object-contain p-3 transition-transform duration-300 group-hover:scale-105"
               loading={isAboveFold ? "eager" : "lazy"}
-              fetchPriority={isAboveFold ? "high" : undefined}
               width="400"
               height="300"
             />

--- a/frontend/app/components/pieces/PiecesGridView.tsx
+++ b/frontend/app/components/pieces/PiecesGridView.tsx
@@ -260,7 +260,7 @@ const PieceCard = memo(function PieceCard({
                 : `Sélectionner ${piece.name}`
             }
             onClick={handleSelect}
-            className={`absolute top-2 left-2 w-6 h-6 rounded-md flex items-center justify-center transition-all duration-300 z-20 ${ isSelected ? "bg-primary shadow-lg shadow-indigo-500/50 scale-110" : "bg-white/90 backdrop-blur-xs border border-slate-200 hover:border-indigo-400 hover:bg-muted" }`}
+            className={`absolute top-2 left-2 w-6 h-6 rounded-md flex items-center justify-center transition-all duration-300 z-20 ${isSelected ? "bg-primary shadow-lg shadow-indigo-500/50 scale-110" : "bg-white/90 backdrop-blur-xs border border-slate-200 hover:border-indigo-400 hover:bg-muted"}`}
           >
             {isSelected ? (
               <svg
@@ -325,7 +325,7 @@ const PieceCard = memo(function PieceCard({
                 ? `Ajouter ${piece.name} au panier`
                 : `${piece.name} indisponible`
             }
-            className={`flex items-center justify-center gap-1.5 px-3 py-2.5 min-h-[44px] min-w-[44px] rounded-lg text-xs sm:text-sm font-bold transition-all duration-200 active:scale-95 ${ !hasStock ? "bg-slate-100 text-slate-400 cursor-not-allowed" : !isLoading ? "bg-primary hover:bg-primary text-white shadow-md shadow-indigo-500/30" : "bg-primary text-white cursor-wait" }`}
+            className={`flex items-center justify-center gap-1.5 px-3 py-2.5 min-h-[44px] min-w-[44px] rounded-lg text-xs sm:text-sm font-bold transition-all duration-200 active:scale-95 ${!hasStock ? "bg-slate-100 text-slate-400 cursor-not-allowed" : !isLoading ? "bg-primary hover:bg-primary text-white shadow-md shadow-indigo-500/30" : "bg-primary text-white cursor-wait"}`}
             disabled={isLoading || !hasStock}
             onClick={handleAddToCart}
           >
@@ -565,7 +565,7 @@ export function PiecesGridView({
             onSelect={onSelectPiece}
             onAddToCart={handleAddToCart}
             onOpenDetail={handleOpenDetail}
-            priority={index < 6}
+            priority={index < 2}
           />
         ))}
       </div>


### PR DESCRIPTION
## Contexte

Rapport GSC CWV mobile 13/07 : LCP >2,5 s sur les groupes **home** (mixte 99 URLs) et **/pieces/\*** (1 325 URLs). L'audit `audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md` (attribution RUM `__seo_cwv_raw`) montre que **l'élément LCP est du TEXTE SSR** (h1/span de hero), pas une image — donc le levier est le `render_delay`, pas le download d'une image.

## Problème (vérifié runtime, DEV:3000 = main)

React 19 Float hoiste tout `<img fetchPriority="high">` en `<link rel="preload" as="image" fetchPriority="high">` **en tête de `<head>`**, avant le CSS render-blocking et les fonts. Preuve sur la home :

```
<head><meta charSet><meta viewport>
  <link rel="preload" as="image" href=".../Filtres.webp" fetchPriority="high"/>
  <link rel="preload" as="image" href=".../Freinage.webp" fetchPriority="high"/>
  <link rel="preload" as="image" href=".../Courroie_galet_poulie.webp" fetchPriority="high"/>
  <link rel="preload" as="image" href=".../Allumage_Prechauffage.webp" fetchPriority="high"/>
  <title>…  <!-- puis, bien plus bas, le <link rel=stylesheet> -->
```

Ces 4 vignettes appartiennent à `CatalogueSection` = **3ᵉ section de la home, sous le fold mobile** (`HeroSection` → `QuickAccessGrid` → `CatalogueSection`). Elles volent la bande passante que le LCP **texte** attend (CSS/fonts). Idem sur /pieces/\* : `priority={index<6}` passait **6 cartes produit** en eager+high alors que 1-2 sont visibles à 375 px.

## Changement (2 lignes)

- `home/CatalogueSection.tsx` — retrait de `fetchPriority="high"` (⇒ plus de preload Float en tête de head). `loading=eager` conservé (comportement inchangé, priorité rendue au CSS).
- `pieces/PiecesGridView.tsx` — `priority={index<6}` → `priority={index<2}` (mobile-réaliste ; `ProductGallery` mappe `priority`→eager+high).

## Pourquoi c'est sûr

Aucune de ces images n'est le LCP (texte) → on supprime un **vol de priorité**, pas un contenu. Les images se chargent toujours (eager). Blast radius nul, réversible. Pas de changement d'URL, pas de payments, pas de meta/H1.

**Hors scope (follow-up noté)** : le hero `PiecesHeader` (`<img>` + `<link rel=preload>` dédié `pieces-vehicle.meta.ts:145`) est entangled avec un preload distinct — retirer le seul attribut img serait inefficace tant que le preload domine. Traité séparément (audit §3C).

## Vérification

- ESLint flat `--max-warnings=0` + prettier (lint-staged pre-commit) ✅
- Mécanisme preload confirmé sur le HTML SSR servi (DEV:3000)
- Mesure d'impact : `render_delay` LCP mobile via `__seo_cwv_daily_rum` (route_group home + pieces_product) sur ~7 j après merge

Ref: `audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md` §3B/3C

🤖 Generated with [Claude Code](https://claude.com/claude-code)