### PR TITLE
perf(lcp): render <Links/> before <Meta/> so CSS is discovered before JSON-LD

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -376,8 +376,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
-        <Meta />
+        {/* LCP: <Links/> (CSS render-blocking + font/module preloads) AVANT <Meta/>.
+            Invariant : aucun bloc JSON-LD volumineux (script:ld+json émis par meta()
+            — Product/FAQPage, ~18 Ko sur R2) ne doit précéder la découverte du CSS
+            bloquant. charSet/viewport restent en tête (parse encoding). Ne pas
+            revenir à l'ordre RR par défaut Meta→Links.
+            Ref: audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md §3A */}
         <Links />
+        <Meta />
         {/* Runtime ENV exposed to the browser. Must run BEFORE entry.client.tsx
             so Sentry can pick up the DSN at hydration. JSON.stringify is safe
             for this minimal set (no user-controlled keys). */}


### PR DESCRIPTION
## Contexte

LCP mobile GSC >2,5 s sur /pieces/* et le groupe mixte. L'élément LCP est du **texte SSR** ; son paint est bloqué par le CSS render-blocking, découvert trop tard.

## Problème (vérifié runtime DEV:3000)

Sur une page R2, `<Meta/>` (rendu avant `<Links/>`) émet ~18 Ko de `script:ld+json` (Product + FAQPage) **avant** le `<link rel=stylesheet>` :

```
first ld+json     offset=3405
first stylesheet  offset=21467
head length       22014
```

Le preload-scanner ne découvre `global.css` qu'après ~21 Ko de HTML → ≥1 RTT mobile perdu avant même de démarrer le CSS bloquant.

## Changement (1 fichier)

`root.tsx` : `<Links/>` (CSS + preloads font/module) rendu **avant** `<Meta/>`. `charSet`/`viewport` restent en tête (encoding). Un commentaire documente l'invariant :

> Aucun bloc JSON-LD volumineux ne doit précéder la découverte du CSS bloquant.

React Router rend les enfants de `<head>` dans l'ordre JSX → le stylesheet remonte en tête, le JSON-LD passe après (le JSON-LD reste valide n'importe où dans le document pour Google).

## Pourquoi c'est sûr

- `charSet`/`viewport` inchangés en tête → parsing d'encodage préservé.
- Aucun changement de contenu : mêmes balises meta, même canonical, même JSON-LD — seul l'**ordre** change.
- Aucune URL, aucun payments, aucun meta_title/description/H1 modifié.
- Indépendant et complémentaire de #1266 (preloads image Float).

## Vérification

- ESLint flat `--max-warnings=0` + prettier ✅ ; typecheck app clean (seules erreurs = `@playwright/test` absent du node_modules du worktree, environnemental).
- Effet SSR déterministe (ordre JSX des enfants `<head>`) ; confirmation runtime = Lighthouse PREPROD CI + probe head post-merge (`first stylesheet` doit passer avant `first ld+json`).

Ref: `audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md` §3A

🤖 Generated with [Claude Code](https://claude.com/claude-code)