### PR TITLE
perf(ttfb): parallélise les fetch loopback indépendants des loaders R7/R4

### DIFF
--- a/frontend/app/routes/constructeurs.$brand[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand[.]html.tsx
@@ -93,7 +93,10 @@ export const headers: HeadersFunction = () => ({
 // 🔄 META
 // ==========================================
 
-export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({
+  loaderData: data,
+  location,
+}) => {
   if (!data || !data.seo) {
     return [{ title: "Pièces Auto" }];
   }
@@ -329,8 +332,14 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const marque_id = parseInt(match[2], 10);
 
   try {
-    // Récupération des données via l'API optimisée
-    const bestsellersResponse = await brandApi.getBrandPageData(marque_id);
+    // ⚡ LCP/TTFB (audit 2026-07-14 §2C) : les deux appels loopback ne dépendent
+    // que de marque_id → lancés en parallèle. getR7Content() ne rejette jamais
+    // (return null interne) : si les gates ci-dessous throw, sa promesse en vol
+    // est simplement abandonnée sans unhandled-rejection.
+    const bestsellersPromise = brandApi.getBrandPageData(marque_id);
+    const r7ContentPromise = brandApi.getR7Content(marque_id);
+
+    const bestsellersResponse = await bestsellersPromise;
 
     if (!bestsellersResponse.success || !bestsellersResponse.data) {
       throw new Error("Failed to fetch brand data");
@@ -347,8 +356,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
       });
     }
 
-    // 🏭 R7 enriched content (optional overlay)
-    const r7Content = await brandApi.getR7Content(marque_id);
+    // 🏭 R7 enriched content (optional overlay) — déjà en vol depuis le début
+    const r7Content = await r7ContentPromise;
 
     return { ...bestsellersResponse.data, r7Content };
   } catch (error) {

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -234,11 +234,6 @@ interface RelatedRef {
   title: string;
 }
 
-interface LoaderData {
-  reference: Reference;
-  relatedRefs: RelatedRef[];
-}
-
 /**
  * S16 — HeroRole vs HeroReference
  * HeroRole (pedagogique) si le texte roleMecanique est riche ET la piece a des interactions cross-gamme.
@@ -325,9 +320,30 @@ export async function loader({ params }: LoaderFunctionArgs) {
   try {
     const backendUrl = getInternalApiUrl("");
 
-    const res = await fetch(`${backendUrl}/api/seo/reference/${slug}`, {
+    // ⚡ LCP/TTFB (audit 2026-07-14 §2C) : le fetch principal et /related ne
+    // dépendent que de `slug` → lancés en parallèle. La promesse related ne
+    // rejette jamais (.catch → []) : si le principal throw 404, elle est
+    // abandonnée sans unhandled-rejection.
+    const referencePromise = fetch(`${backendUrl}/api/seo/reference/${slug}`, {
       headers: { "Content-Type": "application/json" },
     });
+    const relatedRefsPromise: Promise<RelatedRef[]> = fetch(
+      `${backendUrl}/api/seo/reference/${slug}/related`,
+      { headers: { "Content-Type": "application/json" } },
+    )
+      .then(async (relRes) => {
+        if (!relRes.ok) return [] as RelatedRef[];
+        const relData = await relRes.json();
+        return (relData.related || []).map(
+          (r: { slug: string; title: string }) => ({
+            slug: r.slug,
+            title: r.title,
+          }),
+        );
+      })
+      .catch(() => [] as RelatedRef[]); // Silently ignore — related refs are optional
+
+    const res = await referencePromise;
 
     if (!res.ok) {
       throw new Response("Référence non trouvée", { status: 404 });
@@ -339,25 +355,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
       throw new Response("Référence non trouvée", { status: 404 });
     }
 
-    // Fetch related references (non-blocking — empty array on error)
-    let relatedRefs: RelatedRef[] = [];
-    try {
-      const relRes = await fetch(
-        `${backendUrl}/api/seo/reference/${slug}/related`,
-        { headers: { "Content-Type": "application/json" } },
-      );
-      if (relRes.ok) {
-        const relData = await relRes.json();
-        relatedRefs = (relData.related || []).map(
-          (r: { slug: string; title: string }) => ({
-            slug: r.slug,
-            title: r.title,
-          }),
-        );
-      }
-    } catch {
-      // Silently ignore — related refs are optional
-    }
+    const relatedRefs = await relatedRefsPromise;
 
     return data(
       { reference, relatedRefs },

--- a/frontend/tests/unit/constructeurs-brand-loader-parallel.test.ts
+++ b/frontend/tests/unit/constructeurs-brand-loader-parallel.test.ts
@@ -1,0 +1,108 @@
+/**
+ * PR #8 (audit LCP 2026-07-14 §2C) — le loader de la page marque
+ * `/constructeurs/{brand}.html` enchaînait `getBrandPageData` PUIS `getR7Content`
+ * en SÉQUENTIEL alors que les deux ne dépendent que de `marque_id` (2 RTT loopback
+ * additifs → TTFB). Ce test épingle :
+ *   1. le parallélisme (les deux appels partent avant que le 1er ne résolve) ;
+ *   2. la préservation du gate 410 (marque_display===0) et du happy-path.
+ * getR7Content ne rejette jamais (return null interne) — pas de floating rejection.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { loader } from "~/routes/constructeurs.$brand[.]html";
+
+const { getBrandPageData, getR7Content } = vi.hoisted(() => ({
+  getBrandPageData: vi.fn(),
+  getR7Content: vi.fn(),
+}));
+
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("~/services/api/brand.api", () => ({
+  brandApi: { getBrandPageData, getR7Content },
+}));
+
+const call = () =>
+  loader({
+    params: { brand: "bmw-33" },
+    request: new Request("https://www.automecanik.com/constructeurs/bmw-33.html"),
+    context: {},
+  } as never);
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  getBrandPageData.mockReset();
+  getR7Content.mockReset();
+});
+
+describe("constructeurs.$brand[.]html loader — parallélise getBrandPageData + getR7Content", () => {
+  it("dispatche les DEUX appels avant que getBrandPageData ne résolve (parallélisme)", async () => {
+    const brand = deferred<{ success: boolean; data: unknown }>();
+    getBrandPageData.mockReturnValue(brand.promise);
+    getR7Content.mockResolvedValue(null);
+
+    const p = call(); // ne pas await : getBrandPageData est encore pending
+    await Promise.resolve(); // flush microtasks
+
+    // Cœur de la régression : en séquentiel, getR7Content n'est PAS encore appelé.
+    expect(getBrandPageData).toHaveBeenCalledWith(33);
+    expect(getR7Content).toHaveBeenCalledWith(33);
+
+    brand.resolve({ success: true, data: { brand: { marque_display: 1 } } });
+    await p;
+  });
+
+  it("happy-path : retourne les données marque + r7Content", async () => {
+    getBrandPageData.mockResolvedValue({
+      success: true,
+      data: { brand: { marque_display: 1 }, popular_parts: [] },
+    });
+    getR7Content.mockResolvedValue({ h1: "BMW" });
+
+    const result = (await call()) as { r7Content: unknown; brand: unknown };
+    expect(result.brand).toEqual({ marque_display: 1 });
+    expect(result.r7Content).toEqual({ h1: "BMW" });
+    expect(getBrandPageData).toHaveBeenCalledWith(33);
+    expect(getR7Content).toHaveBeenCalledWith(33);
+  });
+
+  it("gate 410 préservé : marque_display===0 → 410 Gone noindex,follow", async () => {
+    getBrandPageData.mockResolvedValue({
+      success: true,
+      data: { brand: { marque_display: 0 } },
+    });
+    getR7Content.mockResolvedValue(null);
+
+    let thrown: Response | undefined;
+    try {
+      await call();
+    } catch (e) {
+      thrown = e as Response;
+    }
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(410);
+    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("échec brand → 404 (le résultat r7 ne fuit pas)", async () => {
+    getBrandPageData.mockResolvedValue({ success: false, data: null });
+    getR7Content.mockResolvedValue({ h1: "leak?" });
+
+    let thrown: Response | undefined;
+    try {
+      await call();
+    } catch (e) {
+      thrown = e as Response;
+    }
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(404);
+  });
+});

--- a/frontend/tests/unit/reference-auto-loader-parallel.test.ts
+++ b/frontend/tests/unit/reference-auto-loader-parallel.test.ts
@@ -1,0 +1,114 @@
+/**
+ * PR #8 (audit LCP 2026-07-14 §2C) — le loader `/reference-auto/{slug}` enchaînait
+ * le fetch principal PUIS le fetch `/related` en SÉQUENTIEL, malgré le commentaire
+ * "non-blocking" : les deux ne dépendent que de `slug`. Ce test épingle :
+ *   1. le parallélisme (les 2 fetch partent avant que le principal ne résolve) ;
+ *   2. la préservation du 404 (principal !ok) et du silent-[] (related en erreur).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { loader } from "~/routes/reference-auto.$slug";
+
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("~/utils/internal-api.server", () => ({
+  getInternalApiUrl: () => "http://internal",
+}));
+
+const SLUG = "soupape-d-admission";
+const call = () =>
+  loader({
+    params: { slug: SLUG },
+    request: new Request(`https://www.automecanik.com/reference-auto/${SLUG}`),
+    context: {},
+  } as never);
+
+const okJson = (body: unknown) => ({ ok: true, json: async () => body });
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("reference-auto.$slug loader — parallélise le fetch principal + /related", () => {
+  it("dispatche les DEUX fetch avant que le principal ne résolve (parallélisme)", async () => {
+    const main = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    fetchMock.mockImplementation((url: string) =>
+      url.endsWith("/related")
+        ? Promise.resolve(okJson({ related: [] }))
+        : main.promise,
+    );
+
+    const p = call(); // principal encore pending
+    await Promise.resolve();
+
+    // Cœur de la régression : en séquentiel, seul le fetch principal est parti.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.some(([u]) => String(u).endsWith("/related"))).toBe(
+      true,
+    );
+
+    main.resolve(okJson({ slug: SLUG, title: "Soupape" }));
+    await p;
+  });
+
+  it("happy-path : retourne reference + relatedRefs mappés", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.endsWith("/related")
+        ? Promise.resolve(
+            okJson({ related: [{ slug: "a", title: "A", extra: "drop" }] }),
+          )
+        : Promise.resolve(okJson({ slug: SLUG, title: "Soupape" })),
+    );
+
+    const body = (
+      (await call()) as { data: { reference: unknown; relatedRefs: unknown } }
+    ).data;
+    expect(body.reference).toEqual({ slug: SLUG, title: "Soupape" });
+    expect(body.relatedRefs).toEqual([{ slug: "a", title: "A" }]);
+  });
+
+  it("principal !ok → 404", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.endsWith("/related")
+        ? Promise.resolve(okJson({ related: [] }))
+        : Promise.resolve({ ok: false, json: async () => ({}) }),
+    );
+
+    let thrown: Response | undefined;
+    try {
+      await call();
+    } catch (e) {
+      thrown = e as Response;
+    }
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(404);
+  });
+
+  it("related en erreur → relatedRefs = [] (silent)", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.endsWith("/related")
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve(okJson({ slug: SLUG, title: "Soupape" })),
+    );
+
+    const body = (
+      (await call()) as { data: { reference: unknown; relatedRefs: unknown } }
+    ).data;
+    expect(body.reference).toEqual({ slug: SLUG, title: "Soupape" });
+    expect(body.relatedRefs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Contexte

Audit LCP mobile §2C : sur les surfaces non edge-cachées, chaque landing paie le TTFB origin complet. Deux loaders enchaînaient des appels **loopback séquentiels** alors que chaque appel ne dépend que du param d'URL → 2 RTT additifs évitables.

## Changement (comportement strictement préservé — seule la concurrence change)

**`constructeurs/{brand}.html`** — `getBrandPageData(marque_id)` PUIS `getR7Content(marque_id)` :
- Les deux promesses sont lancées d'emblée. On `await` la marque **en premier** → les gates 404 / **410** (`marque_display===0`, ADR-084) restent intacts et throwent avant d'utiliser R7.
- `getR7Content` ne rejette jamais (`return null` interne) → pas de floating-rejection si un gate throw.

**`reference-auto/{slug}`** — fetch principal PUIS fetch `/related` (pourtant commenté « non-blocking ») :
- `/related` lancé en parallèle, promesse terminée par `.catch(() => [])` (silent, inchangé).
- Le `404` (principal `!ok` ou `!reference.slug`) est préservé : on throw avant d'`await` related.

## Tests (TDD)

2 fichiers, **8/8**. Le test de parallélisme est écrit pour **échouer sur le code séquentiel** (RED : le 2ᵉ appel n'est pas dispatché avant que le 1ᵉ ne résolve) puis passer après le fix. Les tests de gate (404/410) et happy-path/silent-[] verrouillent la non-régression. Les tests existants `constructeurs-model-410` + `-html-wrapper-noindex` restent verts (7/7).

## Note

Suppression de l'interface morte `LoaderData` dans `reference-auto` (0 référence — la route utilise `useLoaderData<typeof loader>`), **pré-existante sur main**, forcée par le gate `--max-warnings=0` du fichier restagé.

Ref: `audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md` §2C

🤖 Generated with [Claude Code](https://claude.com/claude-code)