### PR TITLE
perf(ttfb): projection status-only du moteur de substitution (hub gamme)

### DIFF
--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,11 +2,12 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-07-02'
+last_scan: '2026-07-14'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts
 - backend/src/modules/substitution/services/substitution-logger.service.ts
+- backend/src/modules/substitution/services/substitution.service.light-mode.test.ts
 - backend/src/modules/substitution/services/substitution.service.ts
 - backend/src/modules/substitution/substitution.module.ts
 - backend/src/modules/substitution/types/substitution.types.ts

--- a/backend/src/modules/substitution/controllers/substitution.controller.ts
+++ b/backend/src/modules/substitution/controllers/substitution.controller.ts
@@ -61,6 +61,10 @@ export class SubstitutionController {
   async checkSubstitution(
     @Query('url') url: string,
     @Headers('user-agent') userAgent: string,
+    // ⚡ `vehicleOptions=false` → projection status-only (sans lock.options, la
+    // liste lourde des motorisations). Défaut = full (rétro-compatible).
+    // Audit LCP 2026-07-14 §2A.
+    @Query('vehicleOptions') vehicleOptions?: string,
   ): Promise<SubstitutionResult> {
     if (!url) {
       return {
@@ -78,7 +82,9 @@ export class SubstitutionController {
     }
 
     this.logger.debug(`Checking substitution for: ${url}`);
-    return this.substitutionService.checkSubstitution(url, userAgent || '');
+    return this.substitutionService.checkSubstitution(url, userAgent || '', {
+      includeVehicleOptions: vehicleOptions !== 'false',
+    });
   }
 
   /**

--- a/backend/src/modules/substitution/services/substitution.service.light-mode.test.ts
+++ b/backend/src/modules/substitution/services/substitution.service.light-mode.test.ts
@@ -1,0 +1,127 @@
+import { SubstitutionService } from './substitution.service';
+import { SubstitutionDataResponse } from '../types/substitution.types';
+
+/**
+ * PR #4 (audit LCP 2026-07-14 §2A) — projection status-only du moteur de
+ * substitution. Le hub gamme SSR ne lit que httpStatus/type et jette `lock` ;
+ * `lock.options` (jusqu'à ~5 300 motorisations ≈ 1,1 Mo) n'a aucun consommateur.
+ * `checkSubstitution(url, ua, { includeVehicleOptions:false })` doit produire le
+ * MÊME résultat, sans peupler `lock.options`.
+ */
+
+const RPC_DATA: SubstitutionDataResponse = {
+  _meta: {
+    gamme_found: true,
+    resolved_by: 'exact',
+    products_count: 5,
+    vehicle_found: false,
+  },
+  gamme: {
+    pg_id: 7,
+    pg_name: 'Filtre à huile',
+    pg_alias: 'filtre-a-huile',
+    mf_id: 1,
+    mf_name: 'Filtration',
+  },
+  compatible_motors: [
+    {
+      type_id: 101,
+      type_name: 'Clio III 1.5 dCi',
+      type_alias: 'clio-iii-1-5-dci',
+      type_fuel: 'Diesel',
+      type_power_ps: '90',
+      type_year_from: '2005',
+      type_year_to: null,
+      type_body: 'Berline',
+    },
+    { type_id: 102, type_name: 'Clio III 1.4', type_alias: 'clio-iii-1-4' },
+  ],
+} as SubstitutionDataResponse;
+
+function makeService(): SubstitutionService {
+  // Bypass du constructeur SupabaseBaseService : on n'a besoin que des collaborateurs
+  // touchés par checkSubstitution (intent, logger async, callRpc stubbé).
+  const service = Object.create(
+    SubstitutionService.prototype,
+  ) as SubstitutionService;
+
+  (service as unknown as { intentExtractor: unknown }).intentExtractor = {
+    isSuspiciousBot: () => false,
+    extractFromPathname: () => ({
+      gammeId: 7,
+      gammeAlias: 'filtre-a-huile',
+      marqueAlias: null,
+      modeleAlias: null,
+      typeAlias: null,
+      typeId: undefined,
+    }),
+  };
+  (service as unknown as { substitutionLogger: unknown }).substitutionLogger = {
+    logAsync: jest.fn(),
+  };
+  (service as unknown as { logger: unknown }).logger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+  };
+  (service as unknown as { callRpc: unknown }).callRpc = jest
+    .fn()
+    .mockResolvedValue({ data: RPC_DATA, error: null });
+
+  return service;
+}
+
+const URL = '/pieces/filtre-a-huile-7.html';
+
+describe('SubstitutionService — projection status-only (includeVehicleOptions)', () => {
+  it('mode plein (défaut) : lock.options peuplé avec les motorisations', async () => {
+    const service = makeService();
+    const r = await service.checkSubstitution(URL, '');
+
+    expect(r.httpStatus).toBe(200);
+    expect(r.type).toBe('vehicle_incomplete');
+    expect(r.lock?.options).toHaveLength(2);
+    expect(r.lock?.options?.[0]).toMatchObject({ id: 101 });
+  });
+
+  it('mode léger (includeVehicleOptions:false) : lock.options VIDE, tout le reste identique', async () => {
+    const service = makeService();
+    const full = await service.checkSubstitution(URL, '');
+    const light = await service.checkSubstitution(URL, '', {
+      includeVehicleOptions: false,
+    });
+
+    // Le cœur du fix : plus de liste lourde.
+    expect(light.lock?.options).toEqual([]);
+
+    // httpStatus / type / message / lock.type / lock.known STRICTEMENT préservés.
+    expect(light.httpStatus).toBe(full.httpStatus);
+    expect(light.type).toBe(full.type);
+    expect(light.message).toBe(full.message);
+    expect(light.lock?.type).toBe('vehicle');
+    expect(light.lock?.known).toEqual(full.lock?.known);
+    expect(light.seo).toEqual(full.seo);
+  });
+
+  it("mode léger n'altère pas le routing 404 (gamme non trouvée)", async () => {
+    const service = makeService();
+    (service as unknown as { callRpc: jest.Mock }).callRpc.mockResolvedValue({
+      data: {
+        _meta: {
+          gamme_found: false,
+          resolved_by: 'none',
+          products_count: 0,
+          vehicle_found: false,
+        },
+      },
+      error: null,
+    });
+
+    const light = await service.checkSubstitution(URL, '', {
+      includeVehicleOptions: false,
+    });
+    expect(light.httpStatus).toBe(404);
+    expect(light.type).toBe('unknown_slug');
+  });
+});

--- a/backend/src/modules/substitution/services/substitution.service.ts
+++ b/backend/src/modules/substitution/services/substitution.service.ts
@@ -12,6 +12,7 @@ import {
   LockType,
   SubstitutionLock,
   SubstitutionDataResponse,
+  CheckSubstitutionOptions,
 } from '../types/substitution.types';
 import { getErrorMessage } from '@common/utils/error.utils';
 
@@ -49,7 +50,15 @@ export class SubstitutionService extends SupabaseBaseService {
   async checkSubstitution(
     url: string,
     userAgent: string = '',
+    opts: CheckSubstitutionOptions = {},
   ): Promise<SubstitutionResult> {
+    // ⚡ TTFB (audit LCP 2026-07-14 §2A) : le consommateur SSR du hub gamme
+    // (pieces.$slug.tsx) ne lit que httpStatus/type et jette le `lock` du payload
+    // client. En mode léger (includeVehicleOptions:false) on n'embarque pas la
+    // liste des motorisations compatibles dans lock.options (jusqu'à ~5 300 items
+    // ≈ 1,1 Mo → parse main-thread SSR). httpStatus/type/known restent identiques.
+    // Défaut = true (rétro-compatible ; aucun autre appelant).
+    const includeVehicleOptions = opts.includeVehicleOptions !== false;
     const startTime = Date.now();
 
     // 1. Détecter les bots suspects
@@ -66,7 +75,11 @@ export class SubstitutionService extends SupabaseBaseService {
     const rpcData = await this.fetchSubstitutionData(intent);
 
     // 4. Déterminer le type de substitution
-    const result = this.determineSubstitution(intent, rpcData);
+    const result = this.determineSubstitution(
+      intent,
+      rpcData,
+      includeVehicleOptions,
+    );
 
     // 5. Logger async (ne bloque pas la réponse)
     this.substitutionLogger.logAsync({
@@ -142,6 +155,7 @@ export class SubstitutionService extends SupabaseBaseService {
   private determineSubstitution(
     intent: ExtractedIntent,
     data: SubstitutionDataResponse,
+    includeVehicleOptions: boolean = true,
   ): SubstitutionResult {
     // CASE 1: Gamme non trouvée → 404
     if (!data._meta?.gamme_found) {
@@ -179,7 +193,12 @@ export class SubstitutionService extends SupabaseBaseService {
     // CASE 3: Véhicule incomplet → 200 avec Lock (page SEO enrichie)
     // V3: Inclut compatibleGammes dans le résultat
     if (!intent.typeId && intent.gammeId) {
-      const lock = this.buildLock('vehicle', intent, data);
+      const lock = this.buildLock(
+        'vehicle',
+        intent,
+        data,
+        includeVehicleOptions,
+      );
       const gammeName = data.gamme?.pg_name || 'Pièces';
 
       return this.buildResult(
@@ -229,6 +248,7 @@ export class SubstitutionService extends SupabaseBaseService {
     type: LockType,
     intent: ExtractedIntent,
     data: SubstitutionDataResponse,
+    includeVehicleOptions: boolean = true,
   ): SubstitutionLock {
     const lock: SubstitutionLock = {
       type,
@@ -248,7 +268,9 @@ export class SubstitutionService extends SupabaseBaseService {
 
     // Remplir les options de déblocage (motorisations compatibles)
     // V3: Inclut les détails véhicule dans metadata
-    if (type === 'vehicle' && data.compatible_motors) {
+    // ⚡ Skippé en mode léger (SSR status-only) : c'est la liste lourde (~5 300
+    // items ≈ 1,1 Mo) et elle n'a aucun consommateur (le loader jette `lock`).
+    if (type === 'vehicle' && includeVehicleOptions && data.compatible_motors) {
       lock.options = data.compatible_motors.map((motor) => ({
         id: motor.type_id,
         label: motor.type_name,

--- a/backend/src/modules/substitution/types/substitution.types.ts
+++ b/backend/src/modules/substitution/types/substitution.types.ts
@@ -102,6 +102,16 @@ export interface SubstitutionLock {
 }
 
 /**
+ * Options de checkSubstitution.
+ * `includeVehicleOptions` (défaut true) : embarquer la liste des motorisations
+ * compatibles dans `lock.options`. Le consommateur SSR status-only la met à
+ * false pour éviter le payload ~1,1 Mo (audit LCP 2026-07-14 §2A).
+ */
+export interface CheckSubstitutionOptions {
+  includeVehicleOptions?: boolean;
+}
+
+/**
  * Resultat de la recherche de substitution
  */
 export interface SubstitutionResult {

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -205,8 +205,11 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     const [apiData, substitutionResponse] = await Promise.all([
       fetchGammePageData(gammeId, { signal: controller.signal }),
       // 🔄 Substitution API pour données enrichies (412/410 handling)
+      // ⚡ vehicleOptions=false : on ne lit que httpStatus/type et on jette `lock`
+      // du payload client (plus bas) → mode léger côté serveur pour éviter le
+      // parse ~1,1 Mo (lock.options, ~5 300 motorisations). Audit LCP §2A.
       fetch(
-        `${API_URL}/api/substitution/check?url=${encodeURIComponent(substitutionPath)}`,
+        `${API_URL}/api/substitution/check?url=${encodeURIComponent(substitutionPath)}&vehicleOptions=false`,
         {
           signal: subController.signal,
         },


### PR DESCRIPTION
## Contexte

Audit LCP §2A. Sur le hub gamme `/pieces/{slug}.html`, le loader SSR fait un self-fetch `/api/substitution/check` et **`res.json()`-parse ~1,1 Mo** (mesuré DEV : réponse `1 146 806 B` constante sur la gamme 7) alors qu'il ne lit que `httpStatus`/`type` et **jette `lock`** du payload client (depuis #1261). Ce parse de 1,1 Mo à chaque SSR = ~300 ms de TTFB origin sur les grosses gammes (filtres, plaquettes = le trafic dominant du groupe GSC).

`buildLock` mappe **toutes** les `compatible_motors` (~5 300 pour la gamme 7) dans `lock.options`. **#1261 avait retiré `lock` du payload _client_, pas ce fetch+parse _serveur_.**

## Changement (opt-in rétro-compatible)

- **Service** `checkSubstitution(url, ua, { includeVehicleOptions })` — défaut `true`. `false` → `buildLock` n'embarque pas `compatible_motors` (`lock.options` reste `[]`). `httpStatus` / `type` / `message` / `lock.type` / `lock.known` / `seo` **strictement identiques**.
- **Controller** : query `?vehicleOptions=false` → mode léger. Défaut = full.
- **Loader** : appelle avec `&vehicleOptions=false`.

Le loader est le **seul** appelant de l'endpoint, et `lock.options` n'a **aucun** consommateur (la seule référence à `lock` côté front est le log de `lock?.type`, préservé). Mode léger sûr.

## Tests (TDD)

`substitution.service.light-mode.test.ts` — **3/3** : full → `options` peuplé (2) ; léger → `options` `[]` + tout le reste égal au full ; léger n'altère pas le 404. **Mutation-check** effectué : en retirant le guard `includeVehicleOptions`, le test léger passe au rouge (puis vert après restauration) → le test garde bien le comportement.

## Suite (hors PR, owner-gated)

Étape 2 : param RPC pour ne pas rapatrier `compatible_motors` de Supabase (le transfert Supabase→Nest subsiste ; nécessite une migration additive). Non inclus ici.

## Vérification

ESLint `--max-warnings=0` (backend + frontend) + prettier ✅ ; backend `tsc --noEmit` clean ; jest 3/3.

Ref: `audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md` §2A

🤖 Generated with [Claude Code](https://claude.com/claude-code)