### PR TITLE
perf(ttfb): cache R3 guide — TTL 30 min → 24 h (blog conseils)

### DIFF
--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -38,8 +38,16 @@ import { InternalLinkingService } from '../../seo/internal-linking.service';
  *  v2 (2026-05-24) : compatible vehicles capped à 24 (LCP /blog-pieces-auto/conseils/* — voir PR LCP-R3-PR1). */
 const R3_CACHE_PREFIX = 'r3-guide:v2:';
 
-/** TTL fresh window (seconds) — CacheService utilise ioredis SETEX en secondes. */
-const R3_CACHE_TTL_SECONDS = 30 * 60;
+/** TTL fresh window (seconds) — CacheService utilise ioredis SETEX en secondes.
+ *  24 h (audit LCP 2026-07-14 §2B) : /blog-pieces-auto/conseils/* = 43 URLs à
+ *  très faible trafic (~1 hit/URL/2 j) — à 30 min quasi chaque visite humaine
+ *  tombait en cache-miss (+~450 ms compute, 9-fanout Supabase) → TTFB p75 ~2,1 s.
+ *  Contenu éditorial (change rarement).
+ *  ⚠️ L'invalidation @OnEvent('article.published'|'article.updated') existe mais
+ *  AUCUN émetteur n'est câblé (dormant) → le TTL est aujourd'hui le SEUL mécanisme
+ *  de fraîcheur : 24 h est le plafond de staleness sur une édition de guide.
+ *  Follow-up recommandé : câbler l'émetteur dans les endpoints admin publish/update. */
+const R3_CACHE_TTL_SECONDS = 24 * 60 * 60;
 
 @Injectable()
 export class R3GuideService {


### PR DESCRIPTION
## Contexte

Audit LCP §2B. Groupe GSC `/blog-pieces-auto/conseils/*` : **LCP 4,6 s**, TTFB moyen dominant **2120 ms**. Ces 43 URLs ont un trafic très faible (RUM ~1 hit/URL/2 j) ; à TTL Redis **30 min**, la fenêtre chaude n'est quasi jamais touchée → presque chaque visite humaine paie le compute complet (**+~450 ms**, 9-fanout Supabase ; DEV : API cold 367-445 ms vs warm 4-5 ms).

## Changement (1 ligne)

`R3_CACHE_TTL_SECONDS` : `30 * 60` → `24 * 60 * 60`. Contenu éditorial (change rarement) → 24 h de fenêtre fraîche adaptée.

## ⚠️ Nuance vérifiée (corrige l'hypothèse de l'audit)

L'audit affirmait « invalidation par événement déjà câblée ». **Vérifié : à moitié faux.** Le _listener_ `@OnEvent('article.published'|'article.updated')` existe, mais **aucun émetteur** n'est câblé dans `backend/src` (0 hit sur `emit('article.…`). L'invalidation event-driven est **dormante** → le TTL est aujourd'hui le **seul** mécanisme de fraîcheur.

Conséquence : 24 h devient le plafond de staleness sur une **édition** de guide (au lieu de 30 min). Acceptable (contenu éditorial rare, trafic faible), mais à trancher côté owner :
- **Follow-up recommandé** : câbler l'émetteur dans les endpoints admin publish/update (invalidation quasi-immédiate) — classe de change distincte, hors de cette PR.
- **Alternative** : réduire le TTL (ex. 6 h) si un plafond plus court est préféré sans câbler l'émetteur.

## Vérification

Test TTL-régression existant (`setCacheTtlForTest`, seconds-vs-ms) : **10/10** vert. ESLint `--max-warnings=0` + prettier ✅.

Ref: `audit/lcp-cwv-mobile-3-groups-root-cause-2026-07-14.md` §2B

🤖 Generated with [Claude Code](https://claude.com/claude-code)