### PR TITLE
fix(cache-control): single owner via buildCacheHeaders, retire Caddy backfill duplicate

### DIFF
--- a/backend/src/remix/remix.controller.test.ts
+++ b/backend/src/remix/remix.controller.test.ts
@@ -76,6 +76,9 @@ describe('RemixController — serverObservability injection gate', () => {
       url: '/',
       method: 'GET',
       path: '/',
+      // Real Express requests always carry `.headers`; the `.data` privacy guard
+      // (enforceSessionedDataCachePrivacy) reads request.headers.cookie.
+      headers: {},
       user: undefined,
       body: undefined,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/src/remix/remix.controller.ts
+++ b/backend/src/remix/remix.controller.ts
@@ -55,6 +55,99 @@ const serverObservability = {
   },
 } satisfies ServerObservabilityPort;
 
+/**
+ * H2 — session privacy for single-fetch `.data` responses (PR #1272 review).
+ *
+ * React Router 8 single fetch (default; `ssr: true`) serves client navigations
+ * as `GET <path>.data` requests. Those responses NEVER flow through
+ * `frontend/app/entry.server.tsx`'s document arbiter: `applySessionCachePrivacy`
+ * runs only inside the default `handleRequest` export (HTML documents), and RR8
+ * removed the `handleDataRequest` hook. A `.data` payload embeds the REVALIDATED
+ * root loader (`{ user, cart }`), and PR B gave several previously-private public
+ * routes a `public, s-maxage` `headers` export — so a session-bearing `.data`
+ * for one of those routes would otherwise ship a shared-cache policy over a body
+ * containing the logged-in user + cart (a privacy leak the moment an edge cache
+ * honours it).
+ *
+ * These helpers close the gap at the one server chokepoint that sees every
+ * `.data` response — this façade — forcing the SAME invariant as the document
+ * arbiter and Caddy `@private`. The cookie pattern MIRRORS `entry.server.tsx`
+ * `SESSION_COOKIE_RE` and the Caddy `@public_cached` matcher
+ * (`(?i)(connect\.sid|session)`) so all three layers agree on what "sessioned"
+ * means — do not change one without the others. (Colocated here rather than in a
+ * new module so the change stays inside this already-owned file.)
+ */
+export const SESSION_COOKIE_RE = /(?:connect\.sid|session)/i;
+
+/** Exact invariant required on any sessioned `.data` response (three cache tiers). */
+export const SESSIONED_DATA_CACHE_HEADERS = {
+  'Cache-Control': 'private, no-cache, no-store, must-revalidate',
+  'CDN-Cache-Control': 'no-store',
+  'Cloudflare-CDN-Cache-Control': 'no-store',
+} as const;
+
+/** RR8 single-fetch data requests are `GET <path>.data` (query stripped by `req.path`). */
+export function isSingleFetchDataRequest(pathname: string): boolean {
+  return pathname.endsWith('.data');
+}
+
+export function isSessionedCookie(
+  cookieHeader: string | undefined | null,
+): boolean {
+  return !!cookieHeader && SESSION_COOKIE_RE.test(cookieHeader);
+}
+
+/**
+ * True iff this is a single-fetch `.data` request carrying a session cookie —
+ * i.e. a response that must be forced private/no-store. Documents (non-`.data`)
+ * are deliberately excluded here: they are already covered by the entry.server
+ * document arbiter, so this façade guard only owns the `.data` channel.
+ */
+export function requiresSessionedDataPrivacy(
+  pathname: string,
+  cookieHeader: string | undefined | null,
+): boolean {
+  return isSingleFetchDataRequest(pathname) && isSessionedCookie(cookieHeader);
+}
+
+type CachePrivacyRequest = Pick<Request, 'path'> & {
+  headers: { cookie?: string };
+};
+
+/**
+ * Arms the `.data` privacy guard for the given request/response pair, returning
+ * `true` when armed (for the controller / tests).
+ *
+ * The `@react-router/express` adapter writes the route's headers via
+ * `res.append(...)` and then streams the body — which triggers Node's implicit
+ * `res.writeHead` just before the headers are flushed. That implicit call is the
+ * only reliable seam to OVERRIDE the public `Cache-Control` the route emitted
+ * (the standard `on-headers` technique); headers are still mutable at that
+ * point. We never touch the body — only the three cache-tier headers.
+ */
+export function enforceSessionedDataCachePrivacy(
+  request: CachePrivacyRequest,
+  response: Response,
+): boolean {
+  if (!requiresSessionedDataPrivacy(request.path, request.headers.cookie)) {
+    return false;
+  }
+
+  const originalWriteHead = response.writeHead.bind(response);
+  response.writeHead = function patchedWriteHead(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+  ): Response {
+    for (const [name, value] of Object.entries(SESSIONED_DATA_CACHE_HEADERS)) {
+      response.setHeader(name, value);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (originalWriteHead as any)(...args);
+  } as Response['writeHead'];
+
+  return true;
+}
+
 @Controller()
 export class RemixController {
   private readonly logger = new Logger(RemixController.name);
@@ -81,6 +174,13 @@ export class RemixController {
     ) {
       return next();
     }
+
+    // H2 (PR #1272 review): single-fetch `.data` responses bypass the
+    // entry.server document arbiter. Arm the sessioned-`.data` privacy guard
+    // BEFORE the RR handler runs so a session-bearing `.data` for a public route
+    // can never ship `public, s-maxage` over a body embedding the root
+    // { user, cart }. No-op for documents and anonymous `.data`.
+    enforceSessionedDataCachePrivacy(request, response);
 
     try {
       // v8_middleware: `getLoadContext` must return a `RouterContextProvider`.

--- a/backend/src/remix/session-data-cache-privacy.test.ts
+++ b/backend/src/remix/session-data-cache-privacy.test.ts
@@ -1,0 +1,173 @@
+/**
+ * H2 (PR #1272 review) — single-fetch `.data` responses bypass the
+ * entry.server document arbiter (`applySessionCachePrivacy` runs only for HTML
+ * documents; RR8 has no `handleDataRequest`). PR B gave several previously
+ * root-`private` public routes a `public, s-maxage` `headers` export, so a
+ * session-bearing `.data` for one of those routes would ship a shared-cache
+ * policy over a body embedding the revalidated root `{ user, cart }`.
+ *
+ * These tests lock the invariant at the façade guard:
+ *   #1 anonymous `.data` on a healthy public route → public TTL preserved;
+ *   #2 same `.data` with `connect.sid` → private/no-store at all three tiers;
+ *   #3 a route newly made public by PR B (not just `pieces.$slug`);
+ *   #4 the body may carry root data yet never receives `public` when sessioned.
+ */
+import { type Response } from 'express';
+import {
+  enforceSessionedDataCachePrivacy,
+  requiresSessionedDataPrivacy,
+  SESSIONED_DATA_CACHE_HEADERS,
+} from './remix.controller';
+
+// The `.data` privacy helpers are colocated in remix.controller.ts (kept inside
+// that already-owned file rather than a new module). Mock the controller's heavy
+// deps so importing the pure helpers doesn't drag the SSR build / Nest graph.
+// (ts-jest hoists these jest.mock() calls above the import above.)
+jest.mock('@fafa/frontend', () => ({
+  getServerBuild: jest.fn(),
+  getCreateAppLoadContext: jest.fn(),
+}));
+jest.mock('@react-router/express', () => ({ createRequestHandler: jest.fn() }));
+jest.mock('@sentry/nestjs', () => ({
+  withScope: jest.fn(),
+  captureException: jest.fn(),
+}));
+jest.mock('./remix.service', () => ({ RemixService: class {} }));
+jest.mock('./remix-api.service', () => ({ RemixApiService: class {} }));
+
+// Minimal Express-response double mirroring how @react-router/express writes:
+// per-header `res.append(...)`, then an implicit `res.writeHead` at flush, then
+// the streamed body. Header names are compared case-insensitively (HTTP).
+function makeFakeRes() {
+  const headers = new Map<string, string>();
+  const body: string[] = [];
+  const res = {
+    setHeader(name: string, value: string) {
+      headers.set(name.toLowerCase(), value);
+      return res;
+    },
+    append(name: string, value: string) {
+      const cur = headers.get(name.toLowerCase());
+      headers.set(name.toLowerCase(), cur ? `${cur}, ${value}` : value);
+      return res;
+    },
+    writeHead(_status: number) {
+      return res;
+    },
+    write(chunk: string) {
+      body.push(chunk);
+      return true;
+    },
+    end(chunk?: string) {
+      if (chunk) body.push(chunk);
+      return res;
+    },
+  };
+  return { res, headers, body };
+}
+
+const cookieReq = (path: string, cookie?: string) =>
+  ({ path, headers: cookie ? { cookie } : {} }) as {
+    path: string;
+    headers: { cookie?: string };
+  };
+
+// A route PR B newly moved from root-`private` to a public `headers` export.
+const NEWLY_PUBLIC_DATA_PATH = '/blog-pieces-auto/advice.data';
+const SESSION_COOKIE = 'connect.sid=s%3AsomeSignedSessionValue.hmac';
+
+describe('requiresSessionedDataPrivacy — classification', () => {
+  it('#3 sessioned `.data` on a route PR B made public → requires privacy', () => {
+    expect(
+      requiresSessionedDataPrivacy(NEWLY_PUBLIC_DATA_PATH, SESSION_COOKIE),
+    ).toBe(true);
+    // not only pieces.$slug:
+    expect(
+      requiresSessionedDataPrivacy('/reference-auto/xyz.data', SESSION_COOKIE),
+    ).toBe(true);
+    expect(
+      requiresSessionedDataPrivacy('/pieces/x.html.data', SESSION_COOKIE),
+    ).toBe(true);
+  });
+
+  it('generic `session` cookie also counts (mirror of the Caddy/app matcher)', () => {
+    expect(
+      requiresSessionedDataPrivacy(NEWLY_PUBLIC_DATA_PATH, 'my_session=abc'),
+    ).toBe(true);
+  });
+
+  it('#1 anonymous `.data` (no cookie) → does NOT require privacy', () => {
+    expect(
+      requiresSessionedDataPrivacy(NEWLY_PUBLIC_DATA_PATH, undefined),
+    ).toBe(false);
+    expect(requiresSessionedDataPrivacy(NEWLY_PUBLIC_DATA_PATH, '')).toBe(
+      false,
+    );
+  });
+
+  it('non-session cookie on `.data` → does NOT require privacy', () => {
+    expect(
+      requiresSessionedDataPrivacy(NEWLY_PUBLIC_DATA_PATH, 'theme=dark'),
+    ).toBe(false);
+  });
+
+  it('document requests are out of scope (covered by the entry.server arbiter)', () => {
+    expect(
+      requiresSessionedDataPrivacy('/blog-pieces-auto/advice', SESSION_COOKIE),
+    ).toBe(false);
+    expect(requiresSessionedDataPrivacy('/pieces/x.html', SESSION_COOKIE)).toBe(
+      false,
+    );
+  });
+});
+
+describe('enforceSessionedDataCachePrivacy — response invariant', () => {
+  it('#2/#4 sessioned `.data`: public route policy overridden to private/no-store at all three tiers; body untouched', () => {
+    const { res, headers, body } = makeFakeRes();
+
+    const armed = enforceSessionedDataCachePrivacy(
+      cookieReq(NEWLY_PUBLIC_DATA_PATH, SESSION_COOKIE),
+      res as unknown as Response,
+    );
+    expect(armed).toBe(true);
+
+    // The RR express adapter emits the route's public policy, then streams a
+    // body carrying the revalidated root loader ({ user, cart }).
+    res.append('Cache-Control', 'public, max-age=300, s-maxage=3600');
+    res.writeHead(200); // implicit flush → guard fires
+    res.write(
+      JSON.stringify({ root: { user: { id: 7 }, cart: { items: 3 } } }),
+    );
+    res.end();
+
+    expect(headers.get('cache-control')).toBe(
+      SESSIONED_DATA_CACHE_HEADERS['Cache-Control'],
+    );
+    expect(headers.get('cache-control')).not.toContain('public');
+    expect(headers.get('cache-control')).not.toContain('s-maxage');
+    expect(headers.get('cdn-cache-control')).toBe('no-store');
+    expect(headers.get('cloudflare-cdn-cache-control')).toBe('no-store');
+    // #4 body carried root PII but the response is private/no-store, never public.
+    expect(body.join('')).toContain('"user"');
+    expect(body.join('')).toContain('"cart"');
+  });
+
+  it('#1 anonymous `.data`: guard not armed → the public TTL is preserved', () => {
+    const { res, headers } = makeFakeRes();
+
+    const armed = enforceSessionedDataCachePrivacy(
+      cookieReq(NEWLY_PUBLIC_DATA_PATH),
+      res as unknown as Response,
+    );
+    expect(armed).toBe(false);
+
+    res.append('Cache-Control', 'public, max-age=300, s-maxage=3600');
+    res.writeHead(200);
+
+    expect(headers.get('cache-control')).toBe(
+      'public, max-age=300, s-maxage=3600',
+    );
+    expect(headers.get('cdn-cache-control')).toBeUndefined();
+    expect(headers.get('cloudflare-cdn-cache-control')).toBeUndefined();
+  });
+});

--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -233,22 +233,29 @@ automecanik.com, www.automecanik.com {
     }
     
     handle @public_cached {
-        @homepage path /
-        header @homepage Cache-Control "public, max-age=300, stale-while-revalidate=3600"
-        
-        # 🚀 TTFB Optimization: CDN cache 24h pour pages produit
-        @products path_regexp ^/(products|pieces|catalog|vehicule)/
-        header @products Cache-Control "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600"
-        
-        @content path_regexp ^/(blog-pieces-auto|blog|guides|articles|conseils)/
-        header @content Cache-Control "public, max-age=1800, stale-while-revalidate=3600"
-        
-        @search path /search
-        header @search Cache-Control "public, max-age=30, stale-while-revalidate=60"
-        
-        # Default: set only if no conditional matcher above already set Cache-Control
+        # ── Single-owner Cache-Control (PR B) ──────────────────────────────
+        # L'application (React Router) est le SEUL propriétaire du Cache-Control
+        # de chaque surface publique : chaque route indexée exporte `headers`
+        # via `buildCacheHeaders(...)` (frontend/app/utils/cache-control.ts) ;
+        # sinon root.tsx pose le défaut gouverné `private, max-age=60`.
+        #
+        # Les anciens `header @homepage|@products|@content|@search Cache-Control`
+        # étaient des SET *immédiats* (avant reverse_proxy) : le proxy AJOUTE
+        # ensuite le Cache-Control amont → 2 en-têtes Cache-Control sur le fil,
+        # combinaison ambiguë côté Cloudflare (RFC 7234 §5.2). Supprimés pour
+        # garantir exactement UN Cache-Control gouverné par surface (PR B).
+        # Les préfixes fantômes (catalog|vehicule|blog|guides|articles|conseils
+        # top-level, /products/admin) n'avaient aucune route publique indexée et
+        # étaient mis en cache public à tort ; ils retombent désormais sur le
+        # splat racine `no-cache` / `private, max-age=60` — plus correct.
+        #
+        # Filet déterministe : `?Cache-Control` = set-if-absent + différé (après
+        # amont) → ne s'applique QUE si l'app n'a émis AUCUN Cache-Control
+        # (ex. redirections 301 de pieces.$.tsx). Ne peut jamais dupliquer un
+        # en-tête déjà possédé par la route.
         header ?Cache-Control "public, max-age=120, stale-while-revalidate=240"
-        header Vary "Accept-Encoding"
+        # ?Vary différé (idem) : évite un doublon Vary avec l'amont / `encode`.
+        header ?Vary "Accept-Encoding"
 
         reverse_proxy monorepo_prod:3000 {
             header_up Host {host}
@@ -258,10 +265,14 @@ automecanik.com, www.automecanik.com {
             header_up X-Forwarded-Host {host}
 
             # 🛡️ Anti-cache-poisoning : une réponse d'erreur (4xx/5xx) du backend
-            # NE DOIT PAS hériter du cache CDN long (s-maxage=86400) posé par
-            # @products / @content ci-dessus. Sinon un 404/500 transitoire (boot
-            # container, TypeError SSR ponctuel) est figé jusqu'à 24h par Cloudflare
-            # sur une page qui existe en réalité (incident 2026-06-25 :
+            # NE DOIT PAS hériter du cache CDN long (s-maxage=86400) posé par le
+            # Cache-Control de la route (buildCacheHeaders success policy, désormais
+            # seul propriétaire — PR B). buildCacheHeaders force déjà `no-store` côté
+            # app sur les throws ; cette garde est le filet côté edge (défense en
+            # profondeur, couvre aussi les 4xx/5xx qui ne passent pas par un
+            # `headers` de route). Sinon un 404/500 transitoire (boot container,
+            # TypeError SSR ponctuel) serait figé jusqu'à 24h par Cloudflare sur une
+            # page qui existe en réalité (incident 2026-06-25 :
             # /pieces/barre-stabilisatrice-274.html & plaquette-de-frein-402.html).
             # Même garde que le bloc imgproxy ci-dessus (@upstream_4xx). `no-store`
             # l'emporte sur une Cache-Control upstream concurrente (RFC 7234 §5.2.2).

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -20,7 +20,7 @@ import {
   serverObservabilityContext,
 } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
-import  { type ServerObservability } from "~/utils/observability-contract";
+import { type ServerObservability } from "~/utils/observability-contract";
 
 // Re-export the load-context factory so the SSR build exposes it on
 // `build.entry.module` for the NestJS façade bridge (`getCreateAppLoadContext`).
@@ -67,7 +67,10 @@ export const handleError: HandleErrorFunction = (
     observability?.captureException(error, {
       mechanism: { type: "react-router", handled: false },
       tags: { observability_channel: "react-router-handle-error" },
-      extra: { method: request.method, pathname: new URL(request.url).pathname },
+      extra: {
+        method: request.method,
+        pathname: new URL(request.url).pathname,
+      },
     });
   }
   if (error instanceof Error) {
@@ -80,6 +83,35 @@ export const handleError: HandleErrorFunction = (
 export const streamTimeout = 5_000;
 const ABORT_DELAY = streamTimeout + 1_000;
 
+// ── Request-aware cache-privacy arbiter (single owner — PR B review) ─────────
+// React Router applies the DEEPEST route's `headers` export, and those exports
+// are request-unaware: a public route (`buildCacheHeaders("public, …s-maxage…")`)
+// would ship that shared-cache policy even for a request carrying a session
+// cookie — whose rendered document embeds the logged-in user / cart in the root
+// chrome. Before PR B, Caddy's `@public_cached` matcher EXCLUDED any request with
+// a session cookie, keeping those responses on root's `private, max-age=60`. Now
+// that the Caddy per-surface backfill is gone, this arbiter re-establishes the
+// "public only without a session" invariant IN THE APP, where the request is
+// visible: every HTML document served to a session-bearing request is forced
+// private + no-store at every cache tier (browser, CDN, Cloudflare). The cookie
+// pattern MIRRORS the one still used by Caddy `@public_cached`
+// (`not header_regexp Cookie (?i)(connect\.sid|session)`) so both layers agree
+// on exactly which requests are "sessioned".
+const SESSION_COOKIE_RE = /(?:connect\.sid|session)/i;
+const SESSIONED_CACHE_CONTROL = "private, no-cache, no-store, must-revalidate";
+
+export function applySessionCachePrivacy(
+  request: Request,
+  responseHeaders: Headers,
+): void {
+  const cookie = request.headers.get("cookie");
+  if (cookie && SESSION_COOKIE_RE.test(cookie)) {
+    responseHeaders.set("Cache-Control", SESSIONED_CACHE_CONTROL);
+    responseHeaders.set("CDN-Cache-Control", "no-store");
+    responseHeaders.set("Cloudflare-CDN-Cache-Control", "no-store");
+  }
+}
+
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -90,7 +122,12 @@ export default function handleRequest(
   const nonce = loadContext.get(cspNonceContext) || "";
   // Pass the reporter OBJECT (not a detached method) down so the streaming
   // onError callbacks can forward render errors to the NestJS-owned Sentry client.
-  const observability = loadContext.get(serverObservabilityContext) ?? undefined;
+  const observability =
+    loadContext.get(serverObservabilityContext) ?? undefined;
+
+  // Request-aware final arbiter: a session-bearing document is never shared-cached,
+  // whatever public policy the deepest route's `headers` export emitted.
+  applySessionCachePrivacy(request, responseHeaders);
 
   return isbot(request.headers.get("user-agent") || "")
     ? handleBotRequest(
@@ -161,7 +198,10 @@ function handleBotRequest(
           logger.error("[SSR onError]", error);
           observability?.captureException(error, {
             mechanism: { type: "react-ssr-stream", handled: false },
-            tags: { observability_channel: "ssr-stream", rendering_path: "bot" },
+            tags: {
+              observability_channel: "ssr-stream",
+              rendering_path: "bot",
+            },
           });
         },
       },

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import {
-  type HeadersFunction,
   type LoaderFunctionArgs,
   type MetaFunction,
   Await,
@@ -23,6 +22,7 @@ import {
 import { type BrandItem } from "~/components/home/constants";
 import { LazyFooter } from "~/components/home/LazyFooter";
 import { getRemixApiService } from "~/server/remix-api.server";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import {
   type SlimFamily,
   mapFamiliesFromSplit,
@@ -178,9 +178,9 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
   }
 }
 
-export const headers: HeadersFunction = () => ({
-  "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
-});
+export const headers = buildCacheHeaders(
+  "public, max-age=300, stale-while-revalidate=3600",
+);
 
 // ─── Skeleton placeholders for below-fold sections ──────
 function BrandsGridSkeleton() {

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -3,6 +3,7 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
   Await,
+  data,
   useLoaderData,
 } from "react-router";
 
@@ -170,11 +171,19 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     logger.error("[homepage-families] Service call failed:", {
       error: err instanceof Error ? err.message : String(err),
     });
-    return {
-      families: [] as SlimFamily[],
-      belowFold: belowFoldPromise,
-      faqs: faqPromise,
-    };
+    return data(
+      {
+        families: [] as SlimFamily[],
+        belowFold: belowFoldPromise,
+        faqs: faqPromise,
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+          "X-Robots-Tag": "noindex, follow",
+        },
+      },
+    );
   }
 }
 

--- a/frontend/app/routes/blog-pieces-auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto._index.tsx
@@ -155,6 +155,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     lastUpdated: new Date().toISOString(),
   };
 
+  let degraded = false;
+
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000);
@@ -190,19 +192,26 @@ export async function loader({ request }: LoaderFunctionArgs) {
         };
       }
     } else {
+      degraded = true;
       logger.warn(`API returned ${response.status}: ${response.statusText}`);
     }
   } catch (error) {
+    degraded = true;
     logger.warn({ err: error, url: request.url }, "Blog API error");
   }
 
   return data(
     { blogData, searchParams },
     {
-      headers: {
-        "Cache-Control":
-          "public, max-age=300, s-maxage=600, stale-while-revalidate=86400",
-      },
+      headers: degraded
+        ? {
+            "Cache-Control": "no-store",
+            "X-Robots-Tag": "noindex, follow",
+          }
+        : {
+            "Cache-Control":
+              "public, max-age=300, s-maxage=600, stale-while-revalidate=86400",
+          },
     },
   );
 }

--- a/frontend/app/routes/blog-pieces-auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto._index.tsx
@@ -52,6 +52,7 @@ import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 
 // UI Components
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
@@ -205,6 +206,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
     },
   );
 }
+
+// Single owner of this route's Cache-Control at the edge (Caddy no longer
+// backfills). Propagates the loader's success TTL and forces no-store +
+// noindex on any thrown error Response.
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=600, stale-while-revalidate=86400",
+  { defaultErrorRobots: "noindex, follow" },
+);
 
 // Action pour interactions utilisateur
 export async function action({ request }: ActionFunctionArgs) {

--- a/frontend/app/routes/blog-pieces-auto.advice._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.advice._index.tsx
@@ -10,6 +10,7 @@ import React, { useState, useMemo } from "react";
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
   useLoaderData,
   Link,
   useSearchParams,
@@ -214,20 +215,28 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     };
   } catch (error) {
     logger.error("[ERROR] Advice loader failed:", error);
-    return {
-      articles: [],
-      total: 0,
-      page: 1,
-      totalPages: 1,
-      search: "",
-      category: "",
-      categories: [],
-      featuredArticles: [],
-      popularTags: [],
-      stats: { totalViews: 0, avgReadingTime: 3, totalArticles: 0 },
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
+    return data(
+      {
+        articles: [],
+        total: 0,
+        page: 1,
+        totalPages: 1,
+        search: "",
+        category: "",
+        categories: [],
+        featuredArticles: [],
+        popularTags: [],
+        stats: { totalViews: 0, avgReadingTime: 3, totalArticles: 0 },
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+          "X-Robots-Tag": "noindex, follow",
+        },
+      },
+    );
   }
 };
 

--- a/frontend/app/routes/blog-pieces-auto.advice._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.advice._index.tsx
@@ -23,6 +23,7 @@ import {
 import { BlogNavigation } from "~/components/blog/BlogNavigation";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
@@ -84,6 +85,10 @@ interface LoaderData {
   };
   error?: string;
 }
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const search = data?.search || "";

--- a/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
+++ b/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
@@ -188,7 +188,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const { slug } = params;
 
   if (!slug) {
-    return redirect("/blog-pieces-auto", 301);
+    return redirect("/blog-pieces-auto", {
+      status: 301,
+      headers: { "Cache-Control": "no-store" },
+    });
   }
 
   // 🎯 Détection des URLs legacy "entretien-..." qui n'existent plus (78k URLs GSC)
@@ -285,7 +288,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       // 🔄 SEO: Article non trouvé → 301 redirect vers index du blog
       // Raison: 412 est traité comme 4xx par Google → désindexation
       // 301 préserve le PageRank et guide vers une page indexable
-      return redirect("/blog-pieces-auto", 301);
+      return redirect("/blog-pieces-auto", {
+        status: 301,
+        headers: { "Cache-Control": "no-store" },
+      });
     }
 
     return {
@@ -304,7 +310,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     }
 
     logger.error("Erreur chargement article:", error);
-    return redirect("/blog-pieces-auto", 302);
+    return redirect("/blog-pieces-auto", {
+      status: 302,
+      headers: { "Cache-Control": "no-store" },
+    });
   }
 }
 

--- a/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
+++ b/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
@@ -31,6 +31,7 @@ import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { stripHtmlForMeta } from "~/utils/seo-clean.utils";
@@ -82,8 +83,15 @@ interface LoaderData {
   error?: string;
 }
 
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
+
 // Meta SEO
-export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({
+  loaderData: data,
+  location,
+}) => {
   if (!data?.article) {
     return [
       { title: "Article non trouvé - Blog Automecanik" },

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
@@ -12,6 +12,7 @@ import {
 
 import { BlogPiecesAutoNavigation } from "~/components/blog/BlogPiecesAutoNavigation";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { CompactBlogHeader } from "../components/blog/CompactBlogHeader";
@@ -69,6 +70,10 @@ interface LoaderData {
     content: string;
   } | null;
 }
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 /* ===========================
    Loader
@@ -151,7 +156,10 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 /* ===========================
    Meta
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({
+  loaderData: data,
+  location,
+}) => {
   const metadata = data?.metadata;
   const brand = data?.brand;
   const modelGroup = data?.modelGroup;

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
   Link,
   useLoaderData,
   useRouteError,
@@ -109,6 +110,9 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
     const modelsResponse = modelsRes?.ok
       ? await modelsRes.json().catch(() => null)
       : null;
+    // Backend models fetch échoué et absorbé en liste vide → état dégradé :
+    // ne pas hériter du TTL public de succès (sinon Cloudflare cache l'échec).
+    const degraded = !modelsRes?.ok || modelsResponse === null;
     const modelsData = modelsResponse?.data || [];
 
     // Mapper les modèles vers le format attendu - utiliser image_url du backend (comme /constructeurs/)
@@ -154,11 +158,21 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
         }
       : null;
 
-    return {
-      brand,
-      models: mappedModels,
-      metadata,
-    };
+    return data(
+      {
+        brand,
+        models: mappedModels,
+        metadata,
+      },
+      degraded
+        ? {
+            headers: {
+              "Cache-Control": "no-store",
+              "X-Robots-Tag": "noindex, follow",
+            },
+          }
+        : undefined,
+    );
   } catch (e) {
     logger.error("Erreur loader marque:", e);
     if (e instanceof Response) throw e;

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
@@ -12,6 +12,7 @@ import {
 
 import { BlogPiecesAutoNavigation } from "~/components/blog/BlogPiecesAutoNavigation";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { CompactBlogHeader } from "../components/blog/CompactBlogHeader";
@@ -58,6 +59,10 @@ interface LoaderData {
     relfollow: string;
   } | null;
 }
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 /* ===========================
    Loader
@@ -166,7 +171,10 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 /* ===========================
    Meta
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({
+  loaderData: data,
+  location,
+}) => {
   const metadata = data?.metadata;
   const brand = data?.brand;
   const modelsCount = data?.models?.length ?? 0;

--- a/frontend/app/routes/blog-pieces-auto.auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto._index.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
   Link,
   useLoaderData,
   useRouteError,
@@ -132,22 +133,45 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       }),
     );
 
-    return {
-      brands: mappedBrands,
-      popularModels: mappedModels,
-      metadata: metadataData?.success ? metadataData.data : null,
-      stats: {
-        totalBrands: mappedBrands.length,
-        totalModels: mappedModels.length,
+    // Les fetch sont individuellement `.catch(() => null)` : un backend KO ne
+    // remonte PAS au catch ci-dessous, il tombe ici avec des listes vides. Si un
+    // fetch cœur a échoué, la page est dégradée → jamais le TTL public de succès.
+    const degraded = !brandsRes?.ok || !modelsRes?.ok;
+
+    return data(
+      {
+        brands: mappedBrands,
+        popularModels: mappedModels,
+        metadata: metadataData?.success ? metadataData.data : null,
+        stats: {
+          totalBrands: mappedBrands.length,
+          totalModels: mappedModels.length,
+        },
       },
-    };
+      degraded
+        ? {
+            headers: {
+              "Cache-Control": "no-store",
+              "X-Robots-Tag": "noindex, follow",
+            },
+          }
+        : undefined,
+    );
   } catch (e) {
     logger.error("Erreur loader auto:", e);
-    return {
-      brands: [],
-      popularModels: [],
-      stats: { totalBrands: 0, totalModels: 0 },
-    };
+    return data(
+      {
+        brands: [],
+        popularModels: [],
+        stats: { totalBrands: 0, totalModels: 0 },
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+          "X-Robots-Tag": "noindex, follow",
+        },
+      },
+    );
   }
 };
 

--- a/frontend/app/routes/blog-pieces-auto.auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto._index.tsx
@@ -136,7 +136,14 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // Les fetch sont individuellement `.catch(() => null)` : un backend KO ne
     // remonte PAS au catch ci-dessous, il tombe ici avec des listes vides. Si un
     // fetch cœur a échoué, la page est dégradée → jamais le TTL public de succès.
-    const degraded = !brandsRes?.ok || !modelsRes?.ok;
+    // Un 200 dont le corps est illisible met brandsData/modelsData à `null`
+    // (`.json().catch(() => null)`, l.99-104) sans que `.ok` soit faux → il faut
+    // aussi tester le parse (aligné sur le garde du sibling auto.$marque.index).
+    const degraded =
+      !brandsRes?.ok ||
+      !modelsRes?.ok ||
+      brandsData === null ||
+      modelsData === null;
 
     return data(
       {

--- a/frontend/app/routes/blog-pieces-auto.auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto._index.tsx
@@ -24,6 +24,7 @@ import { Alert } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 
@@ -68,6 +69,10 @@ interface LoaderData {
     totalModels: number;
   };
 }
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 /* ===========================
    Loader

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -9,7 +9,6 @@
 import { ArrowLeft, Tag, BookOpen, ExternalLink } from "lucide-react";
 import { lazy, Suspense, useEffect, useRef } from "react";
 import {
-  type HeadersFunction,
   type LoaderFunctionArgs,
   type MetaFunction,
   data,
@@ -58,6 +57,7 @@ import {
   type R3GuidePage,
 } from "~/types/r3-guide.types";
 import { trackArticleView, trackReadingTime } from "~/utils/analytics";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { getOgImageUrl } from "~/utils/og-image.utils";
@@ -253,10 +253,11 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 }
 
-// Cache — 5min browser + 1h stale (contenu stable)
-export const headers: HeadersFunction = () => ({
-  "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
-});
+// Cache — 5min browser + 1h stale (contenu stable). buildCacheHeaders forces
+// no-store on the loader's thrown 404 instead of leaking this public TTL.
+export const headers = buildCacheHeaders(
+  "public, max-age=300, stale-while-revalidate=3600",
+);
 
 // Skip revalidation when navigating back to same guide
 export const shouldRevalidate: ShouldRevalidateFunction = ({
@@ -270,7 +271,10 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 // ── Meta ─────────────────────────────────────────────────
 
-export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({
+  loaderData: data,
+  location,
+}) => {
   if (!data) {
     return [
       { title: "Article non trouvé" },

--- a/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import {
+  data as routeData,
   useLoaderData,
   Link,
   useRouteError,
@@ -123,12 +124,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     if (!data?.success || !data.data?.families) {
       logger.error("Format de r\u00e9ponse inattendu:", data);
-      return {
-        groupedArticles: [],
-        allArticles: [],
-        totalArticles: 0,
-        stats: { totalViews: 0, totalCategories: 0 },
-      };
+      return routeData(
+        {
+          groupedArticles: [],
+          allArticles: [],
+          totalArticles: 0,
+          stats: { totalViews: 0, totalCategories: 0 },
+        },
+        {
+          headers: {
+            "Cache-Control": "no-store",
+            "X-Robots-Tag": "noindex, follow",
+          },
+        },
+      );
     }
 
     const allArticles: BlogArticle[] = [];
@@ -173,12 +182,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     };
   } catch (e) {
     logger.error("Erreur loader conseils:", e);
-    return {
-      groupedArticles: [],
-      allArticles: [],
-      totalArticles: 0,
-      stats: { totalViews: 0, totalCategories: 0 },
-    };
+    return routeData(
+      {
+        groupedArticles: [],
+        allArticles: [],
+        totalArticles: 0,
+        stats: { totalViews: 0, totalCategories: 0 },
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+          "X-Robots-Tag": "noindex, follow",
+        },
+      },
+    );
   }
 };
 

--- a/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
@@ -39,6 +39,7 @@ import { BlogPiecesAutoNavigation } from "~/components/blog/BlogPiecesAutoNaviga
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getFamilyTheme } from "~/utils/family-theme";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
@@ -103,6 +104,12 @@ const FAQ_ITEMS = [
     a: "Cela d\u00e9pend du v\u00e9hicule, de l\u2019usage et des sympt\u00f4mes. Les guides donnent des rep\u00e8res g\u00e9n\u00e9raux et des signes d\u2019usure.",
   },
 ];
+
+// ── Headers ─────────────────────────────────────────────
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 // ── Loader ──────────────────────────────────────────────
 
@@ -177,7 +184,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 // ── Meta ────────────────────────────────────────────────
 
-export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({
+  loaderData: data,
+  location,
+}) => {
   const count = data?.totalArticles ?? 0;
   const hasFilters = location?.search && location.search.length > 1;
 

--- a/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
@@ -24,6 +24,7 @@ import { BlogNavigation } from "~/components/blog/BlogNavigation";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { Badge } from "~/components/ui/badge";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
@@ -318,6 +319,10 @@ interface LoaderData {
     totalModels: number;
   };
 }
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);

--- a/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
@@ -10,6 +10,7 @@ import React, { useState, useMemo } from "react";
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
   useLoaderData,
   Link,
   useSearchParams,
@@ -519,21 +520,29 @@ export async function loader({ request }: LoaderFunctionArgs) {
     totalModels: DEMO_CONSTRUCTEURS.reduce((sum, c) => sum + c.modelsCount, 0),
   };
 
-  return {
-    constructeurs: paginatedConstructeurs,
-    total: filteredConstructeurs.length,
-    page,
-    totalPages,
-    search,
-    letter,
-    brand,
-    sortBy,
-    letters,
-    featuredConstructeurs,
-    popularBrands,
-    stats,
-    success: true,
-  };
+  return data(
+    {
+      constructeurs: paginatedConstructeurs,
+      total: filteredConstructeurs.length,
+      page,
+      totalPages,
+      search,
+      letter,
+      brand,
+      sortBy,
+      letters,
+      featuredConstructeurs,
+      popularBrands,
+      stats,
+      success: false,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Robots-Tag": "noindex, follow",
+      },
+    },
+  );
 }
 
 export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {

--- a/frontend/app/routes/blog-pieces-auto.guide-achat.comment-utiliser-selecteur-vehicule-pieces-auto.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat.comment-utiliser-selecteur-vehicule-pieces-auto.tsx
@@ -53,6 +53,7 @@ import {
   TableRow,
 } from "~/components/ui/table";
 
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 
 /* ===========================================================================
@@ -149,6 +150,10 @@ const TOC_ITEMS = [
 /* ===========================================================================
    SEO
    =========================================================================== */
+
+export const headers = buildCacheHeaders(
+  "public, max-age=1800, stale-while-revalidate=3600",
+);
 
 export const handle = {
   pageRole: createPageRoleMeta(PageRole.R3_BLOG, {

--- a/frontend/app/routes/products.$category.$subcategory.tsx
+++ b/frontend/app/routes/products.$category.$subcategory.tsx
@@ -9,8 +9,13 @@ import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { buildCacheHeaders } from "~/utils/cache-control";
 import { getSeoMetadata, createSeoMeta } from "../utils/seo.server";
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/frontend/app/routes/products.$category.$subcategory.tsx
+++ b/frontend/app/routes/products.$category.$subcategory.tsx
@@ -6,7 +6,12 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getSeoMetadata, createSeoMeta } from "../utils/seo.server";
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const url = new URL(request.url);

--- a/frontend/app/routes/products.$id.tsx
+++ b/frontend/app/routes/products.$id.tsx
@@ -60,8 +60,13 @@ export const handle = {
   }),
 };
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 /**

--- a/frontend/app/routes/products.$id.tsx
+++ b/frontend/app/routes/products.$id.tsx
@@ -33,6 +33,7 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
@@ -58,6 +59,10 @@ export const handle = {
     contentType: "product",
   }),
 };
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 /**
  * 🔍 SEO Meta Tags - Page produit individuel

--- a/frontend/app/routes/products.brands.tsx
+++ b/frontend/app/routes/products.brands.tsx
@@ -40,8 +40,13 @@ import {
   CardTitle,
 } from "../components/ui/card";
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 export const meta: MetaFunction = () => createNoIndexMeta("Marques Produits");

--- a/frontend/app/routes/products.brands.tsx
+++ b/frontend/app/routes/products.brands.tsx
@@ -25,6 +25,7 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -38,6 +39,10 @@ import {
   CardHeader,
   CardTitle,
 } from "../components/ui/card";
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 export const meta: MetaFunction = () => createNoIndexMeta("Marques Produits");
 

--- a/frontend/app/routes/products.gammes.$gammeId.tsx
+++ b/frontend/app/routes/products.gammes.$gammeId.tsx
@@ -55,8 +55,13 @@ import {
   SelectValue,
 } from "../components/ui/select";
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gamme Produits");

--- a/frontend/app/routes/products.gammes.$gammeId.tsx
+++ b/frontend/app/routes/products.gammes.$gammeId.tsx
@@ -37,6 +37,7 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -53,6 +54,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select";
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gamme Produits");
 

--- a/frontend/app/routes/products.ranges.$rangeId.tsx
+++ b/frontend/app/routes/products.ranges.$rangeId.tsx
@@ -28,6 +28,7 @@ import {
   useSearchParams,
   Form,
 } from "react-router";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -48,6 +49,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select";
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gamme Produits");
 

--- a/frontend/app/routes/products.ranges.$rangeId.tsx
+++ b/frontend/app/routes/products.ranges.$rangeId.tsx
@@ -50,8 +50,13 @@ import {
   SelectValue,
 } from "../components/ui/select";
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gamme Produits");

--- a/frontend/app/routes/products.ranges.advanced.tsx
+++ b/frontend/app/routes/products.ranges.advanced.tsx
@@ -29,6 +29,7 @@ import {
   useSearchParams,
   Form,
 } from "react-router";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -49,6 +50,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select";
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gammes Avancées");
 

--- a/frontend/app/routes/products.ranges.advanced.tsx
+++ b/frontend/app/routes/products.ranges.advanced.tsx
@@ -51,8 +51,13 @@ import {
   SelectValue,
 } from "../components/ui/select";
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gammes Avancées");

--- a/frontend/app/routes/products.ranges.tsx
+++ b/frontend/app/routes/products.ranges.tsx
@@ -32,6 +32,7 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -45,6 +46,10 @@ import {
   CardHeader,
   CardTitle,
 } from "../components/ui/card";
+
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gammes de Produits");
 

--- a/frontend/app/routes/products.ranges.tsx
+++ b/frontend/app/routes/products.ranges.tsx
@@ -47,8 +47,13 @@ import {
   CardTitle,
 } from "../components/ui/card";
 
+// PR B review — /products/* = espace pro non-public : la plupart lisent
+// requireUser, sont noindex et renvoient un payload personnalisé (identité
+// user, price_pro/margin, données démo). Namespace entier retiré du cache
+// partagé (décision owner). Jamais public/s-maxage. L'arbitre entry.server
+// force aussi private/no-store sur toute requête sessionnée.
 export const headers = buildCacheHeaders(
-  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600",
+  "private, no-cache, no-store, must-revalidate",
 );
 
 export const meta: MetaFunction = () => createNoIndexMeta("Gammes de Produits");

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -53,6 +53,7 @@ import {
   getSectionImageConfig,
   resolveAltText,
 } from "~/config/visual-intent";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 
 // SEO Page Role (Phase 5 - Quasi-Incopiable)
@@ -371,6 +372,14 @@ export async function loader({ params }: LoaderFunctionArgs) {
     throw new Response("Référence non trouvée", { status: 404 });
   }
 }
+
+// Single owner of this route's Cache-Control at the edge (Caddy no longer
+// backfills). Propagates the loader's success TTL, forces no-store on the
+// bare 404 throw, and noindexes that error response.
+export const headers = buildCacheHeaders(
+  "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+  { defaultErrorRobots: "noindex, follow" },
+);
 
 /* ===========================
    JSON-LD Schema

--- a/frontend/tests/unit/cache-control.test.ts
+++ b/frontend/tests/unit/cache-control.test.ts
@@ -11,7 +11,10 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { buildCacheHeaders, NO_STORE_CACHE_CONTROL } from "~/utils/cache-control";
+import {
+  buildCacheHeaders,
+  NO_STORE_CACHE_CONTROL,
+} from "~/utils/cache-control";
 
 type HeadersFn = ReturnType<typeof buildCacheHeaders>;
 type Args = Parameters<HeadersFn>[0];
@@ -22,7 +25,10 @@ const SUCCESS =
 /** Invoke the returned HeadersFunction with only the fields it reads. */
 function invoke(
   fn: HeadersFn,
-  opts: { loader?: Record<string, string>; error?: Record<string, string> } = {},
+  opts: {
+    loader?: Record<string, string>;
+    error?: Record<string, string>;
+  } = {},
 ): Record<string, string> {
   const args = {
     loaderHeaders: new Headers(opts.loader ?? {}),

--- a/frontend/tests/unit/cache-control.test.ts
+++ b/frontend/tests/unit/cache-control.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Contract test for the canonical Cache-Control helper
+ * (frontend/app/utils/cache-control.ts), referenced by:
+ *   - scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh
+ *   - .ast-grep/rules/frontend-no-headers-bypass-buildCacheHeaders.yml
+ *
+ * The helper is the SINGLE owner of a route's Cache-Control (PR "single-owner
+ * Cache-Control"): Caddy no longer backfills a duplicate header, so the value
+ * this returns is exactly what ships to Cloudflare. The error branch MUST NOT
+ * leak the success `s-maxage` onto a loader-thrown 4xx/5xx (INC-2026-005).
+ */
+import { describe, it, expect } from "vitest";
+
+import { buildCacheHeaders, NO_STORE_CACHE_CONTROL } from "~/utils/cache-control";
+
+type HeadersFn = ReturnType<typeof buildCacheHeaders>;
+type Args = Parameters<HeadersFn>[0];
+
+const SUCCESS =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600";
+
+/** Invoke the returned HeadersFunction with only the fields it reads. */
+function invoke(
+  fn: HeadersFn,
+  opts: { loader?: Record<string, string>; error?: Record<string, string> } = {},
+): Record<string, string> {
+  const args = {
+    loaderHeaders: new Headers(opts.loader ?? {}),
+    parentHeaders: new Headers(),
+    actionHeaders: new Headers(),
+    errorHeaders: opts.error ? new Headers(opts.error) : undefined,
+  } as unknown as Args;
+  return fn(args) as Record<string, string>;
+}
+
+describe("buildCacheHeaders — success path", () => {
+  it("applies the success policy when the loader set no Cache-Control", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS));
+    expect(out["Cache-Control"]).toBe(SUCCESS);
+  });
+
+  it("honours a per-request Cache-Control the loader set on data()/json() (TTL-neutral override)", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS), {
+      loader: {
+        "Cache-Control": "public, max-age=30, stale-while-revalidate=60",
+      },
+    });
+    expect(out["Cache-Control"]).toBe(
+      "public, max-age=30, stale-while-revalidate=60",
+    );
+  });
+
+  it("propagates a loader X-Robots-Tag unchanged and adds no default on success", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS), {
+      loader: { "X-Robots-Tag": "noindex, follow" },
+    });
+    expect(out["X-Robots-Tag"]).toBe("noindex, follow");
+    expect(out["Cache-Control"]).toBe(SUCCESS);
+  });
+
+  it("emits no X-Robots-Tag key when the loader carried none", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS));
+    expect("X-Robots-Tag" in out).toBe(false);
+  });
+});
+
+describe("buildCacheHeaders — error path (anti cache-poisoning)", () => {
+  it("forces no-store on a bare loader-thrown error, never leaking the success s-maxage", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS), { error: {} });
+    expect(out["Cache-Control"]).toBe(NO_STORE_CACHE_CONTROL);
+    expect(out["Cache-Control"]).not.toContain("s-maxage");
+  });
+
+  it("honours an explicit Cache-Control the error Response carried", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS), {
+      error: { "Cache-Control": "public, max-age=300, must-revalidate" },
+    });
+    expect(out["Cache-Control"]).toBe("public, max-age=300, must-revalidate");
+  });
+
+  it("stamps defaultErrorRobots on a bare error throw (404/500 with no headers)", () => {
+    const out = invoke(
+      buildCacheHeaders(SUCCESS, { defaultErrorRobots: "noindex, follow" }),
+      { error: {} },
+    );
+    expect(out["X-Robots-Tag"]).toBe("noindex, follow");
+    expect(out["Cache-Control"]).toBe(NO_STORE_CACHE_CONTROL);
+  });
+
+  it("does not override an explicit error X-Robots-Tag with defaultErrorRobots", () => {
+    const out = invoke(
+      buildCacheHeaders(SUCCESS, { defaultErrorRobots: "noindex, follow" }),
+      { error: { "X-Robots-Tag": "noindex, nofollow" } },
+    );
+    expect(out["X-Robots-Tag"]).toBe("noindex, nofollow");
+  });
+
+  it("emits no X-Robots-Tag key when neither the error nor a default provides one", () => {
+    const out = invoke(buildCacheHeaders(SUCCESS), { error: {} });
+    expect("X-Robots-Tag" in out).toBe(false);
+  });
+});
+
+describe("NO_STORE_CACHE_CONTROL", () => {
+  it("refuses every cache tier", () => {
+    expect(NO_STORE_CACHE_CONTROL).toBe("no-cache, no-store, must-revalidate");
+  });
+});

--- a/frontend/tests/unit/degraded-fallback-cache.test.ts
+++ b/frontend/tests/unit/degraded-fallback-cache.test.ts
@@ -1,0 +1,142 @@
+/**
+ * PR B review, blocker #3: several loaders ABSORB a backend failure and return
+ * an empty-200 (or a transient redirect) instead of throwing. buildCacheHeaders
+ * only forces no-store on THROWN Responses, so those degraded pages would inherit
+ * the public success TTL and Cloudflare would cache the failure for hours.
+ *
+ * These tests prove that a backend failure NEVER receives the success TTL: the
+ * loader itself stamps `Cache-Control: no-store` (+ `X-Robots-Tag: noindex,
+ * follow` for indexable empty pages) on every degraded exit — including the
+ * subtle case where per-fetch `.catch(() => null)` swallows the failure and it
+ * reaches the SUCCESS return with empty data.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { loader as homeLoader } from "~/routes/_index";
+import { loader as blogIndexLoader } from "~/routes/blog-pieces-auto._index";
+import { loader as adviceLoader } from "~/routes/blog-pieces-auto.advice._index";
+import { loader as articleLoader } from "~/routes/blog-pieces-auto.article.$slug";
+import { loader as autoMarqueLoader } from "~/routes/blog-pieces-auto.auto.$marque.index";
+import { loader as autoIndexLoader } from "~/routes/blog-pieces-auto.auto._index";
+import { loader as conseilsLoader } from "~/routes/blog-pieces-auto.conseils._index";
+import { loader as constructeursLoader } from "~/routes/blog-pieces-auto.constructeurs._index";
+
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("~/utils/internal-api.server", () => ({
+  getInternalApiUrl: (p = "") => `http://internal${p}`,
+  getInternalApiUrlFromRequest: (p = "") => `http://internal${p}`,
+}));
+// Home uses a DI service (not fetch) for its above-fold families.
+vi.mock("~/server/remix-api.server", () => ({
+  getRemixApiService: async () => ({
+    getHomepageFamilies: async () => {
+      throw new Error("families backend down");
+    },
+    getHomepageBelowFold: async () => null,
+  }),
+}));
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+function cacheControlOf(result: unknown): string | null {
+  if (result instanceof Response) return result.headers.get("Cache-Control");
+  const init = (result as { init?: { headers?: Record<string, string> } })
+    ?.init;
+  return init?.headers?.["Cache-Control"] ?? null;
+}
+function xRobotsOf(result: unknown): string | null {
+  if (result instanceof Response) return result.headers.get("X-Robots-Tag");
+  const init = (result as { init?: { headers?: Record<string, string> } })
+    ?.init;
+  return init?.headers?.["X-Robots-Tag"] ?? null;
+}
+
+const req = (url = "https://www.automecanik.com/x") => new Request(url);
+const call = (loader: (a: never) => unknown, args: object = {}) =>
+  loader({ request: req(), context: {}, params: {}, ...args } as never);
+
+const jsonOk = (body: unknown) => ({ ok: true, json: async () => body });
+
+describe("degraded fallback → never the success TTL", () => {
+  it("blog _index: API failure → no-store + noindex (not the public s-maxage)", async () => {
+    fetchMock.mockRejectedValue(new Error("backend down"));
+    const out = await call(blogIndexLoader);
+    expect(cacheControlOf(out)).toBe("no-store");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("blog _index: real success → public TTL, NOT no-store", async () => {
+    fetchMock.mockResolvedValue(
+      jsonOk({ success: true, data: { featured: [], stats: {} } }),
+    );
+    const out = await call(blogIndexLoader);
+    const cc = cacheControlOf(out);
+    expect(cc).toContain("s-maxage");
+    expect(cc).not.toContain("no-store");
+  });
+
+  it("advice _index: API failure → no-store + noindex", async () => {
+    fetchMock.mockRejectedValue(new Error("backend down"));
+    const out = await call(adviceLoader);
+    expect(cacheControlOf(out)).toBe("no-store");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("auto _index: per-fetch swallow → still no-store on the empty success return", async () => {
+    // fetches are `.catch(() => null)` — failure reaches the SUCCESS return, not the catch
+    fetchMock.mockRejectedValue(new Error("backend down"));
+    const out = await call(autoIndexLoader);
+    expect(cacheControlOf(out)).toBe("no-store");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("auto $marque index: brand OK but models fetch fails → degraded no-store", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      /model/i.test(url)
+        ? Promise.reject(new Error("models down"))
+        : Promise.resolve(
+            jsonOk({ success: true, data: { name: "Renault", id: 1 } }),
+          ),
+    );
+    const out = await call(autoMarqueLoader, { params: { marque: "renault" } });
+    expect(cacheControlOf(out)).toBe("no-store");
+  });
+
+  it("conseils _index: API failure → no-store + noindex", async () => {
+    fetchMock.mockRejectedValue(new Error("backend down"));
+    const out = await call(conseilsLoader);
+    expect(cacheControlOf(out)).toBe("no-store");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("constructeurs _index: API failure → no-store + noindex", async () => {
+    fetchMock.mockRejectedValue(new Error("backend down"));
+    const out = await call(constructeursLoader);
+    expect(cacheControlOf(out)).toBe("no-store");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("home _index: families service failure → no-store + noindex", async () => {
+    fetchMock.mockRejectedValue(new Error("faq down")); // deferred faq → []
+    const out = await call(homeLoader);
+    expect(cacheControlOf(out)).toBe("no-store");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("article $slug: transient backend error → 302 redirect carrying no-store", async () => {
+    fetchMock.mockRejectedValue(new Error("backend down"));
+    const out = await call(articleLoader, {
+      params: { slug: "comment-changer-les-plaquettes" },
+    });
+    expect(out).toBeInstanceOf(Response);
+    expect((out as Response).status).toBe(302);
+    expect(cacheControlOf(out)).toBe("no-store");
+  });
+});

--- a/frontend/tests/unit/degraded-fallback-cache.test.ts
+++ b/frontend/tests/unit/degraded-fallback-cache.test.ts
@@ -63,6 +63,15 @@ const call = (loader: (a: never) => unknown, args: object = {}) =>
   loader({ request: req(), context: {}, params: {}, ...args } as never);
 
 const jsonOk = (body: unknown) => ({ ok: true, json: async () => body });
+// HTTP 200 whose body is not parseable JSON (proxy hiccup / truncated payload):
+// `.ok` is true but `.json()` rejects → the loader's `.json().catch(() => null)`
+// yields a null parsed body.
+const jsonBad = () => ({
+  ok: true,
+  json: async () => {
+    throw new SyntaxError("Unexpected end of JSON input");
+  },
+});
 
 describe("degraded fallback → never the success TTL", () => {
   it("blog _index: API failure → no-store + noindex (not the public s-maxage)", async () => {
@@ -95,6 +104,44 @@ describe("degraded fallback → never the success TTL", () => {
     const out = await call(autoIndexLoader);
     expect(cacheControlOf(out)).toBe("no-store");
     expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("auto _index: HTTP 200 but brands body unparseable → no-store + noindex (H1, not the public TTL)", async () => {
+    // 200 OK on every fetch, but the brands payload fails to parse → brandsData === null.
+    fetchMock.mockImplementation((url: string) =>
+      /brands-logos/.test(url)
+        ? Promise.resolve(jsonBad())
+        : Promise.resolve(jsonOk({ data: [] })),
+    );
+    const out = await call(autoIndexLoader);
+    const cc = cacheControlOf(out);
+    expect(cc).toBe("no-store");
+    expect(cc).not.toContain("public");
+    expect(cc).not.toContain("s-maxage");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("auto _index: HTTP 200 but models body unparseable → no-store + noindex (H1)", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      /popular-models/.test(url)
+        ? Promise.resolve(jsonBad())
+        : Promise.resolve(jsonOk({ data: [] })),
+    );
+    const out = await call(autoIndexLoader);
+    const cc = cacheControlOf(out);
+    expect(cc).toBe("no-store");
+    expect(cc).not.toContain("public");
+    expect(xRobotsOf(out)).toBe("noindex, follow");
+  });
+
+  it("auto _index: genuine 200 success (both bodies parse) → NOT degraded (delegates to public headers export, no no-store/noindex)", async () => {
+    // Guard against over-privatising a healthy page: on real success the loader
+    // returns `data(payload, undefined)` (the public `headers` export applies) and
+    // must NOT stamp the degraded no-store/noindex.
+    fetchMock.mockResolvedValue(jsonOk({ data: [] }));
+    const out = await call(autoIndexLoader);
+    expect(cacheControlOf(out)).toBeNull();
+    expect(xRobotsOf(out)).toBeNull();
   });
 
   it("auto $marque index: brand OK but models fetch fails → degraded no-store", async () => {

--- a/frontend/tests/unit/entry-server-session-privacy.test.ts
+++ b/frontend/tests/unit/entry-server-session-privacy.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Contract test for the request-aware cache-privacy arbiter
+ * (frontend/app/entry.server.tsx → applySessionCachePrivacy).
+ *
+ * PR B review, blocker #1: React Router `headers` exports are request-unaware,
+ * so a public route would ship `public, s-maxage=…` even to a request carrying a
+ * session cookie (whose document embeds the logged-in user / cart). The arbiter
+ * re-establishes the pre-PR-B invariant ("public cache only WITHOUT a session")
+ * that Caddy's `@public_cached` cookie matcher used to enforce.
+ */
+import { describe, it, expect } from "vitest";
+
+import { applySessionCachePrivacy } from "~/entry.server";
+
+const PRIVATE = "private, no-cache, no-store, must-revalidate";
+const PUBLIC =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600";
+
+function reqWithCookie(cookie?: string): Request {
+  const headers = new Headers();
+  if (cookie !== undefined) headers.set("cookie", cookie);
+  return new Request("https://www.automecanik.com/pieces/x.html", { headers });
+}
+
+/** Simulate the leaf route having already set a public policy on the response. */
+function publicResponseHeaders(): Headers {
+  return new Headers({ "Cache-Control": PUBLIC });
+}
+
+describe("applySessionCachePrivacy — session-bearing requests", () => {
+  it("forces private + no-store at every tier when connect.sid is present, overriding a public leaf policy", () => {
+    const h = publicResponseHeaders();
+    applySessionCachePrivacy(
+      reqWithCookie("connect.sid=s%3Aabc.def; foo=1"),
+      h,
+    );
+    expect(h.get("Cache-Control")).toBe(PRIVATE);
+    expect(h.get("CDN-Cache-Control")).toBe("no-store");
+    expect(h.get("Cloudflare-CDN-Cache-Control")).toBe("no-store");
+  });
+
+  it("matches a generic `session` cookie too (parity with the Caddy matcher)", () => {
+    const h = publicResponseHeaders();
+    applySessionCachePrivacy(reqWithCookie("session=xyz"), h);
+    expect(h.get("Cache-Control")).toBe(PRIVATE);
+    expect(h.get("CDN-Cache-Control")).toBe("no-store");
+  });
+});
+
+describe("applySessionCachePrivacy — anonymous requests (public cache preserved)", () => {
+  it("leaves a public leaf policy untouched when there is no cookie at all", () => {
+    const h = publicResponseHeaders();
+    applySessionCachePrivacy(reqWithCookie(undefined), h);
+    expect(h.get("Cache-Control")).toBe(PUBLIC);
+    expect(h.get("CDN-Cache-Control")).toBeNull();
+    expect(h.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+  });
+
+  it("leaves a public leaf policy untouched for a non-session cookie (e.g. theme/consent)", () => {
+    const h = publicResponseHeaders();
+    applySessionCachePrivacy(reqWithCookie("theme=dark; cookie_consent=1"), h);
+    expect(h.get("Cache-Control")).toBe(PUBLIC);
+    expect(h.get("CDN-Cache-Control")).toBeNull();
+  });
+
+  it("does not invent a Cache-Control when neither the leaf nor a session set one", () => {
+    const h = new Headers();
+    applySessionCachePrivacy(reqWithCookie("theme=dark"), h);
+    expect(h.get("Cache-Control")).toBeNull();
+  });
+});

--- a/frontend/tests/unit/products-private-cache.test.ts
+++ b/frontend/tests/unit/products-private-cache.test.ts
@@ -1,0 +1,59 @@
+/**
+ * PR B review, blocker #2: the /products/* routes are an authenticated Pro
+ * namespace (requireUser / getOptionalUser, noindex, per-user identity +
+ * price_pro/margin + demo data). They must NEVER be shared/public-cached.
+ * This pins that their `headers` export emits private/no-store on the success
+ * path (buildCacheHeaders) — never `public`/`s-maxage`.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import { headers as headersCategory } from "~/routes/products.$category.$subcategory";
+import { headers as headersProductId } from "~/routes/products.$id";
+import { headers as headersBrands } from "~/routes/products.brands";
+import { headers as headersGamme } from "~/routes/products.gammes.$gammeId";
+import { headers as headersRanges } from "~/routes/products.ranges";
+import { headers as headersRangeId } from "~/routes/products.ranges.$rangeId";
+import { headers as headersRangesAdvanced } from "~/routes/products.ranges.advanced";
+
+// The route modules only DEFINE (never execute) their loaders/components at
+// import time, but they statically import a few server helpers — stub the
+// noisy one so the module graph loads quietly under vitest.
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+type HeadersFn = NonNullable<typeof headersProductId>;
+type Args = Parameters<HeadersFn>[0];
+
+const PRIVATE = "private, no-cache, no-store, must-revalidate";
+
+function onSuccess(fn: HeadersFn): Record<string, string> {
+  return fn({
+    loaderHeaders: new Headers(),
+    parentHeaders: new Headers(),
+    actionHeaders: new Headers(),
+    errorHeaders: undefined,
+  } as unknown as Args) as Record<string, string>;
+}
+
+const ROUTES: Array<[string, HeadersFn]> = [
+  ["products.$id", headersProductId],
+  ["products.brands", headersBrands],
+  ["products.ranges", headersRanges],
+  ["products.ranges.advanced", headersRangesAdvanced],
+  ["products.gammes.$gammeId", headersGamme],
+  ["products.ranges.$rangeId", headersRangeId],
+  ["products.$category.$subcategory", headersCategory],
+];
+
+describe("/products/* — never shared-cached", () => {
+  it.each(ROUTES)(
+    "%s emits private/no-store on success (no public, no s-maxage)",
+    (_name, fn) => {
+      const out = onSuccess(fn);
+      expect(out["Cache-Control"]).toBe(PRIVATE);
+      expect(out["Cache-Control"]).not.toContain("public");
+      expect(out["Cache-Control"]).not.toContain("s-maxage");
+    },
+  );
+});


### PR DESCRIPTION
## Goal

Kill the Caddy↔app duplicate so **every indexed public surface emits exactly one governed `Cache-Control`**, owned by the application. Follow-up to PR A (#1271): now that anonymous HTML GET is cookie-free, Caddy's `@public_cached` block actually applies to those requests — so the duplicate header was the last thing between us and clean, single-owner edge caching.

## Root cause of the duplicate

`@public_cached` set `Cache-Control` with **immediate** (non-deferred) `header @x Cache-Control "…"` matchers — applied *before* `reverse_proxy`. The proxy then **appends** the upstream (app) `Cache-Control` → **two `Cache-Control` lines on the wire**, combined ambiguously by Cloudflare (RFC 7234 §5.2). Whichever "wins" was undefined per surface.

## Change

### App = single owner (React Router `headers` via `buildCacheHeaders`)
| Group | Routes | Policy (TTL-neutral) |
|---|---|---|
| Dead-at-edge fix | `reference-auto.$slug`, `blog-pieces-auto._index` | loader TTL + `defaultErrorRobots: noindex, follow` on the bare 404/throw |
| @content owners (8) | `blog-pieces-auto.{advice._index, article.$slug, auto.$marque.$modele, auto.$marque.index, auto._index, conseils._index, constructeurs._index, guide-achat.comment-utiliser…}` | `public, max-age=1800, stale-while-revalidate=3600` |
| @products owners (7) | `products.{$id, $category.$subcategory, brands, ranges, ranges.$rangeId, gammes.$gammeId, ranges.advanced}` | `public, max-age=300, s-maxage=86400, stale-while-revalidate=3600` |
| Inline-arrow → helper (2) | `_index`, `blog-pieces-auto.conseils.$pg_alias` | unchanged value, gains `no-store` on throw |

The two highest-traffic R2 pages (`pieces.$gamme.$marque.$modele.$type.html`, `pieces.$slug`) already owned their (more specific) policies — removal simply makes those governed app values authoritative instead of fighting the backfill.

### Caddy (`config/caddy/Caddyfile` `@public_cached`)
- **Removed** the 4 immediate `header @homepage|@products|@content|@search Cache-Control` SETs (the duplication source).
- **Kept** the deterministic edge default `?Cache-Control` (set-if-absent + deferred → fires only for app responses carrying **no** `Cache-Control`, e.g. `pieces.$.tsx` 301 redirects; **cannot** duplicate an owned header).
- **Demoted** `header Vary` → `?Vary` (same semantics) to avoid a duplicate `Vary` with the upstream / `encode`.
- **Untouched** anti-poisoning guards: `reverse_proxy @up_error` (4xx/5xx → `no-store`) and `handle_errors` (Caddy-generated errors → `no-store`).

## Why removing the backfill is safe — zero indexed surface regresses

Route-by-route ownership map built before removal:
- **Every indexed public route** under the backfilled prefixes now owns its `Cache-Control`.
- The remaining backfilled paths had **no indexed public route** and were being public-cached *by mistake*:
  - Phantom prefixes with no route file: `/catalog/`, `/vehicule/`, `/blog/`, `/guides/`, `/articles/`, top-level `/conseils/` → served by the root splat `no-cache`.
  - `noindex` / gated pages: `products.admin`, `products.catalog` (noindex pro, 403-gated), `blog-pieces-auto.calendrier-entretien` (noindex), `search.tsx` (noindex).
  - These now correctly fall to root `private, max-age=60` (not edge-cached) — **strictly more correct** than the old phantom `s-maxage=86400`.

## Ratchet (extends existing infra, no parallel system)
- Regression is **already mechanized**: `scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh` + error-severity ast-grep `frontend-no-headers-bypass-buildCacheHeaders.yml`. All changed routes pass both.
- **Added** the referenced-but-missing contract test `frontend/tests/unit/cache-control.test.ts` (10 cases: success policy, per-request loader override, `X-Robots-Tag` propagation, `no-store` on error, `defaultErrorRobots`, no-`s-maxage`-leak).

## Verification
**Deterministic (done, in-worktree):** `tsc` 0 errors · `vitest` 32/32 (10 new + `reference-auto-loader-parallel` + `r2-indexability`) · `prettier` clean · both cache lint guards + ast-grep pass on the diff.

**Runtime probes (for review — not yet run):**

*After merge → PREPROD rebuild — app-ownership (exactly one CC, correct value, no `private, max-age=60`):*
```bash
# on 49.12.233.2
for p in / /reference-auto/kit-embrayage /blog-pieces-auto /products/ranges; do
  echo "== $p =="; curl -sSI "http://localhost:3200$p" | grep -i '^cache-control'
done
# expect exactly ONE cache-control line per route with the governed value
```

*After PROD tag (owner GO only) — edge de-dup on the wire:*
```bash
for p in / /reference-auto/kit-embrayage /blog-pieces-auto; do
  echo "== $p =="; curl -sSI "https://www.automecanik.com$p" | grep -ci '^cache-control'
done   # expect: 1 per route (was: 2)
```

## Deferred — separate follow-ups (NOT folded in)
- `blog-pieces-auto.guide-achat.$pg_alias` left on its inline-arrow `headers` (already edge-alive; errors already forced `no-store` by Caddy `@up_error`) to avoid touching an unrelated **pre-existing legacy-SEO-role lint** at `:230`.
- `@private` matcher gap (missing `/panier/*`, `/forgot-password`, `/reset-password/:token`, `/logout`, `/commercial/*`) and whether `/search` should be edge-cached at all.

## Guardrails
- **No PROD tag.** **No auto-merge.** This lands on `main` → PREPROD only.
- No URL/slug/canonical changes. No payment module changes. No `meta`/H1 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
