### PR TITLE
feat(seo): ADR-059 projection-read dark-launch controls (PR-E1)

### DIFF
--- a/backend/src/config/feature-flags.projection-read.test.ts
+++ b/backend/src/config/feature-flags.projection-read.test.ts
@@ -1,0 +1,190 @@
+import { ConfigService } from '@nestjs/config';
+import { FeatureFlagsService } from './feature-flags.service';
+
+/**
+ * ADR-059 SEO projection READ — dark-launch controls (PR-E1).
+ *
+ * These invariants pin the *control surface only* — no page is activated by this PR.
+ * The decisive property proved here: enabling the projection read for one role on an
+ * entity (R3_CONSEILS on `gamme:filtre-a-huile`) can NEVER activate a sibling role
+ * (R4_REFERENCE / R6_GUIDE_ACHAT) on the same entity. Role isolation is structural
+ * (token `<role>@<entity_key>`, no bare `*`), not a convention.
+ */
+
+class FakeConfigService {
+  constructor(private readonly env: Record<string, string> = {}) {}
+  get<T = string>(key: string): T | undefined {
+    return this.env[key] as unknown as T | undefined;
+  }
+}
+
+const make = (env: Record<string, string> = {}) =>
+  new FeatureFlagsService(
+    new FakeConfigService(env) as unknown as ConfigService,
+  );
+
+const PILOT_ENTITY = 'gamme:filtre-a-huile';
+
+describe('FeatureFlagsService — ADR-059 projection read (PR-E1, dark-launch)', () => {
+  describe('defaults ship OFF (no page activated)', () => {
+    it('master switch defaults to false', () => {
+      expect(make().seoProjectionReadV1).toBe(false);
+    });
+
+    it('canary allowlist defaults to empty', () => {
+      expect(make().seoProjectionReadCanary).toEqual([]);
+    });
+
+    it('flag absent → every (entity, role) resolves to legacy (not eligible)', () => {
+      const ff = make();
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(
+        false,
+      );
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R4_REFERENCE')).toBe(
+        false,
+      );
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R6_GUIDE_ACHAT')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('master switch is a hard prerequisite', () => {
+    it('allowlist populated but master OFF → still not eligible', () => {
+      const ff = make({
+        SEO_PROJECTION_READ_CANARY: `R3_CONSEILS@${PILOT_ENTITY}`,
+        // SEO_PROJECTION_READ_V1 intentionally absent → false
+      });
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('role-scoped eligibility (the pilot: R3_CONSEILS + gamme:filtre-a-huile)', () => {
+    const ff = make({
+      SEO_PROJECTION_READ_V1: 'true',
+      SEO_PROJECTION_READ_CANARY: `R3_CONSEILS@${PILOT_ENTITY}`,
+    });
+
+    it('R3 allowlisted → R3 is eligible', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(true);
+    });
+
+    it('same entity, R4 NOT allowlisted → R4 stays legacy', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R4_REFERENCE')).toBe(
+        false,
+      );
+    });
+
+    it('same entity, R6 NOT allowlisted → R6 stays legacy', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R6_GUIDE_ACHAT')).toBe(
+        false,
+      );
+    });
+
+    it('enabling R3 does NOT bleed to another entity', () => {
+      expect(
+        ff.isProjectionReadCanary('gamme:disque-de-frein', 'R3_CONSEILS'),
+      ).toBe(false);
+    });
+  });
+
+  describe('role-scoped wildcard <role>@* stays within its role', () => {
+    const ff = make({
+      SEO_PROJECTION_READ_V1: 'true',
+      SEO_PROJECTION_READ_CANARY: 'R3_CONSEILS@*',
+    });
+
+    it('enables R3 for any entity', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(true);
+      expect(
+        ff.isProjectionReadCanary('gamme:disque-de-frein', 'R3_CONSEILS'),
+      ).toBe(true);
+    });
+
+    it('does NOT enable a sibling role, even wildcarded', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R4_REFERENCE')).toBe(
+        false,
+      );
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R6_GUIDE_ACHAT')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('a bare "*" is never honored (cannot cross roles)', () => {
+    const ff = make({
+      SEO_PROJECTION_READ_V1: 'true',
+      SEO_PROJECTION_READ_CANARY: '*',
+    });
+
+    it('bare "*" matches no role', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(
+        false,
+      );
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R4_REFERENCE')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('multi-token allowlist keeps per-token role isolation', () => {
+    // Two roles on the SAME entity are allowlisted independently — proving that
+    // co-activation is always explicit, never a side effect of one another.
+    const ff = make({
+      SEO_PROJECTION_READ_V1: 'true',
+      SEO_PROJECTION_READ_CANARY: `R3_CONSEILS@${PILOT_ENTITY}, R4_REFERENCE@${PILOT_ENTITY}`,
+    });
+
+    it('both explicitly-listed roles are eligible', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(true);
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R4_REFERENCE')).toBe(
+        true,
+      );
+    });
+
+    it('the un-listed sibling (R6) stays legacy', () => {
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R6_GUIDE_ACHAT')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('guards', () => {
+    const ff = make({
+      SEO_PROJECTION_READ_V1: 'true',
+      SEO_PROJECTION_READ_CANARY: `R3_CONSEILS@${PILOT_ENTITY}`,
+    });
+
+    it('empty entityKey or role → not eligible', () => {
+      expect(ff.isProjectionReadCanary('', 'R3_CONSEILS')).toBe(false);
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, '')).toBe(false);
+    });
+  });
+
+  describe('the new keys are governed (visible + overridable)', () => {
+    it('listFlags() exposes both new keys', () => {
+      const flags = make().listFlags();
+      expect(flags).toHaveProperty('SEO_PROJECTION_READ_V1');
+      expect(flags).toHaveProperty('SEO_PROJECTION_READ_CANARY');
+    });
+
+    it('setOverride accepts the new keys and toggles eligibility at runtime', () => {
+      const ff = make();
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(
+        false,
+      );
+      ff.setOverride('SEO_PROJECTION_READ_V1', 'true');
+      ff.setOverride(
+        'SEO_PROJECTION_READ_CANARY',
+        `R3_CONSEILS@${PILOT_ENTITY}`,
+      );
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R3_CONSEILS')).toBe(true);
+      // sibling still legacy after override
+      expect(ff.isProjectionReadCanary(PILOT_ENTITY, 'R4_REFERENCE')).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -79,6 +79,49 @@ export class FeatureFlagsService {
     return this.bool('SEO_BRIEF_WIKI_ENABLED', false);
   }
 
+  // ── ADR-059 SEO projection READ (dark-launch, role-scoped canary) ──
+
+  /**
+   * Master switch for the ADR-059 projection READ path (`SeoProjectionReaderService`
+   * consuming `get_active_seo_projection`). OFF (default) → every role serves its
+   * legacy reader, unconditionally. Hard prerequisite: while this is OFF, no
+   * `(entity_key, projection_role)` pair can be projection-eligible, whatever the
+   * canary allowlist holds. Dark-launch — this PR ships it OFF with an empty
+   * allowlist; no page is activated.
+   */
+  get seoProjectionReadV1(): boolean {
+    return this.bool('SEO_PROJECTION_READ_V1', false);
+  }
+
+  /**
+   * Role-scoped canary allowlist for the projection READ path. CSV of
+   * `<projection_role>@<entity_key>` tokens, where `entity_key` is the namespaced
+   * canonical identity used by the RPC (e.g. `gamme:filtre-a-huile`), or
+   * `<projection_role>@*` to canary every entity of a SINGLE role. Empty by default.
+   * There is deliberately NO bare `*`: a token can never cross roles, so a GO on one
+   * role for an entity can never activate a sibling role (R4/R6) on the same entity.
+   * Membership is resolved through `isProjectionReadCanary`, never read directly.
+   */
+  get seoProjectionReadCanary(): string[] {
+    return this.csv('SEO_PROJECTION_READ_CANARY');
+  }
+
+  /**
+   * True only if BOTH the master switch is ON AND the `(entity_key, projection_role)`
+   * pair is explicitly allowlisted — either the exact `<role>@<entity_key>` token or
+   * the role-scoped wildcard `<role>@*`. Never honors a bare `*`: role isolation is
+   * structural. This is the single decision point for "is this scope projection-eligible?".
+   */
+  isProjectionReadCanary(entityKey: string, projectionRole: string): boolean {
+    if (!this.seoProjectionReadV1) return false;
+    if (!entityKey || !projectionRole) return false;
+    const list = this.seoProjectionReadCanary;
+    return (
+      list.includes(`${projectionRole}@${entityKey}`) ||
+      list.includes(`${projectionRole}@*`)
+    );
+  }
+
   // ── Phase 2 Orchestration flags ──
 
   get executionRegistryEnabled(): boolean {
@@ -357,6 +400,8 @@ export class FeatureFlagsService {
     'BRIEF_GATES_ENABLED',
     'BRIEF_GATES_OBSERVE_ONLY',
     'SEO_BRIEF_WIKI_ENABLED',
+    'SEO_PROJECTION_READ_V1',
+    'SEO_PROJECTION_READ_CANARY',
     'RAG_CATCHUP_ENABLED',
     'RAG_MERGE_DRY_RUN',
     'RAG_MERGE_ALLOWED_ROLES',


### PR DESCRIPTION
## Foundation wave — PR-E1 (mechanical enabler, dark-launch)

Registers the **control surface** for the ADR-059 projection READ path. **Nothing is activated**: ships OFF with an empty allowlist, no reader wiring, no PREPROD/PROD change.

### What this adds (`backend/src/config/feature-flags.service.ts`)
- **`SEO_PROJECTION_READ_V1`** — master switch, default `false`. Hard prerequisite: while OFF, no `(entity_key, projection_role)` pair is projection-eligible, whatever the allowlist holds.
- **`SEO_PROJECTION_READ_CANARY`** — CSV of `<projection_role>@<entity_key>` tokens (entity_key = the namespaced canonical identity the RPC already uses, e.g. `gamme:filtre-a-huile`), or `<role>@*` for a single-role wildcard. Empty by default. **No bare `*`** — a token can never cross roles.
- **`isProjectionReadCanary(entityKey, projectionRole)`** — single decision point; `true` only if master ON **and** exact token or `<role>@*` present.
- Both keys registered in `ALLOWED_KEYS` → surfaced by `listFlags()` (existing flag inventory) and accepted by `setOverride`.

### The invariant it pins
Target contract `(entity_key, projection_role)`. Pilot: `gamme:filtre-a-huile + R3_CONSEILS`.

16 acceptance tests (`feature-flags.projection-read.test.ts`), including the decisive property:
- flag absent/default → **legacy** (not eligible);
- master OFF but allowlist populated → **still not eligible** (hard prereq);
- `R3_CONSEILS@gamme:filtre-a-huile` → **R3 eligible**;
- same entity, R4 not allowlisted → **R4 stays legacy**;
- same entity, R6 not allowlisted → **R6 stays legacy**;
- `<role>@*` wildcard stays inside its role; bare `*` matches nothing.

**Enabling one role for an entity can never activate a sibling role on the same entity** — role isolation is structural, not a convention.

### Out of scope (explicit NO-GO for this PR)
No reader wiring · no R3 consumer activation · no page activated · no PREPROD/PROD projection · no PostgreSQL/grant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)