### PR TITLE
chore(rpc-gate): root allowlist parity for get_active_seo_projection (PR-E2)

### DIFF
--- a/backend/src/security/rpc-gate/rpc-gate.projection-allowlist.test.ts
+++ b/backend/src/security/rpc-gate/rpc-gate.projection-allowlist.test.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ConfigService } from '@nestjs/config';
+import { RpcGateService } from './rpc-gate.service';
+
+/**
+ * ADR-059 — `get_active_seo_projection` allowlist parity + gate invariant (PR-E2).
+ *
+ * The projection READ RPC is backend-proxied and `service_role`-only (no anon GRANT).
+ * The RpcGate reads its allowlist from `<cwd>/governance/rpc/rpc_allowlist.json`
+ * (repo root at DEV runtime; `backend/governance/rpc/...` inside the Docker image
+ * where start.sh does `cd backend`). Both copies must list the RPC or DEV/PROD drift.
+ *
+ * These tests load the REAL shipped root allowlist (the file this PR edits) through
+ * the gate in the strictest posture (enforce + production) and prove:
+ *   1. the RPC is ALLOWED via the allowlist (not merely tolerated as "unknown");
+ *   2. an unknown RPC is still BLOCKED — the gate is not weakened;
+ *   3. the two on-disk copies stay in parity;
+ *   4. the entry stays documented as service_role-only (no anon grant is introduced).
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const ROOT_GOV_DIR = path.join(REPO_ROOT, 'governance', 'rpc');
+const ROOT_ALLOWLIST = path.join(ROOT_GOV_DIR, 'rpc_allowlist.json');
+const BACKEND_ALLOWLIST = path.join(
+  REPO_ROOT,
+  'backend',
+  'governance',
+  'rpc',
+  'rpc_allowlist.json',
+);
+
+const RPC = 'get_active_seo_projection';
+
+class FakeConfigService {
+  constructor(private readonly env: Record<string, string> = {}) {}
+  get<T = string>(key: string): T | undefined {
+    return this.env[key] as unknown as T | undefined;
+  }
+}
+
+/** Gate wired for the strictest posture, reading the real shipped root allowlist. */
+async function makeEnforcedGate(): Promise<RpcGateService> {
+  const cfg = new FakeConfigService({
+    RPC_GATE_MODE: 'enforce',
+    RPC_GATE_ENFORCE_LEVEL: 'ALL',
+    NODE_ENV: 'production',
+    RPC_GATE_GOV_DIR: ROOT_GOV_DIR,
+  });
+  const gate = new RpcGateService(cfg as unknown as ConfigService);
+  await gate.onModuleInit();
+  return gate;
+}
+
+describe('RpcGate — get_active_seo_projection allowlist (PR-E2)', () => {
+  let gate: RpcGateService;
+
+  beforeAll(async () => {
+    gate = await makeEnforcedGate();
+  });
+
+  afterAll(() => {
+    gate?.onModuleDestroy();
+  });
+
+  describe('positive — the projection RPC is explicitly allowed', () => {
+    it('enforce + production: ALLOW via the allowlist (not "unknown")', () => {
+      const res = gate.evaluate(RPC, { source: 'api', role: 'anon' });
+      // role:'anon' (non-service-role) proves the ALLOW comes from the allowlist
+      // entry, NOT from the UNKNOWN_SERVICE_ROLE branch.
+      expect(res.decision).toBe('ALLOW');
+      expect(res.reason).toBe('ALLOWLIST_READ_SAFE');
+    });
+  });
+
+  describe('negative — the gate is not weakened', () => {
+    it('enforce + production: an unknown RPC from a public role is BLOCKED', () => {
+      const res = gate.evaluate('nonexistent_rpc_pr_e2_probe', {
+        source: 'api',
+        role: 'anon',
+      });
+      expect(res.decision).toBe('BLOCK');
+      expect(res.reason).toBe('UNKNOWN_BLOCKED_PROD');
+    });
+  });
+
+  describe('parity — the two on-disk copies do not drift', () => {
+    const load = (p: string) =>
+      JSON.parse(fs.readFileSync(p, 'utf-8')) as {
+        total: number;
+        functions: { name: string; reason?: string }[];
+      };
+
+    it('root and backend allowlists both list the RPC', () => {
+      const root = load(ROOT_ALLOWLIST);
+      const backend = load(BACKEND_ALLOWLIST);
+      expect(root.functions.some((f) => f.name === RPC)).toBe(true);
+      expect(backend.functions.some((f) => f.name === RPC)).toBe(true);
+    });
+
+    it('root allowlist `total` matches its own function count', () => {
+      const root = load(ROOT_ALLOWLIST);
+      expect(root.total).toBe(root.functions.length);
+    });
+
+    it('the entry is documented as service_role-only (no anon grant)', () => {
+      const root = load(ROOT_ALLOWLIST);
+      const entry = root.functions.find((f) => f.name === RPC);
+      expect(entry).toBeDefined();
+      expect(entry?.reason ?? '').toMatch(/service_role only/i);
+      expect(entry?.reason ?? '').toMatch(/no anon GRANT/i);
+    });
+  });
+});

--- a/governance/rpc/rpc_allowlist.json
+++ b/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 169,
+  "total": 171,
   "functions": [
     {
       "name": "auth_email_exists",
@@ -243,6 +243,11 @@
       "name": "get_action_definition",
       "volatility": "STABLE",
       "reason": "SELECT only"
+    },
+    {
+      "name": "get_active_seo_projection",
+      "volatility": "STABLE",
+      "reason": "ADR-059/090 D1 — SEO projection read (facts+blocks envelope, role-filtered). STABLE SECURITY DEFINER pure SELECT over mv_seo_entity_facts_current × mv_seo_content_blocks_current. Backend-proxied (no anon GRANT), called by SeoBriefService.composeBrief. EXECUTE service_role only."
     },
     {
       "name": "get_all_seo_observables_for_sitemap",


### PR DESCRIPTION
## Foundation wave — PR-E2 (governance parity + tests)

**Accurate record (for future incident analysis):** the **backend runtime copy** (`backend/governance/rpc/rpc_allowlist.json`, runtime-authoritative for PROD/PREPROD because `start.sh` does `cd backend`) **already allowlisted** `get_active_seo_projection`. **This PR restored root↔backend governance parity and prevented DEV/PROD policy drift; it did NOT fix an active backend runtime block** — there was none. DEV (repo-root `cwd`), lacking the root entry, tolerated the RPC as `unknown` under observe/service_role, so nothing was blocked at runtime. Do not read this PR as a block fix.

### Context
`RpcGateService` loads its allowlist from `<cwd>/governance/rpc/rpc_allowlist.json`:
- **DEV runtime** (`npm run dev` from repo root) → reads the **root** copy.
- **Docker image** (`start.sh` does `cd backend`) → reads **`backend/governance/rpc/...`** (runtime-authoritative for PREPROD/PROD).

The two copies had drifted (backend had the RPC, root did not). This PR realigns them so DEV governance == PROD governance.

### Changes
- **`governance/rpc/rpc_allowlist.json`** — add `get_active_seo_projection`, copied verbatim from the backend copy (`STABLE`, SECURITY DEFINER, **service_role only, no anon GRANT**), at its alphabetical position.
- Correct the file's `total` field (`169` → `171`). It was already off by one before this PR (169 vs an actual 170); it is now the true count after the add.
- **`rpc-gate.projection-allowlist.test.ts`** — loads the **real shipped root allowlist** through the gate in the strictest posture (`enforce` + `production`) and proves:
  1. `get_active_seo_projection` → **ALLOW** with reason `ALLOWLIST_READ_SAFE`, using `role: 'anon'` so the ALLOW is proven to come from the allowlist entry, **not** the service-role bypass;
  2. an unknown RPC from a public role is still **BLOCK** (`UNKNOWN_BLOCKED_PROD`) — the gate is not weakened;
  3. root and backend copies stay in **parity**;
  4. the entry stays documented as **service_role-only**.

### Out of scope (explicit)
No SQL grant change · no anon grant · no RPC signature change · no runtime service change. Governance-file + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)