### PR TITLE
fix(media-factory): corrige artifact.bytes du manifest pilote (metadata-only) + gitignore handoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,9 @@ frontend/tests/e2e/reports/
 .claude/*.lock
 .claude/.session-log-state/
 
+# Claude Code owner handoffs (prep vault G3 etc. — PREP_ONLY, jamais committé dans ce repo)
+.claude/handoffs/
+
 # Cookies (curl debug artifacts)
 cookies.txt
 

--- a/workspaces/marketing/fafa-media-factory/manifests/renders/fafa-plaquettes-frein-001.json
+++ b/workspaces/marketing/fafa-media-factory/manifests/renders/fafa-plaquettes-frein-001.json
@@ -28,7 +28,7 @@
   "artifact": {
     "filename": "fafa-plaquettes-frein-001.mp4",
     "sha256": "61671dca9528af8a355185ad3a356231572756a74f54407739abdc23e6f6f57e",
-    "bytes": 1132000,
+    "bytes": 1078128,
     "s3KeyCanonical": "s3://automecanik-renders/pilots/fafa-plaquettes-frein-001/motion-graphics-silent.mp4",
     "s3UploadStatus": "PENDING_OPS_UPLOAD",
     "previewLocalPath": "(hors repo — MP4 gitignoré, S3-only ; render local pour review, upload S3 = étape ops séparée)"


### PR DESCRIPTION
## Objet

Fermeture de l'incohérence de métadonnée relevée par l'owner sur le manifest de rendu `fafa-plaquettes-frein-001` (mergé en #1273).

## Diagnostic (owner-requested, exécuté)

Sur le chemin exact du preview :
```
bytes  = 1078128        (wc -c + ffprobe format.size)
sha256 = 61671dca9528af8a355185ad3a356231572756a74f54407739abdc23e6f6f57e
ffprobe = 1080x1920, 30fps, 1140 frames, 38.0s, 0 piste audio
```
Le manifest sur `main` liait le **bon SHA-256** mais annonçait `artifact.bytes: 1132000` (**faux**, erreur de saisie). **Cas (i) de l'owner** : SHA correct + 1 078 128 octets → l'artefact est bien celui lié au manifest (pas un nouveau candidat), seul le champ `bytes` est erroné.

## Changements

1. `manifests/renders/fafa-plaquettes-frein-001.json` : `artifact.bytes` **1132000 → 1078128**. Aucune autre modification ; le SHA-256 lié (verrou d'approbation) est **inchangé**.
2. `.gitignore` : ajout de `.claude/handoffs/` — la prep owner G3 (relocalisée en `.claude/handoffs/vault-fafa-g3/`) est **PREP_ONLY** et ne doit jamais être committée dans ce monorepo (l'écriture réelle se fait dans `ak125/governance-vault`, commit signé).

## Impact

- **Aucun impact runtime.** Correction de métadonnée + hygiène gitignore.
- Le binding d'approbation reste `render_approved` → SHA-256 `61671dca…` (inchangé). `render_approved` reste **false** (visionnage owner en attente).
- La règle gitignore `.claude/handoffs/` prend effet dans le checkout principal **au merge** de cette PR.

Refs : #1273 (manifest d'origine), #1260/#1258 (pilote + palette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)