### PR TITLE
fix(observability): drop client-disconnect socket errors from Sentry (read ECONNRESET on /health)

### DIFF
--- a/backend/src/instrument.test.ts
+++ b/backend/src/instrument.test.ts
@@ -12,6 +12,66 @@
  * import (no network), and `Sentry.captureException` inside the handler is a
  * safe no-op.
  */
+import type { ErrorEvent, EventHint } from '@sentry/nestjs';
+import { sanitizeSentryEvent } from './instrument';
+
+describe('sanitizeSentryEvent — client-disconnect noise filter (beforeSend)', () => {
+  const run = (originalException: unknown, event: Partial<ErrorEvent> = {}) =>
+    sanitizeSentryEvent(
+      event as ErrorEvent,
+      { originalException } as EventHint,
+    );
+
+  it('drops a raw "read ECONNRESET" socket error (wget /health probe / client RST)', () => {
+    // Node surfaces an inbound keep-alive socket reset as `Error: read
+    // ECONNRESET` (code ECONNRESET, syscall read) from TCP.onStreamRead. The
+    // Docker HEALTHCHECK `wget -qO- .../health` and real browsers/CDNs closing
+    // keep-alive sockets produce this; it is not an application fault.
+    const err = Object.assign(new Error('read ECONNRESET'), {
+      code: 'ECONNRESET',
+      syscall: 'read',
+    });
+    expect(run(err)).toBeNull();
+  });
+
+  it('drops EPIPE / ECONNABORTED socket write disconnects', () => {
+    const epipe = Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+      syscall: 'write',
+    });
+    const aborted = Object.assign(new Error('ECONNABORTED'), {
+      code: 'ECONNABORTED',
+      syscall: 'read',
+    });
+    expect(run(epipe)).toBeNull();
+    expect(run(aborted)).toBeNull();
+  });
+
+  it('still drops the sibling raw-body "request aborted" noise (regression)', () => {
+    const err = Object.assign(new Error('request aborted'), {
+      type: 'request.aborted',
+    });
+    expect(run(err)).toBeNull();
+  });
+
+  it('does NOT drop a genuine application error (no over-filtering)', () => {
+    const err = new Error("Cannot read properties of undefined (reading 'x')");
+    const event = { request: { headers: {} } } as ErrorEvent;
+    expect(run(err, event)).not.toBeNull();
+  });
+
+  it('does NOT drop an ECONNRESET that is not a bare socket read/write (has no syscall)', () => {
+    // A domain-level error that merely mentions ECONNRESET in its message but is
+    // not a bare TCP socket error must still surface (guards against blanket
+    // suppression of real upstream failures, which the data layer already
+    // retries — see supabase-base.service.ts).
+    const err = Object.assign(new Error('Supabase RPC failed: ECONNRESET'), {
+      // no `code`, no `syscall` → not a bare socket disconnect
+    });
+    expect(run(err)).not.toBeNull();
+  });
+});
+
 describe('instrument.ts — process-level error handlers', () => {
   it('registers a non-fatal unhandledRejection handler (logs, never exits)', () => {
     const before = new Set(process.listeners('unhandledRejection'));

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -20,20 +20,51 @@ import 'dotenv/config';
 import * as Sentry from '@sentry/nestjs';
 import type { ErrorEvent, EventHint } from '@sentry/nestjs';
 
-// Exported `beforeSend` predicate. Drops client-aborted body-parser errors
-// (raw-body fires `BadRequestError: request aborted` with `err.type =
-// 'request.aborted'` when the TCP connection is cut before the request body
-// finishes streaming — typical for tracking beacons during page unload). Also
+// Socket-level client-disconnect codes. A bare `Error` carrying one of these
+// with a read/write syscall is an inbound connection reset, not an application
+// fault (see sanitizeSentryEvent).
+const CLIENT_DISCONNECT_CODES = new Set([
+  'ECONNRESET',
+  'EPIPE',
+  'ECONNABORTED',
+]);
+
+// Exported `beforeSend` predicate. Drops expected client-disconnect noise and
 // scrubs sensitive request headers as defence-in-depth on top of Sentry's
-// server-side PII scrubbing.
+// server-side PII scrubbing. Two client-disconnect shapes are silenced:
+//
+//  1. raw-body `BadRequestError: request aborted` (`err.type = 'request.aborted'`)
+//     — the TCP connection is cut before the request BODY finishes streaming
+//     (typical for tracking beacons during page unload).
+//  2. bare socket resets `Error: read ECONNRESET` / `write EPIPE` /
+//     `ECONNABORTED` (`err.code` + `err.syscall`) from `TCP.onStreamRead` — an
+//     inbound keep-alive socket reset. The Docker HEALTHCHECK
+//     `wget -qO- http://localhost:3000/health` and real clients (browsers,
+//     CDN/LB) closing keep-alive sockets produce these; they carry no HTTP
+//     status and reach the global filter's `@SentryExceptionCaptured()` as
+//     unhandled `auto.function.nestjs.exception_captured` events.
+//
+// This is NOT a silent fallback for real failures: genuine UPSTREAM resets
+// (e.g. a Supabase socket drop mid-request) are caught and retried in the data
+// layer (supabase-base.service.ts) and never reach this hook as a bare socket
+// error; requiring `err.syscall` keeps the filter to true socket-level noise.
+// Server crashes stay observable via the uncaughtException handler + failing
+// (non-200) healthchecks, not via these inbound resets.
 export function sanitizeSentryEvent(
   event: ErrorEvent,
   hint: EventHint,
 ): ErrorEvent | null {
   const err = hint?.originalException as
-    | { type?: string; message?: string }
+    | { type?: string; message?: string; code?: string; syscall?: string }
     | undefined;
   if (err?.type === 'request.aborted' || err?.message === 'request aborted') {
+    return null;
+  }
+  if (
+    err?.code !== undefined &&
+    CLIENT_DISCONNECT_CODES.has(err.code) &&
+    (err.syscall === 'read' || err.syscall === 'write')
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Problème

Sentry issue `6da6512c` — `Error: read ECONNRESET` sur `GET /health`, projet `automecanik-backend-dev`.

Tag `browser = Wget`, container Alpine (node v24), `mechanism = auto.function.nestjs.exception_captured`.

**C'est du bruit healthcheck, pas une panne.** Le Docker `HEALTHCHECK` (`docker-compose.preprod.yml:61` / `docker-compose.prod.yml:98`) est `wget -qO- http://localhost:3000/health`. BusyBox `wget` (et les vrais clients : navigateurs, CDN/LB) ferment la socket keep-alive côté client ; Node remonte ça comme une `Error: read ECONNRESET` nue depuis `TCP.onStreamRead`, sans statut HTTP. Elle atteint le `@SentryExceptionCaptured()` de `GlobalErrorFilter` (non-HttpException → capturée inconditionnellement) et part vers Sentry.

Le handler `/health` est **synchrone, zéro I/O** (`health.module.ts` — "liveness ALWAYS 200, never Redis-dependent"), donc ce n'est pas une lenteur serveur : c'est une coupure de socket côté client.

## Root cause (confirmé au code)

`sanitizeSentryEvent` (`beforeSend`, `instrument.ts`) filtre déjà le pattern **frère** `request aborted` (`err.type === 'request.aborted'`) mais **pas** `read ECONNRESET`. `global-error.filter.ts:54` pointe explicitement vers ce hook comme **le** point d'extension pour ce type de bruit.

## Fix (single-SoT, extension gouvernée)

Étend `sanitizeSentryEvent` pour aussi drop les coupures socket nues : `code ∈ {ECONNRESET, EPIPE, ECONNABORTED}` **avec** un `syscall` read/write.

**Pas un silent fallback** :
- Les resets **upstream** réels (ex. Supabase mid-requête) sont attrapés + retry dans la couche data (`supabase-base.service.ts:351`) et n'atteignent jamais ce hook comme erreur socket nue. L'exigence de `err.syscall` cantonne le filtre au vrai bruit socket-level.
- Un crash serveur reste observable via le handler `uncaughtException` (`instrument.ts`) + les healthchecks qui **échouent** (non-200), pas via ces resets entrants.
- Cohérent avec le drop `request aborted` déjà en place (même famille client-disconnect), documenté in-file.

## Tests

`instrument.test.ts` (nouveau bloc, TDD — RED confirmé avant fix) :
- ✅ `read ECONNRESET` (syscall read) → drop
- ✅ `write EPIPE` / `ECONNABORTED` → drop
- ✅ `request aborted` → toujours drop (régression)
- ✅ erreur applicative réelle → **surface** (pas d'over-filtering)
- ✅ ECONNRESET dans un message mais sans `syscall` (ex. erreur domaine upstream) → **surface**

`tsc --noEmit` 0 · eslint 0 · 6/6 tests + `instrument-init-count.test.ts` 2/2.

## Déploiement

Scope = merge `main` → container PREPROD CI uniquement. **Pas de tag PROD** (owner-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)