### PR TITLE
fix(seo-projection): replay reads run_id PK, not the non-existent id column

### DIFF
--- a/scripts/seo-projection/replay_projection.py
+++ b/scripts/seo-projection/replay_projection.py
@@ -178,7 +178,10 @@ def validate_run_for_replay(
     sha256 n'est pas validé (garde-fou anti-corruption).
     """
     errors: list[str] = []
-    run_id = run_row.get("id")
+    # __seo_projection_runs PK is `run_id` (uuid) — there is no `id` column.
+    # Reading "id" here made every DB-fetched run short-circuit to missing_run_id
+    # (replay 100% non-functional on live data). No "id" fallback: the column is run_id.
+    run_id = run_row.get("run_id")
     if not run_id:
         return {"ok": False, "run_id": None, "errors": ["missing_run_id"]}
 

--- a/tests/seo_projection/test_replay_projection.py
+++ b/tests/seo_projection/test_replay_projection.py
@@ -41,7 +41,7 @@ def _make_snapshot(tmp_path: Path, content: bytes) -> tuple[Path, str]:
 
 def _valid_run_row(snapshot_hash: str) -> dict:
     return {
-        "id": "00000000-0000-7000-8000-000000000001",
+        "run_id": "00000000-0000-7000-8000-000000000001",
         "started_at": "2026-05-13T10:00:00+00:00",
         "exports_snapshot_hash": snapshot_hash,
         "exports_snapshot_uri": f"/opt/automecanik/object-store/exports-snapshots/{snapshot_hash.split(':')[1]}.tar.zst",
@@ -251,7 +251,7 @@ def test_manifest_writer_writes_into_replay_queue(tmp_path: Path) -> None:
     assert "git checkout" in parsed["replay_authority"].lower()  # FORBIDDEN mention
     assert len(parsed["runs_to_replay"]) == 1
     assert parsed["runs_to_replay"][0]["trigger_kind"] == "replay"
-    assert parsed["runs_to_replay"][0]["replayed_from_run_id"] == run["id"]
+    assert parsed["runs_to_replay"][0]["replayed_from_run_id"] == run["run_id"]
 
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## P2-R3-B item (a) — replay `run_id` fix (green-but-wrong)

`__seo_projection_runs` has **PK `run_id`** (uuid) and **no `id` column** (verified against the live shared DB, project `cxpojprgwgubzjyqzmoq`). `validate_run_for_replay` read `run_row.get("id")`, so every DB-fetched run (`fetch_runs_from_db` does `SELECT *`) short-circuited to `missing_run_id` — **replay was 100% non-functional on live data**.

The regression test **masked** it: `_valid_run_row` keyed the PK as `"id"` and asserted on `run["id"]`, so CI stayed green while the real contract was broken. Fixed **both in lockstep** — the fixture now uses `run_id`, so the test proves the real DB contract. No `"id"` fallback: the column is `run_id`, full stop.

### Verification
- `pytest tests/seo_projection/test_replay_projection.py` → **36 passed**.
- **Negative proof**: reverting *only* the source getter back to `.get("id")` (fixture now keyed `run_id`) → **3 tests fail** (`test_validate_run_full_success`, `..._sha256_mismatch_marks_invalid`, `..._manifest_writer_writes_into_replay_queue`). The bug can no longer hide. Restored → 36 passed.

### Scope
**Item (a) only.** Items (b)–(e) — atomic/reproducible snapshot + `exports_snapshot_hash` + semver versions; role-scoped public `writeEntity`; single-entity feeder guard; `fast-json-stable-stringify`+sha256 content hash; `roles_written/noop/blocked` counters — live in the **producer/writer** surface and follow in a separate PR. `replay_projection.py` stays **read-only** and correctly keeps rejecting live runs (`version_missing` / `exports_snapshot_hash_invalid`) until the producer populates those fields.

Grounded in verified DB truth (`__seo_projection_runs` PK `run_id`; identity = `NAMESPACED_ENTITY_KEY`, GNG-4). No schema change. No activation — projection serving remains NO-GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)