### PR TITLE
feat(seo-projection): durable reproducible snapshot producer + role-scoped writer (P2-R3-B, dark)

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -152,6 +152,43 @@ export class FeatureFlagsService {
     return this.bool('SEO_R6_CONSOLIDATION_ENABLED', false);
   }
 
+  // ── SEO Projection forward-writer (ADR-059 P2-B) — allowlists role-scoped ──
+
+  /**
+   * Types d'entités que le feeder single-entity peut projeter. **`diagnostic` EXCLU** tant que le
+   * contrat S2_DIAG n'est pas fermé (plan §R5 contrat négatif) — même si le gate l'admet encore.
+   * Override CSV `SEO_PROJECTION_WRITABLE_TYPES` (défaut : gamme, constructeur, vehicle).
+   */
+  get seoProjectionWritableTypes(): string[] {
+    const override = this.csv('SEO_PROJECTION_WRITABLE_TYPES');
+    return override.length > 0
+      ? override
+      : ['gamme', 'constructeur', 'vehicle'];
+  }
+
+  /**
+   * Rôles projetables par type d'entité (P2-B) — un type autorisé n'autorise JAMAIS implicitement
+   * tous ses rôles ; une canary mono-rôle n'écrit que le rôle demandé. `gamme` overridable via CSV
+   * `SEO_PROJECTION_GAMME_ROLES` (défaut R3/R4/R6) ; `constructeur`→R7, `vehicle`→R8. R1 = AUCUNE
+   * projection éditoriale autonome (il compose R3/R4/R6). Type inconnu → aucune écriture (fail-closed).
+   */
+  seoProjectionWritableRoles(entityType: string): string[] {
+    switch (entityType) {
+      case 'gamme': {
+        const override = this.csv('SEO_PROJECTION_GAMME_ROLES');
+        return override.length > 0
+          ? override
+          : ['R3_CONSEILS', 'R4_REFERENCE', 'R6_GUIDE_ACHAT'];
+      }
+      case 'constructeur':
+        return ['R7_BRAND'];
+      case 'vehicle':
+        return ['R8_VEHICLE'];
+      default:
+        return [];
+    }
+  }
+
   // ── Conseil Pack flags ──
 
   get conseilPackEnabled(): boolean {

--- a/backend/src/modules/seo-projection/seo-projection-admin.controller.ts
+++ b/backend/src/modules/seo-projection/seo-projection-admin.controller.ts
@@ -6,10 +6,36 @@
  * qui ne gouverne que la planification automatique). Admin-only (AuthenticatedGuard + IsAdminGuard).
  * Aucune lecture publique : le read-path reste dark (RPC PR-7).
  */
-import { Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { z } from 'zod';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
 import { IsAdminGuard } from '@auth/is-admin.guard';
 import { SeoProjectionFeederService } from './seo-projection-feeder.service';
+
+/**
+ * DTO single-entity ROLE-SCOPED (P2-B). **Aucune collection** : le feeder résout EXACTEMENT 1
+ * fichier, cardinalité = 1 (le batch `entities[]` n'apparaîtra qu'en P4 sur une route distincte).
+ * `diagnostic` exclu ici (défense en profondeur ; le feeder le refuse aussi via FeatureFlags).
+ */
+const TriggerEntitySchema = z.object({
+  entityType: z.enum(['gamme', 'constructeur', 'vehicle']),
+  entityId: z
+    .string()
+    .min(1)
+    .max(80)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'slug ^[a-z0-9][a-z0-9-]*$ requis'),
+  projectionRole: z
+    .string()
+    .min(1)
+    .max(40)
+    .regex(/^[A-Z][A-Z0-9_]*$/, 'rôle ^[A-Z][A-Z0-9_]*$ requis'),
+});
 
 @Controller('api/admin/seo-projection')
 @UseGuards(AuthenticatedGuard, IsAdminGuard)
@@ -26,5 +52,25 @@ export class SeoProjectionAdminController {
       message:
         'Feed R1 enqueue (one-off) — voir logs SeoProjectionFeedProcessor pour le résultat.',
     };
+  }
+
+  /**
+   * Enqueue un write-job **single-entity role-scoped** (P2-B) : projette EXCLUSIVEMENT le rôle demandé
+   * d'une entité (une canary R3 n'active jamais R4/R6 de la même gamme). Read-path reste dark (RPC PR-7).
+   */
+  @Post('feed/trigger-entity')
+  async triggerEntity(@Body() body: unknown): Promise<{
+    ok: true;
+    jobId: string;
+    exportPath: string;
+    entityId: string;
+    role: string;
+  }> {
+    const parsed = TriggerEntitySchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.issues);
+    }
+    const res = await this.feeder.triggerEntity(parsed.data);
+    return { ok: true, ...res };
   }
 }

--- a/backend/src/modules/seo-projection/seo-projection-feeder.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-feeder.service.ts
@@ -17,7 +17,12 @@
  *     ne pas encore exister ; le wiki les produit en amont).
  *   - `triggerNow()` = enqueue one-off (endpoint admin) pour prouver la boucle sans attendre le cron.
  */
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  OnModuleInit,
+} from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { ConfigService } from '@nestjs/config';
 import { Queue } from 'bull';
@@ -25,6 +30,7 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { getErrorMessage } from '@common/utils/error.utils';
 import { getAppConfig } from '../../config/app.config';
+import { FeatureFlagsService } from '../../config/feature-flags.service';
 import {
   PROJECTION_FEED_JOB,
   PROJECTION_FEED_QUEUE,
@@ -34,6 +40,9 @@ import {
   type ProjectionFeedResult,
   type ProjectionWriteJobData,
 } from './seo-projection.types';
+
+/** Slug d'entité valide (rejette `/`, `..`, majuscules — sanitize AVANT construction du chemin). */
+const ENTITY_ID_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,80}$/;
 
 /** jobId stable du repeatable → pas de doublon au redeploy (BullMQ stocke les anciens cron sinon). */
 const R1_FEED_REPEATABLE_JOB_ID = 'seo-projection-r1-nightly-feed';
@@ -47,6 +56,7 @@ export class SeoProjectionFeederService implements OnModuleInit {
     @InjectQueue(PROJECTION_WRITE_QUEUE)
     private readonly writeQueue: Queue,
     private readonly configService: ConfigService,
+    private readonly featureFlags: FeatureFlagsService,
   ) {}
 
   /** Init NON-bloquant (fire-and-forget). Bloquer ici stallerait `app.listen()` (cf. backend.md). */
@@ -78,6 +88,130 @@ export class SeoProjectionFeederService implements OnModuleInit {
       `Feeder R1 déclenché manuellement (jobId=${String(job.id)}).`,
     );
     return String(job.id);
+  }
+
+  /**
+   * Enqueue un write-job **SINGLE-ENTITY ROLE-SCOPED** (P2-B, ADR-090 §C2). Résout EXACTEMENT 1
+   * fichier depuis `(entityType, entityId)`, le contient sous `exportsRoot` (realpath anti-symlink),
+   * assert que l'export porte l'`entity_id` namespacé demandé ET déclare le rôle, puis enfile UN SEUL
+   * `exportPath` avec `projectionRole`. **JAMAIS** de slurp de répertoire (≠ `discoverAndEnqueue` qui
+   * enfile tous les `*.json` → défait la cardinalité 1). Fail-closed : toute violation → `BadRequest`.
+   */
+  async triggerEntity(input: {
+    entityType: string;
+    entityId: string;
+    projectionRole: string;
+  }): Promise<{
+    jobId: string;
+    exportPath: string;
+    entityId: string;
+    role: string;
+  }> {
+    const { entityType, entityId, projectionRole } = input;
+
+    // 1. Type autorisé (diagnostic EXCLU tant que S2_DIAG ouvert — allowlist gouvernée FeatureFlags).
+    const writableTypes = this.featureFlags.seoProjectionWritableTypes;
+    if (!writableTypes.includes(entityType)) {
+      throw new BadRequestException(
+        `entityType '${entityType}' non projetable (autorisés: ${writableTypes.join(', ')})`,
+      );
+    }
+    // 2. Rôle autorisé POUR CE TYPE (un type n'autorise jamais implicitement tous ses rôles).
+    const allowedRoles =
+      this.featureFlags.seoProjectionWritableRoles(entityType);
+    if (!allowedRoles.includes(projectionRole)) {
+      throw new BadRequestException(
+        `projectionRole '${projectionRole}' non autorisé pour '${entityType}' ` +
+          `(autorisés: ${allowedRoles.join(', ') || 'aucun'})`,
+      );
+    }
+    // 3. Sanitize entityId AVANT construction du chemin (rejette '/', '..', hors-slug).
+    if (!ENTITY_ID_SLUG_RE.test(entityId)) {
+      throw new BadRequestException(
+        `entityId '${entityId}' invalide (slug \`${ENTITY_ID_SLUG_RE.source}\` requis ; '/' et '..' interdits)`,
+      );
+    }
+
+    // 4. Résout EXACTEMENT 1 chemin puis realpath-contain sous exportsRoot (attrape les symlinks).
+    const exportsRoot = this.getExportsRoot();
+    const candidate = path.join(exportsRoot, entityType, `${entityId}.json`);
+    let real: string;
+    let rootReal: string;
+    try {
+      rootReal = await fs.realpath(exportsRoot);
+      real = await fs.realpath(candidate);
+    } catch (err) {
+      throw new BadRequestException(
+        `export introuvable pour ${entityType}/${entityId} (${getErrorMessage(err)})`,
+      );
+    }
+    if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
+      throw new BadRequestException(
+        `export résolu hors exportsRoot (symlink ?) : ${real}`,
+      );
+    }
+
+    // 5. Parse + assert entity_id namespacé demandé + rôle présent dans roles_allowed de l'export.
+    let exp: { entity_id?: string; roles_allowed?: string[] };
+    try {
+      exp = JSON.parse(await fs.readFile(real, 'utf-8')) as {
+        entity_id?: string;
+        roles_allowed?: string[];
+      };
+    } catch (err) {
+      throw new BadRequestException(
+        `export illisible ${real} (${getErrorMessage(err)})`,
+      );
+    }
+    const namespaced = `${entityType}:${entityId}`;
+    if (exp.entity_id !== namespaced) {
+      throw new BadRequestException(
+        `export.entity_id='${String(exp.entity_id)}' ≠ '${namespaced}' attendu (fichier mal placé ?)`,
+      );
+    }
+    if (!(exp.roles_allowed ?? []).includes(projectionRole)) {
+      throw new BadRequestException(
+        `projectionRole '${projectionRole}' absent de roles_allowed de l'export`,
+      );
+    }
+
+    // 6. Enfile UN SEUL exportPath (assert cardinalité=1 AVANT enqueue ; le DTO n'a AUCUNE collection).
+    const exportPaths = [real];
+    if (exportPaths.length !== 1) {
+      throw new BadRequestException('cardinalité feeder single-entity violée');
+    }
+    const job = await this.writeQueue.add(
+      PROJECTION_WRITE_JOB,
+      {
+        triggeredBy: 'manual',
+        exportPaths,
+        projectionRole,
+      } satisfies ProjectionWriteJobData,
+      { removeOnComplete: 14, removeOnFail: 30, attempts: 1 },
+    );
+    this.logger.log(
+      `Feeder single-entity : ${entityType}/${entityId} role=${projectionRole} → 1 write-job (jobId=${String(job.id)}).`,
+    );
+    return {
+      jobId: String(job.id),
+      exportPath: real,
+      entityId: namespaced,
+      role: projectionRole,
+    };
+  }
+
+  /**
+   * Racine `exports/seo` (base du chemin single-entity `<root>/<entityType>/<slug>.json`). Distincte
+   * de `getExportsDir()` qui pointe le sous-dossier `gamme/` du slurp cron R1.
+   */
+  private getExportsRoot(): string {
+    const configured = this.configService.get<string>(
+      'SEO_PROJECTION_EXPORTS_ROOT',
+      'content/automecanik-wiki/exports/seo',
+    );
+    return path.isAbsolute(configured)
+      ? configured
+      : path.resolve(process.cwd(), configured);
   }
 
   /**
@@ -133,7 +267,8 @@ export class SeoProjectionFeederService implements OnModuleInit {
       {
         triggeredBy: 'cron',
         exportPaths,
-        runMeta: { pipeline_version: `r1-feeder/${triggeredBy}` },
+        // Les 5 versions canoniques sont résolues par le writer (semver garanti). Le feeder ne pose
+        // PLUS de `pipeline_version` non-semver (bug historique : tout run échouait le replay).
       } satisfies ProjectionWriteJobData,
       {
         removeOnComplete: 14,

--- a/backend/src/modules/seo-projection/seo-projection-feeder.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-feeder.test.ts
@@ -1,18 +1,29 @@
 /**
- * Tests SeoProjectionFeederService.discoverAndEnqueue + triggerNow (ADR-059 PR-6c).
- * fs + app.config mockés ; queues = stubs jest. Aucune dépendance BullMQ/DB réelle.
+ * Tests SeoProjectionFeederService : discoverAndEnqueue + triggerNow (slurp cron R1) ET triggerEntity
+ * (single-entity role-scoped P2-B). fs + app.config mockés ; queues + FeatureFlags = stubs jest.
  */
 import type { ConfigService } from '@nestjs/config';
 import type { Queue } from 'bull';
 import { promises as fs } from 'node:fs';
 import { SeoProjectionFeederService } from './seo-projection-feeder.service';
 import { getAppConfig } from '../../config/app.config';
+import type { FeatureFlagsService } from '../../config/feature-flags.service';
 
-jest.mock('node:fs', () => ({ promises: { readdir: jest.fn() } }));
+jest.mock('node:fs', () => ({
+  promises: {
+    readdir: jest.fn(),
+    realpath: jest.fn(),
+    readFile: jest.fn(),
+  },
+}));
 jest.mock('../../config/app.config', () => ({ getAppConfig: jest.fn() }));
 
 const mockReaddir = fs.readdir as jest.Mock;
+const mockRealpath = fs.realpath as unknown as jest.Mock;
+const mockReadFile = fs.readFile as jest.Mock;
 const mockGetAppConfig = getAppConfig as jest.Mock;
+
+const EXPORTS_ROOT = '/abs/seo';
 
 function makeService(opts: { exportsDir?: string } = {}) {
   const feedQueue = {
@@ -25,18 +36,31 @@ function makeService(opts: { exportsDir?: string } = {}) {
     get: jest.fn((key: string, def?: string) => {
       if (key === 'SEO_PROJECTION_R1_EXPORTS_DIR')
         return opts.exportsDir ?? '/abs/exports';
+      if (key === 'SEO_PROJECTION_EXPORTS_ROOT') return EXPORTS_ROOT;
       return def;
     }),
+  };
+  const featureFlags = {
+    seoProjectionWritableTypes: ['gamme', 'constructeur', 'vehicle'],
+    seoProjectionWritableRoles: (type: string) =>
+      type === 'gamme'
+        ? ['R3_CONSEILS', 'R4_REFERENCE', 'R6_GUIDE_ACHAT']
+        : type === 'constructeur'
+          ? ['R7_BRAND']
+          : type === 'vehicle'
+            ? ['R8_VEHICLE']
+            : [],
   };
   const svc = new SeoProjectionFeederService(
     feedQueue as unknown as Queue,
     writeQueue as unknown as Queue,
     config as unknown as ConfigService,
+    featureFlags as unknown as FeatureFlagsService,
   );
   return { svc, feedQueue, writeQueue };
 }
 
-describe('SeoProjectionFeederService', () => {
+describe('SeoProjectionFeederService — slurp cron (discoverAndEnqueue / triggerNow)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAppConfig.mockReturnValue({ supabase: { readOnly: false } });
@@ -56,26 +80,15 @@ describe('SeoProjectionFeederService', () => {
     const { svc, writeQueue } = makeService();
     const r = await svc.discoverAndEnqueue('scheduler');
     expect(r.reason).toBe('NO_EXPORTS_DIR');
-    expect(r.enqueued).toBe(false);
     expect(writeQueue.add).not.toHaveBeenCalled();
   });
 
-  it('dossier sans .json → EMPTY, no-op', async () => {
-    mockReaddir.mockResolvedValue(['readme.txt', 'note.md']);
-    const { svc, writeQueue } = makeService();
-    const r = await svc.discoverAndEnqueue('scheduler');
-    expect(r.reason).toBe('EMPTY');
-    expect(r.discovered).toBe(0);
-    expect(writeQueue.add).not.toHaveBeenCalled();
-  });
-
-  it('exports présents → 1 write-job (triggeredBy=cron) avec les .json triés', async () => {
+  it('exports présents → 1 write-job (cron) triés, SANS pipeline_version non-semver', async () => {
     mockReaddir.mockResolvedValue(['b.json', 'a.json', 'note.md']);
     const { svc, writeQueue } = makeService({ exportsDir: '/abs/exports' });
     const r = await svc.discoverAndEnqueue('manual');
     expect(r.enqueued).toBe(true);
     expect(r.discovered).toBe(2);
-    expect(writeQueue.add).toHaveBeenCalledTimes(1);
     const [jobName, data] = writeQueue.add.mock.calls[0];
     expect(jobName).toBe('seo-projection-write');
     expect(data.triggeredBy).toBe('cron');
@@ -83,16 +96,109 @@ describe('SeoProjectionFeederService', () => {
       '/abs/exports/a.json',
       '/abs/exports/b.json',
     ]);
+    // Le feeder ne pose PLUS de runMeta.pipeline_version (le writer résout les versions semver).
+    expect(data.runMeta?.pipeline_version).toBeUndefined();
+    expect(data.projectionRole).toBeUndefined();
   });
 
   it('triggerNow → enqueue one-off sur la feed queue', async () => {
     const { svc, feedQueue } = makeService();
     const id = await svc.triggerNow();
     expect(id).toBe('feed-1');
-    expect(feedQueue.add).toHaveBeenCalledWith(
-      'seo-projection-r1-feed',
-      { triggeredBy: 'manual' },
-      expect.any(Object),
+    expect(feedQueue.add).toHaveBeenCalled();
+  });
+});
+
+describe('SeoProjectionFeederService.triggerEntity — single-entity role-scoped', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ supabase: { readOnly: false } });
+    // realpath identité par défaut (le candidat reste sous exportsRoot).
+    mockRealpath.mockImplementation(async (p: string) => p);
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        entity_id: 'gamme:filtre-a-huile',
+        roles_allowed: ['R3_CONSEILS', 'R4_REFERENCE', 'R6_GUIDE_ACHAT'],
+      }),
     );
+  });
+
+  const input = {
+    entityType: 'gamme',
+    entityId: 'filtre-a-huile',
+    projectionRole: 'R3_CONSEILS',
+  };
+
+  it('happy path → 1 write-job single-element role-scoped', async () => {
+    const { svc, writeQueue } = makeService();
+    const res = await svc.triggerEntity(input);
+    expect(writeQueue.add).toHaveBeenCalledTimes(1);
+    const [jobName, data] = writeQueue.add.mock.calls[0];
+    expect(jobName).toBe('seo-projection-write');
+    expect(data.triggeredBy).toBe('manual');
+    expect(data.exportPaths).toHaveLength(1);
+    expect(data.exportPaths[0]).toBe(
+      `${EXPORTS_ROOT}/gamme/filtre-a-huile.json`,
+    );
+    expect(data.projectionRole).toBe('R3_CONSEILS');
+    expect(res.entityId).toBe('gamme:filtre-a-huile');
+  });
+
+  it('type non projetable (diagnostic) → rejeté, aucun enqueue', async () => {
+    const { svc, writeQueue } = makeService();
+    await expect(
+      svc.triggerEntity({ ...input, entityType: 'diagnostic' }),
+    ).rejects.toThrow(/non projetable/);
+    expect(writeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('rôle non autorisé pour le type (gamme + R8_VEHICLE) → rejeté', async () => {
+    const { svc, writeQueue } = makeService();
+    await expect(
+      svc.triggerEntity({ ...input, projectionRole: 'R8_VEHICLE' }),
+    ).rejects.toThrow(/non autorisé/);
+    expect(writeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('entityId avec traversal (../) → rejeté AVANT tout accès disque', async () => {
+    const { svc, writeQueue } = makeService();
+    await expect(
+      svc.triggerEntity({ ...input, entityId: '../secret' }),
+    ).rejects.toThrow(/invalide/);
+    expect(mockRealpath).not.toHaveBeenCalled();
+    expect(writeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('realpath hors exportsRoot (symlink escape) → rejeté', async () => {
+    mockRealpath.mockImplementation(async (p: string) =>
+      p === `${EXPORTS_ROOT}/gamme/filtre-a-huile.json` ? '/etc/passwd' : p,
+    );
+    const { svc, writeQueue } = makeService();
+    await expect(svc.triggerEntity(input)).rejects.toThrow(/hors exportsRoot/);
+    expect(writeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('export.entity_id ≠ namespaced attendu → rejeté (fichier mal placé)', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        entity_id: 'gamme:autre-chose',
+        roles_allowed: ['R3_CONSEILS'],
+      }),
+    );
+    const { svc, writeQueue } = makeService();
+    await expect(svc.triggerEntity(input)).rejects.toThrow(/attendu/);
+    expect(writeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('rôle absent de roles_allowed de l’export → rejeté', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        entity_id: 'gamme:filtre-a-huile',
+        roles_allowed: ['R4_REFERENCE'],
+      }),
+    );
+    const { svc, writeQueue } = makeService();
+    await expect(svc.triggerEntity(input)).rejects.toThrow(/roles_allowed/);
+    expect(writeQueue.add).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/seo-projection/seo-projection-snapshot.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-snapshot.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests du builder de snapshot reproductible (P2-R3-B). Prouve les invariants dont dépend le replay :
+ * reproductibilité bit-à-bit (ordre-indépendant), sensibilité au contenu, validité tar (roundtrip zstd),
+ * publication atomique archive→manifest, et cohérence du manifest sidecar.
+ */
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { zstdDecompressSync } from 'node:zlib';
+import {
+  buildDeterministicTar,
+  buildTarZst,
+  sha256Hex,
+  digestEntries,
+  buildAndPublishSnapshot,
+  type SnapshotEntry,
+} from './seo-projection-snapshot';
+
+const e = (name: string, body: string): SnapshotEntry => ({
+  name,
+  data: Buffer.from(body, 'utf-8'),
+});
+
+const VERSIONS = {
+  projection_contract_version: '1.0.0',
+  builder_version: '1.0.0',
+  pipeline_version: '1.0.0',
+  extractor_version: '1.0.0',
+  runner_version: '1.0.0',
+};
+
+describe('seo-projection-snapshot builder', () => {
+  it('reproductible : deux ensembles identiques (ordre différent) → même sha256', () => {
+    const a = [e('b.json', '{"x":2}'), e('a.json', '{"x":1}')];
+    const b = [e('a.json', '{"x":1}'), e('b.json', '{"x":2}')];
+    expect(sha256Hex(buildTarZst(a))).toBe(sha256Hex(buildTarZst(b)));
+  });
+
+  it('sensible au contenu : un octet différent → hash différent', () => {
+    const a = [e('a.json', '{"x":1}')];
+    const b = [e('a.json', '{"x":2}')];
+    expect(sha256Hex(buildTarZst(a))).not.toBe(sha256Hex(buildTarZst(b)));
+  });
+
+  it('déterministe : deux compressions du même input → mêmes octets', () => {
+    const a = [e('a.json', '{"x":1}'), e('b.json', '{"y":2}')];
+    expect(Buffer.compare(buildTarZst(a), buildTarZst(a))).toBe(0);
+  });
+
+  it('tar USTAR valide : roundtrip zstd == tar, headers normalisés (2 blocs nuls de fin)', () => {
+    const entries = [e('a.json', 'hello'), e('b.json', 'world!!')];
+    const tar = buildDeterministicTar(entries);
+    const rt = zstdDecompressSync(buildTarZst(entries));
+    expect(Buffer.compare(rt, tar)).toBe(0);
+    // Taille multiple de 512 (blocs padés) + au moins 2 blocs nuls de fin.
+    expect(tar.length % 512).toBe(0);
+    const tail = tar.subarray(tar.length - 1024);
+    expect(tail.every((byte) => byte === 0)).toBe(true);
+    // uid/gid = 0 (offset 108/116), mtime = 0 (offset 136) → reproductibilité.
+    expect(tar.toString('ascii', 108, 115)).toBe('0000000');
+    expect(tar.toString('ascii', 136, 147)).toBe('00000000000');
+  });
+
+  it('digestEntries : inventaire trié {name, sha256(64hex), size}', () => {
+    const digests = digestEntries([e('b.json', 'BB'), e('a.json', 'A')]);
+    expect(digests.map((d) => d.name)).toEqual(['a.json', 'b.json']);
+    expect(digests[0]).toMatchObject({ name: 'a.json', size: 1 });
+    expect(digests[0].sha256).toHaveLength(64);
+    expect(digests[1]).toMatchObject({ name: 'b.json', size: 2 });
+  });
+
+  describe('buildAndPublishSnapshot (I/O durable)', () => {
+    let root: string;
+    beforeEach(async () => {
+      root = await fs.mkdtemp(path.join(os.tmpdir(), 'snap-test-'));
+    });
+    afterEach(async () => {
+      await fs.rm(root, { recursive: true, force: true });
+    });
+
+    it('publie archive + manifest ; hash = sha256 des octets PERSISTÉS ; manifest = commit marker', async () => {
+      const entries = [e('a.json', '{"entity_id":"gamme:a"}')];
+      const pub = await buildAndPublishSnapshot({
+        objectStoreRoot: root,
+        entries,
+        runId: 'run-xyz',
+        wikiCommitSha: 'abc1234',
+        versions: VERSIONS,
+      });
+
+      // hash format sha256:<hex> et fichiers écrits sous exports-snapshots/.
+      expect(pub.hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      const hex = pub.hash.split(':')[1];
+      expect(pub.uri).toBe(
+        path.join(root, 'exports-snapshots', `${hex}.tar.zst`),
+      );
+
+      // hash == sha256 des octets réellement persistés (pas d'une repr. mémoire divergente).
+      const persisted = await fs.readFile(pub.uri);
+      expect(`sha256:${sha256Hex(persisted)}`).toBe(pub.hash);
+
+      // Manifest sidecar présent + cohérent.
+      const manifest = JSON.parse(await fs.readFile(pub.manifestUri, 'utf-8'));
+      expect(manifest.snapshot_hash).toBe(pub.hash);
+      expect(manifest.versions).toEqual(VERSIONS);
+      expect(manifest.wiki_commit_sha).toBe('abc1234');
+      expect(manifest.entry_count).toBe(1);
+      expect(manifest.entries[0]).toMatchObject({ name: 'a.json' });
+      expect(manifest.entries[0].sha256).toHaveLength(64);
+      // Pas de fichiers temporaires résiduels (rename atomique).
+      const files = await fs.readdir(path.join(root, 'exports-snapshots'));
+      expect(files.some((f) => f.includes('.tmp-'))).toBe(false);
+    });
+
+    it('deux publications du même input → même hash + même chemin (idempotence de contenu)', async () => {
+      const entries = [e('a.json', '{"k":1}'), e('b.json', '{"k":2}')];
+      const p1 = await buildAndPublishSnapshot({
+        objectStoreRoot: root,
+        entries,
+        runId: 'run-1',
+        wikiCommitSha: null,
+        versions: VERSIONS,
+      });
+      const p2 = await buildAndPublishSnapshot({
+        objectStoreRoot: root,
+        entries: [entries[1], entries[0]], // ordre inversé
+        runId: 'run-2',
+        wikiCommitSha: null,
+        versions: VERSIONS,
+      });
+      expect(p2.hash).toBe(p1.hash);
+      expect(p2.uri).toBe(p1.uri);
+    });
+  });
+});

--- a/backend/src/modules/seo-projection/seo-projection-snapshot.ts
+++ b/backend/src/modules/seo-projection/seo-projection-snapshot.ts
@@ -1,0 +1,237 @@
+/**
+ * Reproducible export-snapshot builder — SEO forward-writer (ADR-059 §Versioning, P2-R3-B).
+ *
+ * Produit + publie l'archive `tar.zst` DÉTERMINISTE qui est la **seule autorité de replay**
+ * (ADR-059 : « exports_snapshot_uri = seule autorité replay, PAS git »). Le hash stocké dans
+ * `__seo_projection_runs.exports_snapshot_hash` est calculé sur les **octets persistés** de cette
+ * archive, jamais sur une représentation en mémoire divergente.
+ *
+ * Reproductible bit-à-bit — deux ensembles d'exports identiques ⇒ même `sha256` :
+ *   - entrées triées par nom (indépendant de l'ordre de découverte) ;
+ *   - header USTAR normalisé : mtime=0, uid=gid=0, uname/gname vides, permissions fixes 0644 ;
+ *   - zstd à niveau figé (zstd n'embarque PAS de timestamp, contrairement à gzip).
+ * (invariant prouvé par `seo-projection-snapshot.test.ts`).
+ *
+ * Publication ATOMIQUE + durable : temp voisin → `fsync(fichier)` → `rename` → `fsync(dir parent)`.
+ * Le manifest sidecar `<hash>.manifest.json` est écrit **en dernier** (commit marker : sa présence
+ * prouve que l'archive est complète et durable). Aucune dépendance tar externe (le backend n'en
+ * embarque pas) : writer USTAR minimal, déterministe, relu par `tar`/`bsdtar` standard.
+ */
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { zstdCompressSync, constants as zlibConstants } from 'node:zlib';
+
+const BLOCK = 512;
+/** rw-r--r-- — 7 chiffres octaux (champ mode USTAR = 8 bytes avec le NUL final). */
+const FIXED_MODE = '0000644';
+/** Niveau zstd figé → sortie reproductible (déterministe pour une version de lib donnée). */
+const ZSTD_LEVEL = 19;
+
+/** Sous-répertoire object-store des snapshots (miroir de `replay_projection.py:SNAPSHOTS_SUBDIR`). */
+export const SNAPSHOTS_SUBDIR = 'exports-snapshots';
+/** Version du schéma de manifest sidecar (bumpée si la forme change). */
+export const SNAPSHOT_MANIFEST_SCHEMA = 'seo-projection-snapshot/1';
+
+export interface SnapshotEntry {
+  /** Nom d'entrée tar (relatif, stable ; typiquement le basename du fichier d'export). */
+  name: string;
+  /** Octets bruts du fichier d'export — JAMAIS réencodés (byte-exact). */
+  data: Buffer;
+}
+
+export interface SnapshotEntryDigest {
+  name: string;
+  sha256: string;
+  size: number;
+}
+
+export interface SnapshotManifest {
+  schema: typeof SNAPSHOT_MANIFEST_SCHEMA;
+  /** `sha256:<hex>` des octets tar.zst persistés (identité de l'archive). */
+  snapshot_hash: string;
+  tar_zst_size: number;
+  created_from_run_id: string | null;
+  wiki_commit_sha: string | null;
+  /** Les 5 versions canoniques du run (replay determinism). */
+  versions: Record<string, string | null>;
+  entry_count: number;
+  entries: SnapshotEntryDigest[];
+}
+
+export interface PublishedSnapshot {
+  /** `sha256:<hex>` — valeur stockée dans `exports_snapshot_hash`. */
+  hash: string;
+  /** Chemin absolu de l'archive persistée — valeur stockée dans `exports_snapshot_uri`. */
+  uri: string;
+  manifestUri: string;
+  entryCount: number;
+}
+
+function writeOctal(
+  buf: Buffer,
+  offset: number,
+  value: number,
+  len: number,
+): void {
+  // len-1 chiffres octaux zero-paddés + NUL final.
+  const str = value.toString(8).padStart(len - 1, '0') + '\0';
+  buf.write(str, offset, len, 'ascii');
+}
+
+function writeString(
+  buf: Buffer,
+  offset: number,
+  value: string,
+  len: number,
+): void {
+  buf.write(value.slice(0, len), offset, len, 'ascii');
+}
+
+/** Header USTAR déterministe (512 bytes) pour un fichier régulier. */
+function ustarHeader(name: string, size: number): Buffer {
+  const h = Buffer.alloc(BLOCK, 0);
+  writeString(h, 0, name, 100); // name
+  h.write(FIXED_MODE + '\0', 100, 8, 'ascii'); // mode
+  h.write('0000000\0', 108, 8, 'ascii'); // uid = 0
+  h.write('0000000\0', 116, 8, 'ascii'); // gid = 0
+  writeOctal(h, 124, size, 12); // size
+  h.write('00000000000\0', 136, 12, 'ascii'); // mtime = 0 (epoch)
+  h.write('        ', 148, 8, 'ascii'); // chksum : espaces pour le calcul
+  h.write('0', 156, 1, 'ascii'); // typeflag = fichier régulier
+  h.write('ustar\0', 257, 6, 'ascii'); // magic
+  h.write('00', 263, 2, 'ascii'); // version
+  // uname/gname/devmajor/devminor/prefix : laissés à 0.
+
+  let sum = 0;
+  for (let i = 0; i < BLOCK; i += 1) sum += h[i];
+  const chk = sum.toString(8).padStart(6, '0') + '\0 ';
+  h.write(chk, 148, 8, 'ascii');
+  return h;
+}
+
+function pad512(size: number): number {
+  const rem = size % BLOCK;
+  return rem === 0 ? 0 : BLOCK - rem;
+}
+
+const byName = (a: { name: string }, b: { name: string }): number =>
+  a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+
+/**
+ * Construit un tar USTAR déterministe (entrées triées, headers normalisés, 2 blocs nuls de fin).
+ * Sans compression. Exporté pour test (validité tar + reproductibilité).
+ */
+export function buildDeterministicTar(entries: SnapshotEntry[]): Buffer {
+  const sorted = [...entries].sort(byName);
+  const chunks: Buffer[] = [];
+  for (const e of sorted) {
+    chunks.push(ustarHeader(e.name, e.data.length));
+    chunks.push(e.data);
+    const p = pad512(e.data.length);
+    if (p) chunks.push(Buffer.alloc(p, 0));
+  }
+  chunks.push(Buffer.alloc(BLOCK * 2, 0)); // fin d'archive
+  return Buffer.concat(chunks);
+}
+
+/** tar.zst déterministe (zstd niveau figé). Exporté pour test. */
+export function buildTarZst(entries: SnapshotEntry[]): Buffer {
+  const tar = buildDeterministicTar(entries);
+  return zstdCompressSync(tar, {
+    params: { [zlibConstants.ZSTD_c_compressionLevel]: ZSTD_LEVEL },
+  });
+}
+
+export function sha256Hex(buf: Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+/** Inventaire trié {name, sha256, size} des entrées (pour le manifest + la validation replay). */
+export function digestEntries(entries: SnapshotEntry[]): SnapshotEntryDigest[] {
+  return entries
+    .map((e) => ({
+      name: e.name,
+      sha256: sha256Hex(e.data),
+      size: e.data.length,
+    }))
+    .sort(byName);
+}
+
+/**
+ * Écrit `bytes` en `finalPath` ATOMIQUEMENT + durablement : temp voisin unique → `fsync(fichier)`
+ * → `rename` → `fsync(dir parent)`. Le suffixe `uniq` (runId) évite toute collision inter-runs.
+ */
+export async function atomicWrite(
+  finalPath: string,
+  bytes: Buffer,
+  uniq: string,
+): Promise<void> {
+  const dir = path.dirname(finalPath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = `${finalPath}.tmp-${uniq}`;
+  const fh = await fs.open(tmp, 'w');
+  try {
+    await fh.write(bytes);
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+  await fs.rename(tmp, finalPath);
+  // fsync du répertoire parent → rend le rename durable (POSIX).
+  const dh = await fs.open(dir, 'r');
+  try {
+    await dh.sync();
+  } finally {
+    await dh.close();
+  }
+}
+
+/**
+ * Construit + publie le snapshot d'un run : archive `<hex>.tar.zst` PUIS manifest sidecar
+ * `<hex>.manifest.json` (en dernier = commit marker). Le `hash` retourné est calculé sur les octets
+ * réellement écrits. Fail-loud : toute erreur d'I/O remonte (l'appelant marque le run `failed`).
+ */
+export async function buildAndPublishSnapshot(params: {
+  objectStoreRoot: string;
+  entries: SnapshotEntry[];
+  runId: string;
+  wikiCommitSha: string | null;
+  versions: Record<string, string | null>;
+}): Promise<PublishedSnapshot> {
+  const { objectStoreRoot, entries, runId, wikiCommitSha, versions } = params;
+  const tarZst = buildTarZst(entries);
+  const hex = sha256Hex(tarZst);
+  const hashFull = `sha256:${hex}`;
+
+  const snapDir = path.join(objectStoreRoot, SNAPSHOTS_SUBDIR);
+  const archivePath = path.join(snapDir, `${hex}.tar.zst`);
+  const manifestPath = path.join(snapDir, `${hex}.manifest.json`);
+
+  // 1. Archive d'abord (durable).
+  await atomicWrite(archivePath, tarZst, runId);
+
+  // 2. Manifest EN DERNIER (commit marker : sa présence prouve l'archive complète).
+  const manifest: SnapshotManifest = {
+    schema: SNAPSHOT_MANIFEST_SCHEMA,
+    snapshot_hash: hashFull,
+    tar_zst_size: tarZst.length,
+    created_from_run_id: runId,
+    wiki_commit_sha: wikiCommitSha,
+    versions,
+    entry_count: entries.length,
+    entries: digestEntries(entries),
+  };
+  await atomicWrite(
+    manifestPath,
+    Buffer.from(JSON.stringify(manifest, null, 2) + '\n', 'utf-8'),
+    runId,
+  );
+
+  return {
+    hash: hashFull,
+    uri: archivePath,
+    manifestUri: manifestPath,
+    entryCount: entries.length,
+  };
+}

--- a/backend/src/modules/seo-projection/seo-projection-snapshot.ts
+++ b/backend/src/modules/seo-projection/seo-projection-snapshot.ts
@@ -90,6 +90,14 @@ function writeString(
 
 /** Header USTAR déterministe (512 bytes) pour un fichier régulier. */
 function ustarHeader(name: string, size: number): Buffer {
+  // Le champ `name` USTAR fait 100 octets : un nom plus long serait TRONQUÉ silencieusement →
+  // divergence entre l'entrée tar et l'inventaire du manifest (digestEntries garde le nom complet).
+  // Fail-loud plutôt que corruption silencieuse (no-silent-fallback). Les noms réels = slugs bornés.
+  if (Buffer.byteLength(name, 'utf-8') > 100) {
+    throw new Error(
+      `snapshot entry name exceeds 100 bytes (USTAR limit): ${name}`,
+    );
+  }
   const h = Buffer.alloc(BLOCK, 0);
   writeString(h, 0, name, 100); // name
   h.write(FIXED_MODE + '\0', 100, 8, 'ascii'); // mode
@@ -206,7 +214,12 @@ export async function buildAndPublishSnapshot(params: {
 
   const snapDir = path.join(objectStoreRoot, SNAPSHOTS_SUBDIR);
   const archivePath = path.join(snapDir, `${hex}.tar.zst`);
-  const manifestPath = path.join(snapDir, `${hex}.manifest.json`);
+  // Manifest keyé PAR RUN (`<hex>.<runId>.manifest.json`), pas seulement par hash : l'archive est
+  // content-addressed (dédup — 2 runs d'exports identiques partagent le `.tar.zst`), MAIS les 5
+  // versions sont per-run. Un manifest partagé serait écrasé par un run ultérieur d'exports identiques
+  // mais de versions bumpées → un run antérieur échouerait ensuite la validation replay (versions
+  // divergentes). Le manifest per-run garantit versions==run + reste le commit marker (écrit en dernier).
+  const manifestPath = path.join(snapDir, `${hex}.${runId}.manifest.json`);
 
   // 1. Archive d'abord (durable).
   await atomicWrite(archivePath, tarZst, runId);

--- a/backend/src/modules/seo-projection/seo-projection-write.processor.ts
+++ b/backend/src/modules/seo-projection/seo-projection-write.processor.ts
@@ -34,14 +34,21 @@ export class SeoProjectionWriteProcessor {
       exportPaths = [],
       triggeredBy = 'manual',
       runMeta = {},
+      projectionRole,
     } = job.data ?? ({} as ProjectionWriteJobData);
     const result = await this.writer.projectExports(
       exportPaths,
       triggeredBy,
       runMeta,
+      projectionRole,
     );
 
-    if (!result.readOnlySkipped && result.entitiesWritten > 0) {
+    // Refresh dès qu'une version active a été flippée : facts OU blocs de rôle. Un facts no-op qui
+    // écrit de nouveaux blocs de rôle DOIT aussi rafraîchir les MV (sinon la projection reste stale).
+    if (
+      !result.readOnlySkipped &&
+      (result.entitiesWritten > 0 || result.rolesWritten > 0)
+    ) {
       // Coalescing : jobId fixe → un seul refresh en attente à la fois (single-flight, debounce 5s).
       await this.refreshQueue.add(
         PROJECTION_REFRESH_JOB,
@@ -56,7 +63,9 @@ export class SeoProjectionWriteProcessor {
       result.refreshEnqueued = true;
     }
     this.logger.log(
-      `projection write run=${result.runId ?? 'none'} written=${result.entitiesWritten} refresh=${result.refreshEnqueued}` +
+      `projection write run=${result.runId ?? 'none'} facts=${result.entitiesWritten} ` +
+        `roles(w/n/b/r)=${result.rolesWritten}/${result.rolesNoop}/${result.rolesBlocked}/${result.rolesRegressed} ` +
+        `snapshot=${result.snapshot?.hash ?? 'none'} refresh=${result.refreshEnqueued}` +
         (result.readOnlySkipped ? ' [READ_ONLY skipped]' : ''),
     );
     return result;

--- a/backend/src/modules/seo-projection/seo-projection-writer-role-scope.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer-role-scope.test.ts
@@ -8,6 +8,9 @@
  * et résout les versions "active" depuis un état pilotable. On appelle directement `writeEntity`
  * (le cœur du découplage) sans I/O.
  */
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { SeoProjectionWriterService } from './seo-projection-writer.service';
 import type { SeoProjectionExport } from './seo-projection.types';
 
@@ -69,8 +72,9 @@ function makeSupabase(state: MockState) {
     single() {
       if (this.op === 'insert') {
         insertSeq += 1;
+        // run_id sert à openRun (`.select('run_id')`) ; version_id aux inserts de versions.
         return Promise.resolve({
-          data: { version_id: `v-${insertSeq}` },
+          data: { version_id: `v-${insertSeq}`, run_id: `run-${insertSeq}` },
           error: null,
         });
       }
@@ -125,7 +129,14 @@ interface TestWriter {
   projectExports: (
     paths: string[],
     t?: string,
-  ) => Promise<{ runId: string | null; snapshot: unknown }>;
+    m?: Record<string, unknown>,
+    role?: string,
+  ) => Promise<{
+    runId: string | null;
+    entitiesWritten: number;
+    rolesWritten: number;
+    snapshot: unknown;
+  }>;
 }
 
 function makeWriter(client: { from: (t: string) => unknown }): TestWriter {
@@ -356,5 +367,68 @@ describe('writeEntity — facts/role decouple + role-scoping (non-negotiable)', 
     const res = await makeWriter(client).projectExports([]);
     expect(res.runId).toBeNull();
     expect(res.snapshot).toBeNull();
+  });
+
+  // Atomicité ADR-059 « active content ⇒ durable replay snapshot » : le snapshot durable est publié
+  // AVANT tout flip de version active. Export LISIBLE (writeEntity écrirait) MAIS publication snapshot
+  // en échec (object-store KO / ENOSPC) → AUCUNE version écrite/flippée, run `failed`, hash null, conflit
+  // loggé. Régression corrigée : l'ancien ordre flippait l'actif PUIS tentait le snapshot → contenu actif
+  // sans snapshot de replay, et le refresh MV était quand même enqueue (guard entitiesWritten>0).
+  it('atomicité snapshot-first : export LISIBLE mais publication snapshot ÉCHOUE → 0 flip actif, run failed', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'p2r3b-atomic-'));
+    const exportPath = join(dir, 'filtre-a-huile.json');
+    writeFileSync(exportPath, JSON.stringify(exportFixture()), 'utf-8');
+    try {
+      const { client, ops } = makeSupabase({
+        factsActive: new Map(),
+        blocksActive: new Map(),
+      });
+      const writer = makeWriter(client);
+      // gate pass (sinon projectOne bloque AVANT writeEntity) + publication snapshot en échec dur.
+      (
+        writer as unknown as {
+          gate: { evaluate: () => { ok: boolean; verdicts: [] } };
+        }
+      ).gate = { evaluate: () => ({ ok: true, verdicts: [] }) };
+      (
+        writer as unknown as { buildSnapshotForRun: () => Promise<never> }
+      ).buildSnapshotForRun = () =>
+        Promise.reject(new Error('object-store write failed (ENOSPC)'));
+
+      const res = await writer.projectExports(
+        [exportPath],
+        'manual',
+        {},
+        'R3_CONSEILS',
+      );
+
+      // Snapshot-first : le flip des versions actives ne précède JAMAIS la publication durable.
+      expect(factVersionInserts(ops)).toHaveLength(0);
+      expect(blockVersionInserts(ops)).toHaveLength(0);
+      expect(
+        ops.filter(
+          (o) => o.table === '__seo_content_blocks' && o.op === 'upsert',
+        ),
+      ).toHaveLength(0);
+      // Run ouvert PUIS fermé failed, hash de snapshot null.
+      const runUpdates = ops.filter(
+        (o) => o.table === '__seo_projection_runs' && o.op === 'update',
+      );
+      expect(runUpdates).toHaveLength(1);
+      expect(runUpdates[0].payload.status).toBe('failed');
+      expect(runUpdates[0].payload.exports_snapshot_hash).toBeNull();
+      // Échec observable (conflit), pas de repli silencieux.
+      const conflicts = inserts(ops, '__seo_projection_conflicts');
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0].payload.conflict_kind).toBe(
+        'snapshot_publish_failed',
+      );
+      // Résultat : 0 écriture, pas de snapshot.
+      expect(res.entitiesWritten).toBe(0);
+      expect(res.rolesWritten).toBe(0);
+      expect(res.snapshot).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/backend/src/modules/seo-projection/seo-projection-writer-role-scope.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer-role-scope.test.ts
@@ -18,6 +18,8 @@ interface MockState {
     string,
     { content_hash: string; confidence_base: number | null }
   >;
+  /** Drafts existants keyés `${block_id}::${content_hash}` (test d'idempotence de régression). */
+  draftsByHash?: Set<string>;
 }
 interface RecordedOp {
   table: string;
@@ -58,8 +60,11 @@ function makeSupabase(state: MockState) {
       this.filters[`neq_${k}`] = v;
       return this;
     }
+    limit(_n: number) {
+      return this;
+    }
     maybeSingle() {
-      return Promise.resolve({ data: this.resolveActive(), error: null });
+      return Promise.resolve({ data: this.resolve(), error: null });
     }
     single() {
       if (this.op === 'insert') {
@@ -69,16 +74,28 @@ function makeSupabase(state: MockState) {
           error: null,
         });
       }
-      return Promise.resolve({ data: this.resolveActive(), error: null });
+      return Promise.resolve({ data: this.resolve(), error: null });
     }
     // Rend Q awaitable pour les chaînes update/insert-conflict sans terminal explicite.
     then(onF: (v: { data: null; error: null }) => unknown) {
       return Promise.resolve({ data: null, error: null }).then(onF);
     }
-    private resolveActive(): {
-      content_hash: string;
+    private resolve(): {
+      content_hash?: string;
       confidence_base?: number | null;
+      version_id?: string;
     } | null {
+      // Query de dédup draft (status='draft' + content_hash) : idempotence de régression.
+      if (
+        this.table === '__seo_content_block_versions' &&
+        this.filters.status === 'draft' &&
+        typeof this.filters.content_hash === 'string'
+      ) {
+        const key = `${String(this.filters.block_id)}::${String(this.filters.content_hash)}`;
+        return state.draftsByHash?.has(key)
+          ? { version_id: 'existing-draft' }
+          : null;
+      }
       if (this.filters.status !== 'active') return null;
       if (this.table === '__seo_entity_fact_versions') {
         return state.factsActive.get(this.filters.entity_id as string) ?? null;
@@ -96,16 +113,28 @@ type WriteEntityFn = (
   e: SeoProjectionExport,
   r: string | null,
   role?: string,
-) => Promise<{ factsOutcome: string; roleOutcome: string }>;
+) => Promise<{
+  factsOutcome: string;
+  roleOutcome: string;
+  blocksWritten?: number;
+  conflicts?: number;
+}>;
 
-function makeWriter(client: { from: (t: string) => unknown }): {
+interface TestWriter {
   writeEntity: WriteEntityFn;
-} {
+  projectExports: (
+    paths: string[],
+    t?: string,
+  ) => Promise<{ runId: string | null; snapshot: unknown }>;
+}
+
+function makeWriter(client: { from: (t: string) => unknown }): TestWriter {
   // Bypass du constructeur SupabaseBaseService (I/O lourde) : on greffe supabase + log sur le proto.
   const writer = Object.create(SeoProjectionWriterService.prototype);
   writer.supabase = client;
   writer.log = { warn() {}, error() {}, log() {} };
-  return writer as { writeEntity: WriteEntityFn };
+  writer.readOnly = false;
+  return writer as TestWriter;
 }
 
 const exportFixture = (): SeoProjectionExport => ({
@@ -256,5 +285,76 @@ describe('writeEntity — facts/role decouple + role-scoping (non-negotiable)', 
     expect(out.roleOutcome).toBe('noop');
     expect(factVersionInserts(ops)).toHaveLength(0);
     expect(blockVersionInserts(ops)).toHaveLength(0);
+  });
+
+  // Bloc régressant : contenu différent MAIS confiance strictement inférieure à l'active.
+  const regressExport = (): SeoProjectionExport => ({
+    ...exportFixture(),
+    roles_allowed: ['R3_CONSEILS'],
+    blocks: [
+      {
+        role: 'R3_CONSEILS',
+        content_md: 'r3 moins fiable',
+        source_ids: [],
+        truth_level: 'sourced',
+        section: 'Diagnostic',
+        content_hash: 'NEW_H',
+        confidence_base: 0.5,
+      },
+    ],
+  });
+  const conflictInserts = (ops: RecordedOp[]) =>
+    inserts(ops, '__seo_projection_conflicts');
+
+  it('régression : 1er run insère 1 draft + 1 conflit (active plus fiable préservée)', async () => {
+    const state: MockState = {
+      factsActive: new Map([
+        ['gamme:filtre-a-huile', { content_hash: 'FACTS_H1' }],
+      ]),
+      blocksActive: new Map([
+        [R3_BLOCK_ID, { content_hash: 'ACTIVE_H', confidence_base: 0.9 }],
+      ]),
+      draftsByHash: new Set(),
+    };
+    const { client, ops } = makeSupabase(state);
+    const out = await makeWriter(client).writeEntity(
+      regressExport(),
+      'run-1',
+      'R3_CONSEILS',
+    );
+    expect(out.roleOutcome).toBe('regressed_draft');
+    expect(blockVersionInserts(ops)).toHaveLength(1);
+    expect(conflictInserts(ops)).toHaveLength(1);
+  });
+
+  it('régression IDEMPOTENTE : re-projeter un export régressant inchangé (draft déjà présent) → no-op, 0 draft dupliqué, 0 conflit', async () => {
+    const state: MockState = {
+      factsActive: new Map([
+        ['gamme:filtre-a-huile', { content_hash: 'FACTS_H1' }],
+      ]),
+      blocksActive: new Map([
+        [R3_BLOCK_ID, { content_hash: 'ACTIVE_H', confidence_base: 0.9 }],
+      ]),
+      draftsByHash: new Set([`${R3_BLOCK_ID}::NEW_H`]),
+    };
+    const { client, ops } = makeSupabase(state);
+    const out = await makeWriter(client).writeEntity(
+      regressExport(),
+      'run-2',
+      'R3_CONSEILS',
+    );
+    expect(out.roleOutcome).toBe('noop');
+    expect(blockVersionInserts(ops)).toHaveLength(0); // pas de draft dupliqué
+    expect(conflictInserts(ops)).toHaveLength(0); // pas de conflit dupliqué
+  });
+
+  it('projectExports([]) → no-op observable, aucun run ouvert (job malformé/stale)', async () => {
+    const { client } = makeSupabase({
+      factsActive: new Map(),
+      blocksActive: new Map(),
+    });
+    const res = await makeWriter(client).projectExports([]);
+    expect(res.runId).toBeNull();
+    expect(res.snapshot).toBeNull();
   });
 });

--- a/backend/src/modules/seo-projection/seo-projection-writer-role-scope.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer-role-scope.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Régression writer NON-NÉGOCIABLE (P2-R3-B) : le résultat des FACTS partagés est découplé du
+ * résultat du RÔLE demandé. Un facts no-op ne DOIT JAMAIS court-circuiter l'écriture des blocs du
+ * rôle ; une canary mono-rôle n'écrit QUE ses blocs (les autres rôles restent intacts).
+ *
+ * Méthode : on instancie le service via `Object.create(prototype)` (bypass du constructeur
+ * SupabaseBaseService lourd) + un client Supabase chaînable mocké qui enregistre chaque opération
+ * et résout les versions "active" depuis un état pilotable. On appelle directement `writeEntity`
+ * (le cœur du découplage) sans I/O.
+ */
+import { SeoProjectionWriterService } from './seo-projection-writer.service';
+import type { SeoProjectionExport } from './seo-projection.types';
+
+// ── Client Supabase chaînable mocké ───────────────────────────────────────────
+interface MockState {
+  factsActive: Map<string, { content_hash: string }>;
+  blocksActive: Map<
+    string,
+    { content_hash: string; confidence_base: number | null }
+  >;
+}
+interface RecordedOp {
+  table: string;
+  op: 'upsert' | 'insert' | 'update';
+  payload: Record<string, unknown>;
+}
+
+function makeSupabase(state: MockState) {
+  const ops: RecordedOp[] = [];
+  let insertSeq = 0;
+
+  class Q {
+    private op: 'select' | 'upsert' | 'insert' | 'update' = 'select';
+    private filters: Record<string, unknown> = {};
+    constructor(private readonly table: string) {}
+    upsert(payload: Record<string, unknown>) {
+      ops.push({ table: this.table, op: 'upsert', payload });
+      return Promise.resolve({ data: null, error: null });
+    }
+    insert(payload: Record<string, unknown>) {
+      this.op = 'insert';
+      ops.push({ table: this.table, op: 'insert', payload });
+      return this;
+    }
+    update(payload: Record<string, unknown>) {
+      this.op = 'update';
+      ops.push({ table: this.table, op: 'update', payload });
+      return this;
+    }
+    select() {
+      return this;
+    }
+    eq(k: string, v: unknown) {
+      this.filters[k] = v;
+      return this;
+    }
+    neq(k: string, v: unknown) {
+      this.filters[`neq_${k}`] = v;
+      return this;
+    }
+    maybeSingle() {
+      return Promise.resolve({ data: this.resolveActive(), error: null });
+    }
+    single() {
+      if (this.op === 'insert') {
+        insertSeq += 1;
+        return Promise.resolve({
+          data: { version_id: `v-${insertSeq}` },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: this.resolveActive(), error: null });
+    }
+    // Rend Q awaitable pour les chaînes update/insert-conflict sans terminal explicite.
+    then(onF: (v: { data: null; error: null }) => unknown) {
+      return Promise.resolve({ data: null, error: null }).then(onF);
+    }
+    private resolveActive(): {
+      content_hash: string;
+      confidence_base?: number | null;
+    } | null {
+      if (this.filters.status !== 'active') return null;
+      if (this.table === '__seo_entity_fact_versions') {
+        return state.factsActive.get(this.filters.entity_id as string) ?? null;
+      }
+      if (this.table === '__seo_content_block_versions') {
+        return state.blocksActive.get(this.filters.block_id as string) ?? null;
+      }
+      return null;
+    }
+  }
+  return { client: { from: (t: string) => new Q(t) }, ops };
+}
+
+type WriteEntityFn = (
+  e: SeoProjectionExport,
+  r: string | null,
+  role?: string,
+) => Promise<{ factsOutcome: string; roleOutcome: string }>;
+
+function makeWriter(client: { from: (t: string) => unknown }): {
+  writeEntity: WriteEntityFn;
+} {
+  // Bypass du constructeur SupabaseBaseService (I/O lourde) : on greffe supabase + log sur le proto.
+  const writer = Object.create(SeoProjectionWriterService.prototype);
+  writer.supabase = client;
+  writer.log = { warn() {}, error() {}, log() {} };
+  return writer as { writeEntity: WriteEntityFn };
+}
+
+const exportFixture = (): SeoProjectionExport => ({
+  entity_id: 'gamme:filtre-a-huile',
+  entity_type: 'gamme',
+  schema_version: '2.0.0',
+  projection_contract_version: '1.0.0',
+  source_wiki_commit: 'abc1234',
+  wiki_path: 'wiki/gamme/filtre-a-huile.md',
+  content_hash: 'FACTS_H1',
+  generated_at: '2026-07-15T00:00:00Z',
+  facts: [{ k: 'v' }],
+  sources: [],
+  roles_allowed: ['R3_CONSEILS', 'R4_REFERENCE'],
+  consumers_allowed: ['seo'],
+  blocks: [
+    {
+      role: 'R3_CONSEILS',
+      content_md: 'r3',
+      source_ids: [],
+      truth_level: 'sourced',
+      section: 'Diagnostic',
+      content_hash: 'R3_H1',
+    },
+    {
+      role: 'R4_REFERENCE',
+      content_md: 'r4',
+      source_ids: [],
+      truth_level: 'sourced',
+      section: 'Reference',
+      content_hash: 'R4_H1',
+    },
+  ],
+});
+
+const R3_BLOCK_ID = 'gamme:filtre-a-huile#R3_CONSEILS#diagnostic';
+
+const inserts = (ops: RecordedOp[], table: string) =>
+  ops.filter((o) => o.table === table && o.op === 'insert');
+const blockVersionInserts = (ops: RecordedOp[]) =>
+  inserts(ops, '__seo_content_block_versions');
+const factVersionInserts = (ops: RecordedOp[]) =>
+  inserts(ops, '__seo_entity_fact_versions');
+
+describe('writeEntity — facts/role decouple + role-scoping (non-negotiable)', () => {
+  it('trigger R3 (entité neuve) → facts written + SEULS blocs R3 écrits (jamais R4)', async () => {
+    const state: MockState = {
+      factsActive: new Map(),
+      blocksActive: new Map(),
+    };
+    const { client, ops } = makeSupabase(state);
+    const writer = makeWriter(client);
+
+    const out = await writer.writeEntity(
+      exportFixture(),
+      'run-1',
+      'R3_CONSEILS',
+    );
+
+    expect(out.factsOutcome).toBe('written');
+    expect(out.roleOutcome).toBe('written');
+    expect(factVersionInserts(ops)).toHaveLength(1);
+    const bvi = blockVersionInserts(ops);
+    expect(bvi).toHaveLength(1);
+    expect(bvi[0].payload.block_id).toContain('R3_CONSEILS');
+    expect(
+      bvi.some((o) => String(o.payload.block_id).includes('R4_REFERENCE')),
+    ).toBe(false);
+    // content_blocks upsert : uniquement le rôle R3.
+    const cbUpserts = ops.filter(
+      (o) => o.table === '__seo_content_blocks' && o.op === 'upsert',
+    );
+    expect(cbUpserts).toHaveLength(1);
+    expect(cbUpserts[0].payload.role).toBe('R3_CONSEILS');
+  });
+
+  it('facts NO-OP ne saute PAS un nouveau rôle : re-trigger R4 sur export inchangé → facts noop + blocs R4 écrits, R3 intact', async () => {
+    // État après un trigger R3 : facts déjà actifs (même hash) + bloc R3 actif.
+    const state: MockState = {
+      factsActive: new Map([
+        ['gamme:filtre-a-huile', { content_hash: 'FACTS_H1' }],
+      ]),
+      blocksActive: new Map([
+        [R3_BLOCK_ID, { content_hash: 'R3_H1', confidence_base: null }],
+      ]),
+    };
+    const { client, ops } = makeSupabase(state);
+    const writer = makeWriter(client);
+
+    const out = await writer.writeEntity(
+      exportFixture(),
+      'run-2',
+      'R4_REFERENCE',
+    );
+
+    // Le facts est un no-op…
+    expect(out.factsOutcome).toBe('noop');
+    expect(factVersionInserts(ops)).toHaveLength(0);
+    // …MAIS les blocs R4 sont écrits (la régression : un facts noop les sautait).
+    expect(out.roleOutcome).toBe('written');
+    const bvi = blockVersionInserts(ops);
+    expect(bvi).toHaveLength(1);
+    expect(bvi[0].payload.block_id).toContain('R4_REFERENCE');
+    // R3 n'est JAMAIS retouché (ni version, ni upsert de ligne bloc).
+    expect(
+      bvi.some((o) => String(o.payload.block_id).includes('R3_CONSEILS')),
+    ).toBe(false);
+    const cbUpserts = ops.filter(
+      (o) => o.table === '__seo_content_blocks' && o.op === 'upsert',
+    );
+    expect(cbUpserts.every((o) => o.payload.role === 'R4_REFERENCE')).toBe(
+      true,
+    );
+  });
+
+  it('slurp (role absent) → facts written + TOUS les blocs (R3 + R4) écrits', async () => {
+    const state: MockState = {
+      factsActive: new Map(),
+      blocksActive: new Map(),
+    };
+    const { client, ops } = makeSupabase(state);
+    const writer = makeWriter(client);
+    await writer.writeEntity(exportFixture(), 'run-3');
+    expect(factVersionInserts(ops)).toHaveLength(1);
+    expect(blockVersionInserts(ops)).toHaveLength(2);
+  });
+
+  it('facts noop + bloc du rôle noop → factsOutcome=noop ET roleOutcome=noop (0 écriture de version)', async () => {
+    const state: MockState = {
+      factsActive: new Map([
+        ['gamme:filtre-a-huile', { content_hash: 'FACTS_H1' }],
+      ]),
+      blocksActive: new Map([
+        [
+          'gamme:filtre-a-huile#R4_REFERENCE#reference',
+          { content_hash: 'R4_H1', confidence_base: null },
+        ],
+      ]),
+    };
+    const { client, ops } = makeSupabase(state);
+    const writer = makeWriter(client);
+    const out = await writer.writeEntity(
+      exportFixture(),
+      'run-4',
+      'R4_REFERENCE',
+    );
+    expect(out.factsOutcome).toBe('noop');
+    expect(out.roleOutcome).toBe('noop');
+    expect(factVersionInserts(ops)).toHaveLength(0);
+    expect(blockVersionInserts(ops)).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -197,12 +197,73 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     // non-semver historique du feeder). Seed = 1er export lisible (best-effort, fail-open sur meta).
     const seed = await this.readExportMeta(exportPaths[0]);
     const versions = this.resolveRunVersions(seed, runMeta);
-    const runId = await this.openRun(
-      triggeredBy,
-      versions,
-      seed.wikiCommitSha ?? runMeta.wiki_commit_sha ?? null,
-    );
+    const wikiCommitSha = seed.wikiCommitSha ?? runMeta.wiki_commit_sha ?? null;
+    const runId = await this.openRun(triggeredBy, versions, wikiCommitSha);
 
+    // openRun a échoué (erreur DB) → aucun run attribuable → AUCUNE écriture. On ne flippe jamais
+    // de contenu actif sans run + snapshot de replay (fail-closed ; openRun a déjà loggé l'erreur).
+    if (!runId) {
+      return {
+        runId: null,
+        triggeredBy,
+        entitiesWritten: 0,
+        rolesWritten: 0,
+        rolesNoop: 0,
+        rolesBlocked: 0,
+        rolesRegressed: 0,
+        outcomes: [],
+        refreshEnqueued: false,
+        snapshot: null,
+      };
+    }
+
+    // Snapshot durable publié AVANT toute écriture (atomicité ADR-059 « active content ⇒ durable
+    // replay snapshot »). L'archive tar.zst est une fonction PURE des exports d'ENTRÉE (indépendante
+    // des écritures DB), donc publiable en amont ; son hash porte sur les octets PERSISTÉS = seule
+    // autorité de replay. Échec de publication → run `failed`, ZÉRO version flippée, et le processor
+    // ne déclenche AUCUN refresh MV (guard `entitiesWritten|rolesWritten>0`) → jamais de contenu actif
+    // orphelin de son snapshot. (Régression corrigée : l'ordre write-puis-snapshot flippait l'actif
+    // même quand le snapshot échouait ensuite.)
+    let snapshot: { hash: string; uri: string };
+    try {
+      snapshot = await this.buildSnapshotForRun(
+        exportPaths,
+        runId,
+        wikiCommitSha,
+        versions,
+      );
+    } catch (e) {
+      const snapshotError = getErrorMessage(e);
+      this.log.error(
+        `snapshot publish failed (run=${runId}): ${snapshotError}`,
+      );
+      await this.recordConflict(
+        '?',
+        null,
+        'snapshot_publish_failed',
+        { error: snapshotError },
+        runId,
+      );
+      await this.closeRun(runId, {
+        entitiesWritten: 0,
+        failed: true,
+        snapshot: null,
+      });
+      return {
+        runId,
+        triggeredBy,
+        entitiesWritten: 0,
+        rolesWritten: 0,
+        rolesNoop: 0,
+        rolesBlocked: 0,
+        rolesRegressed: 0,
+        outcomes: [],
+        refreshEnqueued: false,
+        snapshot: null,
+      };
+    }
+
+    // Snapshot durable garanti → on peut écrire (flip des versions actives) en sûreté.
     const outcomes: EntityWriteOutcome[] = [];
     for (const p of exportPaths) {
       outcomes.push(await this.projectOne(p, runId, projectionRole));
@@ -222,37 +283,10 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       (o) => o.roleOutcome === 'regressed_draft',
     ).length;
 
-    // Snapshot durable AVANT de marquer `succeeded` : l'archive tar.zst immutable + le hash calculé
-    // sur les octets PERSISTÉS sont la seule autorité de replay (ADR-059). Échec publication → failed.
-    let snapshot: { hash: string; uri: string } | null = null;
-    let snapshotError: string | null = null;
-    if (runId) {
-      try {
-        snapshot = await this.buildSnapshotForRun(
-          exportPaths,
-          runId,
-          seed.wikiCommitSha ?? runMeta.wiki_commit_sha ?? null,
-          versions,
-        );
-      } catch (e) {
-        snapshotError = getErrorMessage(e);
-        this.log.error(
-          `snapshot publish failed (run=${runId}): ${snapshotError}`,
-        );
-        await this.recordConflict(
-          '?',
-          null,
-          'snapshot_publish_failed',
-          { error: snapshotError },
-          runId,
-        );
-      }
-    }
-
     await this.closeRun(runId, {
       entitiesWritten,
-      // succeeded UNIQUEMENT si aucun rôle bloqué ET snapshot durable publié.
-      failed: rolesBlocked > 0 || snapshotError != null,
+      // Snapshot déjà garanti durable ; seul un rôle bloqué peut encore faire échouer le run.
+      failed: rolesBlocked > 0,
       snapshot,
     });
 

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -173,6 +173,26 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       };
     }
 
+    // Garde : 0 export (job malformé/stale) → aucun run ouvert, aucun snapshot vide publié (observable).
+    // Le feeder garantit ≥1 chemin (triggerEntity=1, slurp cron>0) ; ceci protège des jobs Redis corrompus.
+    if (exportPaths.length === 0) {
+      this.log.warn(
+        `projectExports: 0 exportPath (${triggeredBy}) — no-op, aucun run ouvert.`,
+      );
+      return {
+        runId: null,
+        triggeredBy,
+        entitiesWritten: 0,
+        rolesWritten: 0,
+        rolesNoop: 0,
+        rolesBlocked: 0,
+        rolesRegressed: 0,
+        outcomes: [],
+        refreshEnqueued: false,
+        snapshot: null,
+      };
+    }
+
     // Versions semver résolues depuis l'export + composants writer (jamais le `pipeline_version`
     // non-semver historique du feeder). Seed = 1er export lisible (best-effort, fail-open sur meta).
     const seed = await this.readExportMeta(exportPaths[0]);
@@ -488,6 +508,26 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         typeof active.confidence_base === 'number' &&
         row.confidenceBase != null &&
         row.confidenceBase < active.confidence_base;
+
+      if (wouldRegress) {
+        // Idempotence : la version active ne flippant jamais sur le draft, re-projeter un export
+        // INCHANGÉ mais régressant (replay / cron d'un contenu figé) rejouerait cette branche à
+        // chaque run. Dédup : si un draft de MÊME content_hash existe déjà pour ce bloc, c'est un
+        // no-op gouverné (0 nouvelle version, 0 conflit dupliqué) — sinon les tables versionnées et
+        // __seo_projection_conflicts croîtraient sans borne (rupture d'idempotence/replay).
+        const { data: existingDraft } = await this.supabase
+          .from('__seo_content_block_versions')
+          .select('version_id')
+          .eq('block_id', row.blockId)
+          .eq('status', 'draft')
+          .eq('content_hash', row.contentHash)
+          .limit(1)
+          .maybeSingle();
+        if (existingDraft) {
+          noop += 1;
+          continue; // draft régressant déjà enregistré → no-op idempotent
+        }
+      }
 
       const { data: ins, error } = await this.supabase
         .from('__seo_content_block_versions')

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -15,19 +15,58 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import stableStringify from 'fast-json-stable-stringify';
 import { SupabaseBaseService } from '../../database/services/supabase-base.service';
 import { getAppConfig } from '../../config/app.config';
+import { getErrorMessage } from '@common/utils/error.utils';
 import { SeoProjectionGateService } from './seo-projection-gate.service';
 import {
+  buildAndPublishSnapshot,
+  type SnapshotEntry,
+} from './seo-projection-snapshot';
+import {
   type EntityWriteOutcome,
-  type ProjectedBlockRow,
   type ProjectionRunMeta,
   type ProjectionRunResult,
   type ProjectionTriggeredBy,
+  type ProjectedBlockRow,
   type SeoProjectionBlock,
   type SeoProjectionExport,
+  OBJECT_STORE_ROOT_DEFAULT,
+  PROJECTION_BUILDER_VERSION,
+  PROJECTION_CONTRACT_FALLBACK,
+  PROJECTION_EXTRACTOR_VERSION,
+  PROJECTION_PIPELINE_VERSION,
+  PROJECTION_RUNNER_VERSION,
   WRITER_CONTRACT_VERSION,
 } from './seo-projection.types';
+
+/** Semver strict `MAJOR.MINOR.PATCH` (miroir de `replay_projection.py:verify_versions_complete`). */
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/** Retourne `candidate` s'il est un semver valide, sinon `fallback`. */
+function semverOr(candidate: unknown, fallback: string): string {
+  return typeof candidate === 'string' && SEMVER_RE.test(candidate)
+    ? candidate
+    : fallback;
+}
+
+/** Les 5 versions canoniques du run (toutes semver valides — condition NÉCESSAIRE du replay). */
+interface RunVersions {
+  projection_contract_version: string;
+  builder_version: string;
+  pipeline_version: string;
+  extractor_version: string;
+  runner_version: string;
+}
+
+/** Métadonnées lues best-effort sur le 1er export (seed des versions + wiki_commit du run). */
+interface ExportSeedMeta {
+  projectionContractVersion?: string;
+  builderVersion?: string;
+  wikiCommitSha?: string | null;
+}
 
 /** Slug déterministe (kebab, ascii) pour dériver block_kind depuis `section`. */
 function slugifyKind(raw: string): string {
@@ -72,9 +111,13 @@ export function mapExportBlockToDbBlock(
   if (b.last_verified_at != null) content.last_verified_at = b.last_verified_at;
   if (b.consumer_pages != null) content.consumer_pages = b.consumer_pages;
 
+  // Hash déterministe = sha256 sur une sérialisation à ordre de clés STABLE
+  // (`fast-json-stable-stringify`, convention repo cf. seo-control.service.ts). Remplace
+  // `md5(JSON.stringify(...))` : md5 est faible et `JSON.stringify` dépend de l'ordre d'insertion
+  // (deux `content` équivalents pouvaient produire des hash différents → no-op detection cassée).
   const contentHash =
     b.content_hash ??
-    createHash('md5').update(JSON.stringify(content)).digest('hex');
+    createHash('sha256').update(stableStringify(content)).digest('hex');
 
   return {
     blockId,
@@ -100,11 +143,16 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     super(configService);
   }
 
-  /** Projette une liste d'exports. Retourne un résultat observable (jamais d'exception non tracée). */
+  /**
+   * Projette une liste d'exports. Retourne un résultat observable (jamais d'exception non tracée).
+   * `projectionRole` (P2-B) : quand présent, N'ÉCRIT QUE les blocs de ce rôle (facts partagés
+   * inchangés) → une canary mono-rôle ne réécrit jamais les autres rôles de la même entité.
+   */
   async projectExports(
     exportPaths: string[],
     triggeredBy: ProjectionTriggeredBy = 'manual',
     runMeta: Partial<ProjectionRunMeta> = {},
+    projectionRole?: string,
   ): Promise<ProjectionRunResult> {
     if (this.readOnly) {
       this.log.log(
@@ -114,56 +162,138 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         runId: null,
         triggeredBy,
         entitiesWritten: 0,
+        rolesWritten: 0,
+        rolesNoop: 0,
+        rolesBlocked: 0,
+        rolesRegressed: 0,
         outcomes: [],
         refreshEnqueued: false,
         readOnlySkipped: true,
+        snapshot: null,
       };
     }
 
-    const runId = await this.openRun(triggeredBy, runMeta);
-    const outcomes: EntityWriteOutcome[] = [];
-    let written = 0;
+    // Versions semver résolues depuis l'export + composants writer (jamais le `pipeline_version`
+    // non-semver historique du feeder). Seed = 1er export lisible (best-effort, fail-open sur meta).
+    const seed = await this.readExportMeta(exportPaths[0]);
+    const versions = this.resolveRunVersions(seed, runMeta);
+    const runId = await this.openRun(
+      triggeredBy,
+      versions,
+      seed.wikiCommitSha ?? runMeta.wiki_commit_sha ?? null,
+    );
 
-    for (const path of exportPaths) {
-      const outcome = await this.projectOne(path, runId);
-      outcomes.push(outcome);
-      if (outcome.status === 'written') written += 1;
+    const outcomes: EntityWriteOutcome[] = [];
+    for (const p of exportPaths) {
+      outcomes.push(await this.projectOne(p, runId, projectionRole));
     }
 
-    await this.closeRun(
-      runId,
-      written,
-      outcomes.some((o) => o.status === 'blocked'),
-    );
+    const entitiesWritten = outcomes.filter(
+      (o) => o.factsOutcome === 'written',
+    ).length;
+    const rolesWritten = outcomes.filter(
+      (o) => o.roleOutcome === 'written',
+    ).length;
+    const rolesNoop = outcomes.filter((o) => o.roleOutcome === 'noop').length;
+    const rolesBlocked = outcomes.filter(
+      (o) => o.roleOutcome === 'blocked',
+    ).length;
+    const rolesRegressed = outcomes.filter(
+      (o) => o.roleOutcome === 'regressed_draft',
+    ).length;
+
+    // Snapshot durable AVANT de marquer `succeeded` : l'archive tar.zst immutable + le hash calculé
+    // sur les octets PERSISTÉS sont la seule autorité de replay (ADR-059). Échec publication → failed.
+    let snapshot: { hash: string; uri: string } | null = null;
+    let snapshotError: string | null = null;
+    if (runId) {
+      try {
+        snapshot = await this.buildSnapshotForRun(
+          exportPaths,
+          runId,
+          seed.wikiCommitSha ?? runMeta.wiki_commit_sha ?? null,
+          versions,
+        );
+      } catch (e) {
+        snapshotError = getErrorMessage(e);
+        this.log.error(
+          `snapshot publish failed (run=${runId}): ${snapshotError}`,
+        );
+        await this.recordConflict(
+          '?',
+          null,
+          'snapshot_publish_failed',
+          { error: snapshotError },
+          runId,
+        );
+      }
+    }
+
+    await this.closeRun(runId, {
+      entitiesWritten,
+      // succeeded UNIQUEMENT si aucun rôle bloqué ET snapshot durable publié.
+      failed: rolesBlocked > 0 || snapshotError != null,
+      snapshot,
+    });
+
     return {
       runId,
       triggeredBy,
-      entitiesWritten: written,
+      entitiesWritten,
+      rolesWritten,
+      rolesNoop,
+      rolesBlocked,
+      rolesRegressed,
       outcomes,
       refreshEnqueued: false,
+      snapshot,
     };
   }
 
-  /** Projette un export. Fail-closed : erreur → conflit + outcome blocked, jamais de throw. */
+  /** Projette un export. Fail-closed : erreur → conflit + roleOutcome blocked, jamais de throw. */
   private async projectOne(
-    path: string,
+    exportPath: string,
     runId: string | null,
+    role?: string,
   ): Promise<EntityWriteOutcome> {
     let exp: SeoProjectionExport;
     try {
-      exp = JSON.parse(await fs.readFile(path, 'utf-8')) as SeoProjectionExport;
+      exp = JSON.parse(
+        await fs.readFile(exportPath, 'utf-8'),
+      ) as SeoProjectionExport;
     } catch (e) {
       await this.recordConflict(
         '?',
         null,
         'export_unreadable',
-        { path, error: String(e) },
+        { path: exportPath, error: String(e) },
         runId,
       );
       return {
-        entity_id: path,
-        status: 'blocked',
+        entity_id: exportPath,
+        role: role ?? null,
+        factsOutcome: 'noop',
+        roleOutcome: 'blocked',
         reasons: [`export illisible: ${String(e)}`],
+      };
+    }
+
+    // Rôle demandé (P2 single-role) absent de roles_allowed → bloqué (trigger mal dirigé), rien
+    // écrit (ni facts ni blocs). Le gate ne vérifie QUE la pureté des blocs, pas le rôle demandé.
+    if (role && !(exp.roles_allowed ?? []).includes(role)) {
+      await this.recordConflict(
+        exp.entity_id,
+        null,
+        'role_not_allowed',
+        { role, roles_allowed: exp.roles_allowed },
+        runId,
+      );
+      return {
+        entity_id: exp.entity_id,
+        role,
+        factsOutcome: 'noop',
+        roleOutcome: 'blocked',
+        reasons: [`role '${role}' absent de roles_allowed`],
       };
     }
 
@@ -177,11 +307,17 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         { verdicts },
         runId,
       );
-      return { entity_id: exp.entity_id, status: 'blocked', reasons };
+      return {
+        entity_id: exp.entity_id,
+        role: role ?? null,
+        factsOutcome: 'noop',
+        roleOutcome: 'blocked',
+        reasons,
+      };
     }
 
     try {
-      return await this.writeEntity(exp, runId);
+      return await this.writeEntity(exp, runId, role);
     } catch (e) {
       await this.recordConflict(
         exp.entity_id,
@@ -192,18 +328,26 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       );
       return {
         entity_id: exp.entity_id,
-        status: 'blocked',
+        role: role ?? null,
+        factsOutcome: 'noop',
+        roleOutcome: 'blocked',
         reasons: [`écriture: ${String(e)}`],
       };
     }
   }
 
-  /** INSERT-new-version (facts) + flip active_version_id ; no-op si content_hash identique. */
+  /**
+   * Écrit une entité en découplant **FACTS partagés** et **BLOCS du rôle** (régression non-négociable
+   * P2-B) : un facts no-op ne court-circuite JAMAIS l'écriture des blocs du rôle demandé. Trigger R3
+   * → facts written + blocs R3 ; re-trigger R4 sur le même export inchangé → facts noop MAIS blocs R4
+   * écrits, sans réécrire un bloc R3.
+   */
   private async writeEntity(
     exp: SeoProjectionExport,
     runId: string | null,
+    role?: string,
   ): Promise<EntityWriteOutcome> {
-    // Upsert la ligne entity (idempotent ; ne touche pas active_version_id ici).
+    // 1. Upsert la ligne entity (idempotent ; ne touche pas active_version_id ici).
     await this.supabase.from('__seo_entity_facts').upsert(
       {
         entity_id: exp.entity_id,
@@ -215,7 +359,37 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       { onConflict: 'entity_id' },
     );
 
-    // no-op detection : la version active a-t-elle déjà ce content_hash ?
+    // 2. FACTS partagés — INSERT-new-version + flip, ou no-op. Résultat INDÉPENDANT du rôle.
+    const facts = await this.writeFacts(exp, runId);
+
+    // 3. BLOCS du rôle demandé (ou tous si slurp) — TOUJOURS exécuté, même sur un facts no-op.
+    const blocks = await this.writeBlocks(exp, runId, role);
+    const roleOutcome: EntityWriteOutcome['roleOutcome'] =
+      blocks.written > 0
+        ? 'written'
+        : blocks.regressed > 0
+          ? 'regressed_draft'
+          : 'noop';
+
+    return {
+      entity_id: exp.entity_id,
+      role: role ?? null,
+      factsOutcome: facts.written ? 'written' : 'noop',
+      roleOutcome,
+      factsVersionId: facts.versionId,
+      blocksWritten: blocks.written,
+      conflicts: blocks.regressed,
+    };
+  }
+
+  /**
+   * FACTS partagés de l'entité : no-op si `content_hash` identique à l'active, sinon INSERT-new-version
+   * (`status='active'`) + dépréciation de l'ancienne + flip du pointeur (JAMAIS d'UPDATE en place).
+   */
+  private async writeFacts(
+    exp: SeoProjectionExport,
+    runId: string | null,
+  ): Promise<{ written: boolean; versionId?: string }> {
     const { data: active } = await this.supabase
       .from('__seo_entity_fact_versions')
       .select('content_hash')
@@ -224,10 +398,9 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       .maybeSingle();
 
     if (active?.content_hash === exp.content_hash) {
-      return { entity_id: exp.entity_id, status: 'noop' };
+      return { written: false };
     }
 
-    // INSERT new version (active) — JAMAIS d'UPDATE d'une version existante.
     const { data: ins, error } = await this.supabase
       .from('__seo_entity_fact_versions')
       .insert({
@@ -242,7 +415,6 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     if (error || !ins)
       throw new Error(`insert fact_version: ${error?.message ?? 'no row'}`);
 
-    // Déprécier l'ancienne active + flip le pointeur (audit trail préservé, jamais DELETE).
     await this.supabase
       .from('__seo_entity_fact_versions')
       .update({ status: 'deprecated', valid_to: new Date().toISOString() })
@@ -257,26 +429,28 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       })
       .eq('entity_id', exp.entity_id);
 
-    const blocksWritten = await this.writeBlocks(exp, runId);
-    return {
-      entity_id: exp.entity_id,
-      status: 'written',
-      factsVersionId: ins.version_id,
-      blocksWritten: blocksWritten.written,
-      conflicts: blocksWritten.regressed,
-    };
+    return { written: true, versionId: ins.version_id };
   }
 
-  /** Écrit les blocks rôle-aware ; no-rétro-régression PAR BLOC (version "pire" → draft, pas active). */
+  /**
+   * Écrit les blocs — **role-scoped** (P2-B) : si `role` fourni, ne projette QUE ses blocs (les autres
+   * rôles de l'entité restent intacts) ; sinon tous (slurp legacy). L'INDEX POSITIONNEL est celui du
+   * tableau COMPLET (pas du filtré) → `block_kind` fallback `b<index>` STABLE quel que soit le rôle
+   * demandé (sinon un même bloc obtiendrait 2 block_id selon slurp vs role-scoped → no-op cassé).
+   * No-rétro-régression PAR BLOC (version "pire" → draft, jamais active).
+   */
   private async writeBlocks(
     exp: SeoProjectionExport,
     runId: string | null,
-  ): Promise<{ written: number; regressed: number }> {
+    role?: string,
+  ): Promise<{ written: number; regressed: number; noop: number }> {
     let written = 0;
     let regressed = 0;
+    let noop = 0;
     const blocks = exp.blocks ?? [];
     for (let index = 0; index < blocks.length; index += 1) {
       const b = blocks[index];
+      if (role && b?.role !== role) continue; // role-scoped : ignore les autres rôles (index préservé)
       // Adapte le bloc FLAT (builder) → forme DB (block_kind + content jsonb NOT NULL). Sans perte.
       const row = mapExportBlockToDbBlock(exp.entity_id, b, index);
       if (row.kindFallback) {
@@ -302,7 +476,10 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         .eq('status', 'active')
         .maybeSingle();
 
-      if (active?.content_hash === row.contentHash) continue; // no-op
+      if (active?.content_hash === row.contentHash) {
+        noop += 1;
+        continue; // no-op
+      }
 
       // no-rétro-régression : si une version active existe avec une confiance strictement supérieure, on
       // insère la nouvelle en draft (jamais active) + conflit observable.
@@ -356,7 +533,7 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         .eq('block_id', row.blockId);
       written += 1;
     }
-    return { written, regressed };
+    return { written, regressed, noop };
   }
 
   /**
@@ -388,9 +565,11 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     return { refreshed };
   }
 
+  /** Ouvre un run avec les 5 versions canoniques semver déjà résolues (jamais de `...meta` opaque). */
   private async openRun(
     triggeredBy: ProjectionTriggeredBy,
-    meta: Partial<ProjectionRunMeta>,
+    versions: RunVersions,
+    wikiCommitSha: string | null,
   ): Promise<string | null> {
     const { data, error } = await this.supabase
       .from('__seo_projection_runs')
@@ -398,7 +577,12 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         trigger_kind: triggeredBy === 'test' ? 'manual' : triggeredBy,
         status: 'running',
         writer_contract_version: WRITER_CONTRACT_VERSION,
-        ...meta,
+        projection_contract_version: versions.projection_contract_version,
+        builder_version: versions.builder_version,
+        pipeline_version: versions.pipeline_version,
+        extractor_version: versions.extractor_version,
+        runner_version: versions.runner_version,
+        wiki_commit_sha: wikiCommitSha,
       })
       .select('run_id')
       .single();
@@ -409,20 +593,109 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     return data?.run_id ?? null;
   }
 
+  /**
+   * Ferme le run : `succeeded` ⟺ `!failed` ; persiste `exports_snapshot_hash/_uri` (sur les octets
+   * PERSISTÉS du tarball) — l'audit trail porte désormais la référence replay authoritative.
+   */
   private async closeRun(
     runId: string | null,
-    written: number,
-    hadBlocked: boolean,
+    close: {
+      entitiesWritten: number;
+      failed: boolean;
+      snapshot: { hash: string; uri: string } | null;
+    },
   ): Promise<void> {
     if (!runId) return;
     await this.supabase
       .from('__seo_projection_runs')
       .update({
-        status: hadBlocked ? 'failed' : 'succeeded',
-        entities_written: written,
+        status: close.failed ? 'failed' : 'succeeded',
+        entities_written: close.entitiesWritten,
+        exports_snapshot_hash: close.snapshot?.hash ?? null,
+        exports_snapshot_uri: close.snapshot?.uri ?? null,
         finished_at: new Date().toISOString(),
       })
       .eq('run_id', runId);
+  }
+
+  /**
+   * Résout les 5 versions canoniques (semver garanti) : `projection_contract_version` ← export/runMeta
+   * (fallback constant) ; `builder_version` ← export ; `pipeline/extractor/runner` ← composants writer.
+   */
+  private resolveRunVersions(
+    seed: ExportSeedMeta,
+    runMeta: Partial<ProjectionRunMeta>,
+  ): RunVersions {
+    return {
+      projection_contract_version: semverOr(
+        runMeta.projection_contract_version ?? seed.projectionContractVersion,
+        PROJECTION_CONTRACT_FALLBACK,
+      ),
+      builder_version: semverOr(
+        seed.builderVersion,
+        PROJECTION_BUILDER_VERSION,
+      ),
+      pipeline_version: PROJECTION_PIPELINE_VERSION,
+      extractor_version: PROJECTION_EXTRACTOR_VERSION,
+      runner_version: PROJECTION_RUNNER_VERSION,
+    };
+  }
+
+  /** Best-effort (fail-open sur la META uniquement) : lit versions + wiki_commit du 1er export. */
+  private async readExportMeta(
+    firstPath: string | undefined,
+  ): Promise<ExportSeedMeta> {
+    if (!firstPath) return {};
+    try {
+      const exp = JSON.parse(
+        await fs.readFile(firstPath, 'utf-8'),
+      ) as Partial<SeoProjectionExport>;
+      return {
+        projectionContractVersion: exp.projection_contract_version,
+        builderVersion: exp.builder_version,
+        wikiCommitSha: exp.source_wiki_commit ?? null,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  /** Racine object-store où sont publiés les snapshots (aligné sur `replay_projection.py`). */
+  private getObjectStoreRoot(): string {
+    return (
+      this.configService?.get<string>('SEO_PROJECTION_OBJECT_STORE_ROOT') ??
+      OBJECT_STORE_ROOT_DEFAULT
+    );
+  }
+
+  /**
+   * Lit les octets bruts des exports + publie le snapshot tar.zst durable (délègue au builder
+   * reproductible). Fail-loud : toute erreur d'I/O remonte → run marqué `failed` par l'appelant.
+   */
+  private async buildSnapshotForRun(
+    exportPaths: string[],
+    runId: string,
+    wikiCommitSha: string | null,
+    versions: RunVersions,
+  ): Promise<{ hash: string; uri: string }> {
+    const entries: SnapshotEntry[] = [];
+    for (const p of exportPaths) {
+      entries.push({ name: path.basename(p), data: await fs.readFile(p) });
+    }
+    const published = await buildAndPublishSnapshot({
+      objectStoreRoot: this.getObjectStoreRoot(),
+      entries,
+      runId,
+      wikiCommitSha,
+      versions: {
+        projection_contract_version: versions.projection_contract_version,
+        builder_version: versions.builder_version,
+        pipeline_version: versions.pipeline_version,
+        extractor_version: versions.extractor_version,
+        runner_version: versions.runner_version,
+      },
+    });
+    return { hash: published.hash, uri: published.uri };
   }
 
   private async recordConflict(

--- a/backend/src/modules/seo-projection/seo-projection-writer.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.test.ts
@@ -108,7 +108,7 @@ describe('mapExportBlockToDbBlock', () => {
 
     expect(h1).toBe(h2);
     expect(h1).not.toBe(h3);
-    expect(h1).toHaveLength(32); // md5 hex
+    expect(h1).toHaveLength(64); // sha256 hex (fast-json-stable-stringify → déterministe, ex-md5)
   });
 
   it('respecte un content_hash autoritaire fourni par le builder', () => {

--- a/backend/src/modules/seo-projection/seo-projection.types.ts
+++ b/backend/src/modules/seo-projection/seo-projection.types.ts
@@ -32,6 +32,28 @@ export const PROJECTION_FEED_JOB = 'seo-projection-r1-feed';
 /** Version du contrat WRITER (ADR-090 Q1 : découplé du projection_contract_version du runner). */
 export const WRITER_CONTRACT_VERSION = '1.0.0';
 
+/**
+ * Versions semver des composants du forward-writer (P2-R3-B). Source réelle = **ce code**
+ * (chaque composant déclare sa propre version, bumpée quand son comportement change) → les 5
+ * versions canoniques du run sont TOUJOURS des semver valides, condition NÉCESSAIRE du replay
+ * (`replay_projection.py:verify_versions_complete` refuse tout run dont une version manque ou
+ * n'est pas `MAJOR.MINOR.PATCH`). `projection_contract_version` provient de l'export lui-même
+ * (le contrat que le builder wiki déclare) ; les 4 autres sont les versions des composants writer.
+ * Corrige le bug historique : le feeder posait `pipeline_version="r1-feeder/<trigger>"` (non-semver)
+ * → tout run réel échouait `validate_run_for_replay`.
+ */
+export const PROJECTION_BUILDER_VERSION = '1.0.0'; // adaptateur export→DB (mapExportBlockToDbBlock)
+export const PROJECTION_PIPELINE_VERSION = '1.0.0'; // pipeline d'écriture (projectExports)
+export const PROJECTION_EXTRACTOR_VERSION = '1.0.0'; // extraction facts/blocks depuis l'export
+export const PROJECTION_RUNNER_VERSION = '1.0.0'; // runner (processor → writer)
+/** Fallback si l'export ne déclare pas de `projection_contract_version` semver exploitable. */
+export const PROJECTION_CONTRACT_FALLBACK = '1.0.0';
+
+/** Sous-répertoire object-store des snapshots (miroir `replay_projection.py:SNAPSHOTS_SUBDIR`). */
+export const OBJECT_STORE_SNAPSHOTS_SUBDIR = 'exports-snapshots';
+/** Racine object-store par défaut (miroir du défaut CLI `replay_projection.py --object-store`). */
+export const OBJECT_STORE_ROOT_DEFAULT = '/opt/automecanik/object-store';
+
 /** Debounce du refresh (ADR-059 : coalescing 5s, concurrency=1, single-flight). */
 export const REFRESH_DEBOUNCE_MS = 5_000;
 
@@ -47,6 +69,13 @@ export interface ProjectionWriteJobData {
   triggeredBy: ProjectionTriggeredBy;
   /** Chemins absolus des exports/seo/<type>/<slug>.json à projeter. */
   exportPaths: string[];
+  /**
+   * Rôle de projection à écrire EXCLUSIVEMENT (P2-B role-scoped, ADR-090 §C2). Présent → le
+   * writer ne projette QUE les blocs de ce rôle (facts partagés inchangés) → une canary mono-rôle
+   * n'écrit jamais « tous les rôles présents dans l'export ». Absent = mode slurp legacy (tous rôles,
+   * cron R1). Un GO R3 n'active JAMAIS R4/R6 de la même gamme.
+   */
+  projectionRole?: string;
   /** Métadonnées run (versions semver) pour l'audit trail __seo_projection_runs. */
   runMeta?: Partial<ProjectionRunMeta>;
 }
@@ -146,10 +175,23 @@ export interface GateVerdict {
   reasons: string[];
 }
 
-/** Résultat d'écriture d'une entité (observable, jamais silencieux). */
+/**
+ * Résultat d'écriture d'une entité (observable, jamais silencieux). **Régression writer
+ * non-négociable (P2-B)** : le résultat des FACTS partagés est séparé du résultat du RÔLE demandé.
+ *   - `factsOutcome` = état des facts partagés de l'entité (`written` = nouvelle version active,
+ *     `noop` = content_hash inchangé). Un `noop` de facts ne DOIT JAMAIS court-circuiter l'écriture
+ *     des blocs du rôle (trigger R3 → facts written + blocs R3 ; re-trigger R4 sur le même export
+ *     inchangé → facts noop MAIS blocs R4 écrits, sans réécrire un bloc R3).
+ *   - `roleOutcome` = état des blocs du `role` demandé (`written` ≥1 bloc flippé actif · `noop`
+ *     aucun changement · `blocked` gate/rôle-non-autorisé/erreur, rien écrit · `regressed_draft`
+ *     nouvelle version insérée en draft car pire que l'active — jamais promue).
+ */
 export interface EntityWriteOutcome {
   entity_id: string;
-  status: 'written' | 'noop' | 'blocked' | 'regressed_draft';
+  /** Rôle demandé (P2 single-role) ; `null` = mode slurp legacy (tous rôles). */
+  role: string | null;
+  factsOutcome: 'written' | 'noop';
+  roleOutcome: 'written' | 'noop' | 'blocked' | 'regressed_draft';
   factsVersionId?: string;
   blocksWritten?: number;
   conflicts?: number;
@@ -159,8 +201,17 @@ export interface EntityWriteOutcome {
 export interface ProjectionRunResult {
   runId: string | null;
   triggeredBy: ProjectionTriggeredBy;
+  /** Nb d'entités dont les FACTS ont reçu une nouvelle version active (facts noop non compté). */
   entitiesWritten: number;
+  /** Compteurs rôle (P2-B) : partition des `roleOutcome` sur les entités du run. */
+  rolesWritten: number;
+  rolesNoop: number;
+  rolesBlocked: number;
+  /** `regressed_draft` (nouvelle version insérée en draft, active préservée) — observable à part. */
+  rolesRegressed: number;
   outcomes: EntityWriteOutcome[];
   refreshEnqueued: boolean;
   readOnlySkipped?: boolean;
+  /** Snapshot durable publié pour ce run (replay SoT) ; `null` si aucun / échec de publication. */
+  snapshot?: { hash: string; uri: string } | null;
 }

--- a/log.md
+++ b/log.md
@@ -555,3 +555,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/substitution-fail-open-on-rpc-error`
 - **Décision** : fix(migration): add statement_timeout + lock_timeout guards (squawk migration-safety) (+2 other commits)
 - **Sortie** : PR #1148 | commits d04a1b2e8 68b87e00b 9044444c4
+
+## 2026-07-15 — feat/p2r3b-producer (auto)
+
+- **Branche** : `feat/p2r3b-producer`
+- **Décision** : feat(seo-projection): durable reproducible snapshot producer + role-scoped writer (P2-R3-B)
+- **Sortie** : PR aucune | commits a5434bb61

--- a/log.md
+++ b/log.md
@@ -561,3 +561,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/p2r3b-producer`
 - **Décision** : feat(seo-projection): durable reproducible snapshot producer + role-scoped writer (P2-R3-B)
 - **Sortie** : PR aucune | commits a5434bb61
+
+## 2026-07-15 — feat/p2r3b-producer (auto)
+
+- **Branche** : `feat/p2r3b-producer`
+- **Décision** : fix(seo-projection): idempotent regress-draft, per-run manifest, empty-export guard (+2 other commits)
+- **Sortie** : PR #1282 | commits b7f8c7601 18ae1a0ed 91d7a7dbd

--- a/scripts/seo-projection/replay_projection.py
+++ b/scripts/seo-projection/replay_projection.py
@@ -146,10 +146,19 @@ def verify_versions_complete(run_row: dict[str, Any]) -> tuple[bool, list[str]]:
     return (not missing), missing
 
 
-def verify_manifest_sidecar(snapshot_path: Path) -> tuple[bool, str, dict | None]:
+def verify_manifest_sidecar(
+    snapshot_path: Path,
+    expected_hash_full: str,
+    expected_versions: dict[str, Any],
+) -> tuple[bool, str, dict | None]:
     """
-    Vérifie que le manifest sidecar `<hash>.manifest.json` (PR-5b) existe et
-    matche les versions du tar.zst. Audit-only — informational.
+    Vérifie le manifest sidecar `<hash>.manifest.json` (commit marker écrit EN DERNIER par le
+    writer). Contrat de validation (P2-R3-B) — trois axes doivent MATCHER, pas juste exister :
+      1. `snapshot_hash` == hash attendu du run (l'archive tar.zst persistée) ;
+      2. `versions` == les 5 versions canoniques du run (replay determinism) ;
+      3. inventaire d'entrées présent + cohérent (`entry_count` == len(entries) ;
+         chaque entrée = {name:str non vide, sha256:64hex, size:int>=0}).
+    Toute divergence → `ok=False` (fail-closed), le run n'est pas replayable.
     """
     manifest_path = snapshot_path.parent / (
         snapshot_path.stem.replace(".tar", "") + ".manifest.json"
@@ -160,6 +169,54 @@ def verify_manifest_sidecar(snapshot_path: Path) -> tuple[bool, str, dict | None
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         return False, f"manifest_parse_failed: {exc}", None
+
+    if not isinstance(manifest, dict):
+        return False, "manifest_not_object", None
+
+    # 1. Archive hash déclaré == hash attendu (le tar.zst persisté, déjà vérifié bit-exact).
+    declared_hash = manifest.get("snapshot_hash")
+    if declared_hash != expected_hash_full:
+        return (
+            False,
+            f"manifest_hash_mismatch: manifest={declared_hash!r} run={expected_hash_full!r}",
+            manifest,
+        )
+
+    # 2. Versions déclarées == 5 versions canoniques du run.
+    declared_versions = manifest.get("versions")
+    if not isinstance(declared_versions, dict):
+        return False, "manifest_versions_missing", manifest
+    for field in REQUIRED_VERSIONS:
+        if declared_versions.get(field) != expected_versions.get(field):
+            return (
+                False,
+                f"manifest_version_mismatch:{field}: "
+                f"manifest={declared_versions.get(field)!r} run={expected_versions.get(field)!r}",
+                manifest,
+            )
+
+    # 3. Inventaire d'entrées présent + cohérent.
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return False, "manifest_entries_missing_or_empty", manifest
+    if manifest.get("entry_count") != len(entries):
+        return (
+            False,
+            f"manifest_entry_count_mismatch: declared={manifest.get('entry_count')} actual={len(entries)}",
+            manifest,
+        )
+    for entry in entries:
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("name"), str)
+            or not entry.get("name")
+            or not isinstance(entry.get("sha256"), str)
+            or len(entry.get("sha256", "")) != 64
+            or not isinstance(entry.get("size"), int)
+            or entry.get("size", -1) < 0
+        ):
+            return False, f"manifest_entry_malformed: {entry!r}", manifest
+
     return True, "manifest_ok", manifest
 
 
@@ -205,7 +262,10 @@ def validate_run_for_replay(
     if not integrity_ok:
         errors.append(f"integrity:{integrity_msg}")
 
-    manifest_ok, manifest_msg, manifest_data = verify_manifest_sidecar(snapshot_path)
+    expected_versions = {v: run_row.get(v) for v in REQUIRED_VERSIONS}
+    manifest_ok, manifest_msg, _manifest_data = verify_manifest_sidecar(
+        snapshot_path, snapshot_hash_full, expected_versions
+    )
     if not manifest_ok:
         errors.append(f"manifest:{manifest_msg}")
 

--- a/scripts/seo-projection/replay_projection.py
+++ b/scripts/seo-projection/replay_projection.py
@@ -148,21 +148,24 @@ def verify_versions_complete(run_row: dict[str, Any]) -> tuple[bool, list[str]]:
 
 def verify_manifest_sidecar(
     snapshot_path: Path,
+    run_id: str,
     expected_hash_full: str,
     expected_versions: dict[str, Any],
 ) -> tuple[bool, str, dict | None]:
     """
-    Vérifie le manifest sidecar `<hash>.manifest.json` (commit marker écrit EN DERNIER par le
-    writer). Contrat de validation (P2-R3-B) — trois axes doivent MATCHER, pas juste exister :
+    Vérifie le manifest sidecar PER-RUN `<hash>.<run_id>.manifest.json` (commit marker écrit EN
+    DERNIER par le writer). Le manifest est keyé par run (pas seulement par hash) : l'archive tar.zst
+    est content-addressed (dédup entre runs d'exports identiques), mais les 5 versions sont per-run —
+    un manifest partagé serait écrasé par un run ultérieur de versions différentes. Contrat de
+    validation (P2-R3-B) — trois axes doivent MATCHER, pas juste exister :
       1. `snapshot_hash` == hash attendu du run (l'archive tar.zst persistée) ;
       2. `versions` == les 5 versions canoniques du run (replay determinism) ;
       3. inventaire d'entrées présent + cohérent (`entry_count` == len(entries) ;
          chaque entrée = {name:str non vide, sha256:64hex, size:int>=0}).
     Toute divergence → `ok=False` (fail-closed), le run n'est pas replayable.
     """
-    manifest_path = snapshot_path.parent / (
-        snapshot_path.stem.replace(".tar", "") + ".manifest.json"
-    )
+    hex_hash = snapshot_path.stem.replace(".tar", "")
+    manifest_path = snapshot_path.parent / f"{hex_hash}.{run_id}.manifest.json"
     if not manifest_path.is_file():
         return False, f"manifest_sidecar_missing: {manifest_path}", None
     try:
@@ -264,7 +267,7 @@ def validate_run_for_replay(
 
     expected_versions = {v: run_row.get(v) for v in REQUIRED_VERSIONS}
     manifest_ok, manifest_msg, _manifest_data = verify_manifest_sidecar(
-        snapshot_path, snapshot_hash_full, expected_versions
+        snapshot_path, str(run_id), snapshot_hash_full, expected_versions
     )
     if not manifest_ok:
         errors.append(f"manifest:{manifest_msg}")
@@ -277,7 +280,10 @@ def validate_run_for_replay(
         "versions": {v: run_row.get(v) for v in REQUIRED_VERSIONS},
         "wiki_commit_sha": run_row.get("wiki_commit_sha"),
         "manifest_path": (
-            str(snapshot_path.parent / (snapshot_path.stem.replace(".tar", "") + ".manifest.json"))
+            str(
+                snapshot_path.parent
+                / f"{snapshot_path.stem.replace('.tar', '')}.{run_id}.manifest.json"
+            )
             if manifest_ok
             else None
         ),

--- a/tests/seo_projection/test_replay_projection.py
+++ b/tests/seo_projection/test_replay_projection.py
@@ -24,6 +24,9 @@ SCRIPT_PATH = (
 # ────────────────────────────────────────────────────────────────────────────
 
 
+DEFAULT_RUN_ID = "00000000-0000-7000-8000-000000000001"
+
+
 def _default_manifest(full_hash: str, *, versions=None, entries=None) -> dict:
     """Manifest sidecar conforme (P2-R3-B) : snapshot_hash + 5 versions + inventaire d'entrées."""
     return {
@@ -43,16 +46,20 @@ def _default_manifest(full_hash: str, *, versions=None, entries=None) -> dict:
 
 
 def _make_snapshot(
-    tmp_path: Path, content: bytes, *, manifest: dict | None = None
+    tmp_path: Path,
+    content: bytes,
+    *,
+    manifest: dict | None = None,
+    run_id: str = DEFAULT_RUN_ID,
 ) -> tuple[Path, str]:
-    """Crée un fichier <hash>.tar.zst + manifest sidecar. Retourne (path, hash_full)."""
+    """Crée <hash>.tar.zst + manifest sidecar PER-RUN <hash>.<run_id>.manifest.json. Retourne (path, hash_full)."""
     snapshots_dir = tmp_path / "exports-snapshots"
     snapshots_dir.mkdir(parents=True, exist_ok=True)
     hex_hash = hashlib.sha256(content).hexdigest()
     full_hash = f"sha256:{hex_hash}"
     snapshot = snapshots_dir / f"{hex_hash}.tar.zst"
     snapshot.write_bytes(content)
-    manifest_path = snapshots_dir / f"{hex_hash}.manifest.json"
+    manifest_path = snapshots_dir / f"{hex_hash}.{run_id}.manifest.json"
     manifest_path.write_text(
         json.dumps(manifest if manifest is not None else _default_manifest(full_hash))
     )
@@ -61,7 +68,7 @@ def _make_snapshot(
 
 def _valid_run_row(snapshot_hash: str) -> dict:
     return {
-        "run_id": "00000000-0000-7000-8000-000000000001",
+        "run_id": DEFAULT_RUN_ID,
         "started_at": "2026-05-13T10:00:00+00:00",
         "exports_snapshot_hash": snapshot_hash,
         "exports_snapshot_uri": f"/opt/automecanik/object-store/exports-snapshots/{snapshot_hash.split(':')[1]}.tar.zst",

--- a/tests/seo_projection/test_replay_projection.py
+++ b/tests/seo_projection/test_replay_projection.py
@@ -24,7 +24,27 @@ SCRIPT_PATH = (
 # ────────────────────────────────────────────────────────────────────────────
 
 
-def _make_snapshot(tmp_path: Path, content: bytes) -> tuple[Path, str]:
+def _default_manifest(full_hash: str, *, versions=None, entries=None) -> dict:
+    """Manifest sidecar conforme (P2-R3-B) : snapshot_hash + 5 versions + inventaire d'entrées."""
+    return {
+        "schema": "seo-projection-snapshot/1",
+        "snapshot_hash": full_hash,
+        "tar_zst_size": 123,
+        "created_from_run_id": "00000000-0000-7000-8000-000000000001",
+        "wiki_commit_sha": "abcd1234" * 5,
+        "versions": versions
+        if versions is not None
+        else {v: "1.0.0" for v in replay.REQUIRED_VERSIONS},
+        "entry_count": len(entries) if entries is not None else 1,
+        "entries": entries
+        if entries is not None
+        else [{"name": "a.json", "sha256": "a" * 64, "size": 12}],
+    }
+
+
+def _make_snapshot(
+    tmp_path: Path, content: bytes, *, manifest: dict | None = None
+) -> tuple[Path, str]:
     """Crée un fichier <hash>.tar.zst + manifest sidecar. Retourne (path, hash_full)."""
     snapshots_dir = tmp_path / "exports-snapshots"
     snapshots_dir.mkdir(parents=True, exist_ok=True)
@@ -32,9 +52,9 @@ def _make_snapshot(tmp_path: Path, content: bytes) -> tuple[Path, str]:
     full_hash = f"sha256:{hex_hash}"
     snapshot = snapshots_dir / f"{hex_hash}.tar.zst"
     snapshot.write_bytes(content)
-    manifest = snapshots_dir / f"{hex_hash}.manifest.json"
-    manifest.write_text(
-        json.dumps({"content_hash": full_hash, "filename": snapshot.name})
+    manifest_path = snapshots_dir / f"{hex_hash}.manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest if manifest is not None else _default_manifest(full_hash))
     )
     return snapshot, full_hash
 
@@ -144,6 +164,87 @@ def test_validate_run_sha256_mismatch_marks_invalid(tmp_path: Path) -> None:
     report = replay.validate_run_for_replay(run, tmp_path)
     assert not report["ok"]
     assert any("integrity" in e and "sha256_mismatch" in e for e in report["errors"])
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Manifest sidecar validation (P2-R3-B : hash + versions + entry inventory MATCH)
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_manifest_valid_passes(tmp_path: Path) -> None:
+    _make_snapshot(tmp_path, b"snap-ok")
+    run = _valid_run_row(f"sha256:{hashlib.sha256(b'snap-ok').hexdigest()}")
+    report = replay.validate_run_for_replay(run, tmp_path)
+    assert report["ok"], report["errors"]
+
+
+def test_manifest_missing_rejected(tmp_path: Path) -> None:
+    content = b"snap-nomani"
+    hex_hash = hashlib.sha256(content).hexdigest()
+    snapshots_dir = tmp_path / "exports-snapshots"
+    snapshots_dir.mkdir(parents=True)
+    (snapshots_dir / f"{hex_hash}.tar.zst").write_bytes(content)  # no sidecar
+    run = _valid_run_row(f"sha256:{hex_hash}")
+    report = replay.validate_run_for_replay(run, tmp_path)
+    assert not report["ok"]
+    assert any("manifest_sidecar_missing" in e for e in report["errors"])
+
+
+def test_manifest_hash_mismatch_rejected(tmp_path: Path) -> None:
+    content = b"snap-hash"
+    full_hash = f"sha256:{hashlib.sha256(content).hexdigest()}"
+    bad = _default_manifest(full_hash)
+    bad["snapshot_hash"] = "sha256:" + "9" * 64  # ne matche pas le run
+    _make_snapshot(tmp_path, content, manifest=bad)
+    report = replay.validate_run_for_replay(_valid_run_row(full_hash), tmp_path)
+    assert not report["ok"]
+    assert any("manifest_hash_mismatch" in e for e in report["errors"])
+
+
+def test_manifest_versions_mismatch_rejected(tmp_path: Path) -> None:
+    content = b"snap-ver"
+    full_hash = f"sha256:{hashlib.sha256(content).hexdigest()}"
+    versions = {v: "1.0.0" for v in replay.REQUIRED_VERSIONS}
+    versions["builder_version"] = "9.9.9"  # diverge du run (1.0.0)
+    _make_snapshot(tmp_path, content, manifest=_default_manifest(full_hash, versions=versions))
+    report = replay.validate_run_for_replay(_valid_run_row(full_hash), tmp_path)
+    assert not report["ok"]
+    assert any("manifest_version_mismatch:builder_version" in e for e in report["errors"])
+
+
+def test_manifest_entries_missing_rejected(tmp_path: Path) -> None:
+    content = b"snap-noentries"
+    full_hash = f"sha256:{hashlib.sha256(content).hexdigest()}"
+    m = _default_manifest(full_hash)
+    m["entries"] = []
+    m["entry_count"] = 0
+    _make_snapshot(tmp_path, content, manifest=m)
+    report = replay.validate_run_for_replay(_valid_run_row(full_hash), tmp_path)
+    assert not report["ok"]
+    assert any("manifest_entries_missing_or_empty" in e for e in report["errors"])
+
+
+def test_manifest_entry_malformed_rejected(tmp_path: Path) -> None:
+    content = b"snap-badentry"
+    full_hash = f"sha256:{hashlib.sha256(content).hexdigest()}"
+    m = _default_manifest(
+        full_hash, entries=[{"name": "a.json", "sha256": "short", "size": 1}]
+    )
+    _make_snapshot(tmp_path, content, manifest=m)
+    report = replay.validate_run_for_replay(_valid_run_row(full_hash), tmp_path)
+    assert not report["ok"]
+    assert any("manifest_entry_malformed" in e for e in report["errors"])
+
+
+def test_manifest_entry_count_mismatch_rejected(tmp_path: Path) -> None:
+    content = b"snap-count"
+    full_hash = f"sha256:{hashlib.sha256(content).hexdigest()}"
+    m = _default_manifest(full_hash)
+    m["entry_count"] = 5  # ≠ len(entries)=1
+    _make_snapshot(tmp_path, content, manifest=m)
+    report = replay.validate_run_for_replay(_valid_run_row(full_hash), tmp_path)
+    assert not report["ok"]
+    assert any("manifest_entry_count_mismatch" in e for e in report["errors"])
 
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## P2-R3-B — Producteur de projection SEO (forward-writer ADR-059), **DARK**

Câble le producteur de la boucle forward-writer : le writer live **construit + publie un
snapshot `.tar.zst` reproductible** de l'ensemble d'exports immuable, calcule le hash sur les
**octets persistés**, peuple les **5 versions canoniques** + les compteurs de run, et ne marque
`succeeded` **qu'après** commit durable de l'archive. La validation de replay est étendue en
**lockstep** (hash + versions + inventaire d'entrées).

> **DARK — aucune surface de lecture.** 0 `SeoProjectionReaderService` câblé · 0 read canary ·
> 0 consumer public · 0 service PREPROD/PROD de projection · 0 grant anon · 0 activation
> diagnostic. Le producteur écrit dans les tables de projection (versionnées, séparées des tables
> legacy servies), rien ne les lit encore. **C0 (reader) suit seulement après revue verte de cette PR.**

### Ce que la PR livre (b–e + replay en lockstep)

- **Snapshot durable & reproductible** : USTAR déterministe (entrées triées, mtime=0, uid/gid=0,
  uname/gname vides, mode 0644) + `zstdCompressSync` niveau figé → deux ensembles d'exports
  identiques ⇒ même `sha256`. Publication atomique temp→`fsync`→`rename`→`fsync(dir)`.
- **Manifest sidecar écrit en dernier** (commit marker) — keyé **par run** `<hex>.<runId>.manifest.json`
  (l'archive est content-addressed/dédupliquée, mais les 5 versions sont per-run).
- **5 versions canoniques** (`projection_contract/builder/pipeline/extractor/runner`) toutes en
  semver `MAJOR.MINOR.PATCH` réel — un `pipeline_version` non-semver faisait échouer tout run.
- **`exports_snapshot_hash` = sha256 des octets persistés** (plus jamais une vue mémoire divergente).
- **`writeEntity` role-scoped** ; `triggerEntity` single-entity single-role ; allowlist d'écriture
  dark séparée `<role>@<entity_key>`.
- **Hash de contenu = SHA-256 sur JSON stable** (`fast-json-stable-stringify`), plus `md5(JSON.stringify)`.
- **Compteurs** `roles_written / roles_noop / roles_blocked` + transition de run
  `running → succeeded|failed` vérifiée.
- **Replay** : `verify_manifest_sidecar` valide hash d'archive, versions et inventaire d'entrées ;
  fix PK `run_row['run_id']` (était `id`).

### Invariant writer non-négociable (découplage faits ↔ rôle)

`factsOutcome` (`written|noop`) est **séparé** de `roleOutcome` (`written|noop|blocked|regressed_draft`).
Un no-op de faits **ne court-circuite jamais** l'écriture d'un nouveau rôle :
> trigger R3 → faits écrits + blocs R3 écrits ; trigger R4 sur le **même export inchangé** →
> faits **noop** → blocs R4 **quand même écrits** → **aucun** bloc R3 réécrit.

Garanti par un index UNIQUE partiel `(entity_type, entity_id, projection_role) WHERE active` (R3/R4/R6
partagent l'entité gamme) — activer R4 ne désactive jamais R3.

### Corrections de la revue adverse (multi-agents) — incluses

1. **Régression de bloc idempotente** : re-projeter un export régressant inchangé ne duplique plus
   draft+conflit (dédup par `content_hash` avant insert).
2. **Manifest per-run** (voir ci-dessus) — évite l'écrasement par un run ultérieur d'exports
   identiques aux versions bumpées.
3. **Garde `exportPaths=[]`** : court-circuite avant `openRun` → pas de run fantôme (`runId=null`).
4. **Durcissement** : nom d'entrée USTAR >100 octets ⇒ erreur explicite (fail-loud, pas de troncature).

### Validation locale

`tsc` 0 · `jest` 38 · `pytest` 43 · `eslint` 0 (11 fichiers) · `check-role-purity` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
