### PR TITLE
fix(audit): refresh served-write-sink baseline after B5 r3-image-prompt closure (#1278 follow-up)

### DIFF
--- a/audit/baselines/served-content-write-sinks-baseline.json
+++ b/audit/baselines/served-content-write-sinks-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "v1",
-  "createdAt": "2026-07-14",
+  "createdAt": "2026-07-15",
   "createdOnCommit": null,
   "sourcePr": null,
   "mode": "block-new-only",
@@ -74,7 +74,7 @@
     {
       "mechanism": "direct_literal",
       "id": "backend/src/modules/admin/services/r3-image-prompt.service.ts::__seo_r3_image_prompts",
-      "count": 3
+      "count": 2
     },
     {
       "mechanism": "direct_literal",


### PR DESCRIPTION
## Refresh served-content write-sink baseline — B5 (#1278) follow-up

**main is currently RED** on the required check **"Block new served-content write sinks"**.

### Root cause
#1278 (B5) removed the R3 image-prompt **RAG generation**, retiring one
`__seo_r3_image_prompts` write sink in
`backend/src/modules/admin/services/r3-image-prompt.service.ts` (**3 → 2**). B5 refreshed
its *other* ratchet but **not** `audit/baselines/served-content-write-sinks-baseline.json`.
The write-sink ratchet fails on a decrease-without-baseline-update ("a real closure
masquerading as an un-recorded drop"), so the gate has been red on `main` since #1278 merged.

### Fix
Sanctioned refresh (`npm run audit:served-write-ratchet:refresh`), which records the closure:

- sole entry `r3-image-prompt.service.ts::__seo_r3_image_prompts` **3 → 2**
- **no other sink count changes** (64 keys, 269 occurrences) — proving this is exactly B5's
  closure and nothing else drifted
- `createdAt` date auto-stamped by the tool

Ratchet now green. **No code behavior change** — a 2-line baseline edit only.

### Why a separate PR
This is B5 hygiene, structurally independent of the P2-R3-B producer work (#1282), which is
blocked purely by inheriting this red. Merging this first turns #1282 green on rebase without
coupling a B5 concern into the producer diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
