### PR TITLE
feat(seo-projection): extract dark projection reader (C0, behavior-identical)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-07-02'
+last_scan: '2026-07-16'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/constants/seo-control.constants.ts
@@ -25,6 +25,7 @@ depends_on:
 - VehiclesModule
 - OperatingMatrixModule
 - FeatureFlagsModule
+- SeoProjectionReadModule
 - BullModule
 ---
 

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -79,6 +79,7 @@ import {
 import { CanonObservabilityService } from './services/canon-observability.service'; // 🛡️ Canon violation Sentry emitter
 import { PageBriefService } from './services/page-brief.service'; // 📋 Page Briefs CRUD + overlap
 import { SeoBriefService } from './services/seo-brief.service'; // 🧱 D1 — WIKI-driven evidence brief (ADR-059/090)
+import { SeoProjectionReadModule } from '../seo-projection/seo-projection-read.module'; // 🔎 C0 — reader léger (moindre-privilège) consommé par SeoBriefService
 import { BriefGatesService } from './services/brief-gates.service'; // 🚦 Pre-publish gates anti-cannibalisation
 import { HardGatesService } from './services/hard-gates.service'; // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)
 import { KeywordDensityGateService } from './services/keyword-density-gate.service'; // 🚦 Gate F: keyword density check
@@ -168,6 +169,7 @@ import { SeoControlRefreshProcessor } from './processors/seo-control-refresh.pro
     VehiclesModule, // 🚗 INC-2026-007 — pour AdminVehicleCacheController (VehicleRpcService)
     OperatingMatrixModule, // 🛡️ Read-only governance matrix (zero infra deps)
     FeatureFlagsModule, // 🎛️ PR-SBD-1 — feature.seoControlDashboardEnabled kill-switch
+    SeoProjectionReadModule, // 🔎 C0 — expose SeoProjectionReaderService à SeoBriefService (read léger, pas le write-side)
     BullModule.registerQueue({ name: SEO_CONTROL_REFRESH_QUEUE }), // 🚀 PR-SBD-1 SWR per-block refresh
   ],
   controllers: [

--- a/backend/src/modules/admin/services/seo-brief.service.test.ts
+++ b/backend/src/modules/admin/services/seo-brief.service.test.ts
@@ -4,6 +4,7 @@
  * SOURCE_MIX (pas 100% éditorial), SUBSTANCE_FLOOR par rôle, EVIDENCE_BOUND (orphelins non comptés), exclusion R2.
  */
 import {
+  SeoBriefService,
   extractSubstanceElements,
   countProprietary,
   sourceMix,
@@ -11,6 +12,7 @@ import {
   SUBSTANCE_FLOOR_BY_ROLE,
   type BriefRole,
   type BlockTruthLevel,
+  type BriefEvidenceBundle,
 } from './seo-brief.service';
 
 const block = (
@@ -162,5 +164,168 @@ describe('evaluateSubstanceGate', () => {
     // @ts-expect-error R2 n'est pas un BriefRole — la page transactionnelle a un chemin dédié strict.
     const floor = SUBSTANCE_FLOOR_BY_ROLE.R2_PRODUCT;
     expect(floor).toBeUndefined();
+  });
+});
+
+// ── Caractérisation de composeBrief (GARDE behavior-identical pour C0) ──────────
+// Fige le contrat OBSERVABLE de composeBrief AVANT l'extraction du reader : dérivation
+// entity_id, mapping projectionRole, et les 4 dégradations observables (flag OFF, RPC error,
+// RPC exception, projection absente) + le happy-path wiki_evidence. Après extraction du
+// SeoProjectionReaderService, ces mêmes assertions doivent rester vertes (seul le stub de
+// lecture change : callRpc → reader.readActiveProjection ; les bundles retournés sont identiques).
+type ReaderResult = {
+  envelope: unknown | null;
+  degradeReason: string | null;
+};
+interface BriefHarness {
+  composeBrief: (p: {
+    pgId?: number;
+    pgAlias?: string;
+    vehicleSlug?: string;
+    pageRole: BriefRole;
+  }) => Promise<BriefEvidenceBundle>;
+  lastRead?: { entityId: string; role: string };
+}
+
+function makeBrief(opts: {
+  wikiEnabled?: boolean;
+  read?: () => Promise<ReaderResult>;
+}): BriefHarness {
+  const svc = Object.create(SeoBriefService.prototype) as Record<
+    string,
+    unknown
+  > & { lastRead?: { entityId: string; role: string } };
+  svc.logger = { warn() {}, log() {}, error() {} };
+  svc.featureFlags = { seoBriefWikiEnabled: opts.wikiEnabled ?? true };
+  // Stub du reader unique (C0 : composeBrief délègue à projectionReader.readActiveProjection).
+  // Enregistre (entityId, role) pour prouver la dérivation ; le mapping p_entity_id/p_role est
+  // désormais testé dans l'unité du reader.
+  svc.projectionReader = {
+    readActiveProjection: (entityId: string, role: string) => {
+      svc.lastRead = { entityId, role };
+      return (
+        opts.read ??
+        (() =>
+          Promise.resolve({
+            envelope: null,
+            degradeReason: 'projection absente',
+          }))
+      )();
+    },
+  };
+  return svc as unknown as BriefHarness;
+}
+
+const sourcedBlocks = (n: number, role = 'R3_CONSEILS') =>
+  Array.from({ length: n }, (_, i) => ({
+    role,
+    block_kind: `sec${i}`,
+    content: {
+      content_md: 'x'.repeat(80),
+      source_ids: [`oem:s${i}`],
+      truth_level: 'sourced' as const,
+      section: `sec${i}`,
+    },
+  }));
+
+describe('composeBrief — caractérisation (behavior-identical guard C0)', () => {
+  it('flag OFF → dégradé observable (SEO_BRIEF_WIKI_ENABLED=false), aucune lecture RPC', async () => {
+    const h = makeBrief({ wikiEnabled: false });
+    const b = await h.composeBrief({
+      pgAlias: 'filtre-a-huile',
+      pageRole: 'R3_CONSEILS',
+    });
+    expect(b.wiki_available).toBe(false);
+    expect(b.brief_source).toBe('keyword');
+    expect(b.entity_id).toBe('gamme:filtre-a-huile');
+    expect(b.substance_gate.reasons).toEqual(['SEO_BRIEF_WIKI_ENABLED=false']);
+    expect(b.substance_gate.floor).toBe(SUBSTANCE_FLOOR_BY_ROLE.R3_CONSEILS);
+    expect(h.lastRead).toBeUndefined(); // pas de lecture quand le flag est OFF
+  });
+
+  it('RPC error → dégradé observable "RPC error: <msg>"', async () => {
+    const h = makeBrief({
+      read: () =>
+        Promise.resolve({ envelope: null, degradeReason: 'RPC error: boom' }),
+    });
+    const b = await h.composeBrief({
+      pgAlias: 'filtre-a-huile',
+      pageRole: 'R3_CONSEILS',
+    });
+    expect(b.wiki_available).toBe(false);
+    expect(b.brief_source).toBe('keyword');
+    expect(b.substance_gate.reasons).toEqual(['RPC error: boom']);
+  });
+
+  it('RPC exception → dégradé observable "RPC exception"', async () => {
+    // Le reader capture l'exception et renvoie degradeReason (SeoBriefService ne catch plus).
+    const h = makeBrief({
+      read: () =>
+        Promise.resolve({ envelope: null, degradeReason: 'RPC exception' }),
+    });
+    const b = await h.composeBrief({
+      pgAlias: 'filtre-a-huile',
+      pageRole: 'R3_CONSEILS',
+    });
+    expect(b.wiki_available).toBe(false);
+    expect(b.substance_gate.reasons).toEqual(['RPC exception']);
+  });
+
+  it('projection absente (envelope null) → dégradé "projection absente"', async () => {
+    const h = makeBrief({
+      read: () =>
+        Promise.resolve({
+          envelope: null,
+          degradeReason: 'projection absente',
+        }),
+    });
+    const b = await h.composeBrief({
+      pgAlias: 'filtre-a-huile',
+      pageRole: 'R3_CONSEILS',
+    });
+    expect(b.wiki_available).toBe(false);
+    expect(b.substance_gate.reasons).toEqual(['projection absente']);
+  });
+
+  it('vehicleSlug → entity_id vehicle: + role R8_VEHICLE (dérivation passée au reader)', async () => {
+    const h = makeBrief({
+      read: () =>
+        Promise.resolve({
+          envelope: null,
+          degradeReason: 'projection absente',
+        }),
+    });
+    await h.composeBrief({
+      vehicleSlug: 'golf-5-1-9-tdi',
+      pageRole: 'R8_VEHICLE',
+    });
+    expect(h.lastRead).toEqual({
+      entityId: 'vehicle:golf-5-1-9-tdi',
+      role: 'R8_VEHICLE',
+    });
+  });
+
+  it('projection valide (5 blocs sourced R3) → wiki_evidence, gate PASS', async () => {
+    const env = {
+      entity_id: 'gamme:filtre-a-huile',
+      entity_type: 'gamme',
+      slug: 'filtre-a-huile',
+      facts: [],
+      blocks: sourcedBlocks(5, 'R3_CONSEILS'),
+    };
+    const h = makeBrief({
+      read: () => Promise.resolve({ envelope: env, degradeReason: null }),
+    });
+    const b = await h.composeBrief({
+      pgAlias: 'filtre-a-huile',
+      pageRole: 'R3_CONSEILS',
+    });
+    expect(b.wiki_available).toBe(true);
+    expect(b.brief_source).toBe('wiki_evidence');
+    expect(b.proprietary_count).toBe(5);
+    expect(b.substance_gate.pass).toBe(true);
+    expect(b.substance_elements).toHaveLength(5);
+    // role mappé vers R3_CONSEILS (R3_CONSEILS/R3_GUIDE partagent les blocs R3).
+    expect(h.lastRead?.role).toBe('R3_CONSEILS');
   });
 });

--- a/backend/src/modules/admin/services/seo-brief.service.ts
+++ b/backend/src/modules/admin/services/seo-brief.service.ts
@@ -15,10 +15,11 @@
  * R2 est **exclu au niveau type** (BriefRole) — la page transactionnelle reste la plus stricte, traitée en dernier.
  */
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { SupabaseBaseService } from '@database/services/supabase-base.service';
-import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { FeatureFlagsService } from '@config/feature-flags.service';
+import {
+  SeoProjectionReaderService,
+  type ProjectionBlock,
+} from '../../seo-projection/seo-projection-reader.service';
 
 /** Rôles composables par cette fabrique. **R2 exclu structurellement** (transactionnel = chemin dédié strict). */
 export type BriefRole = 'R3_CONSEILS' | 'R3_GUIDE' | 'R8_VEHICLE';
@@ -70,25 +71,7 @@ export const SUBSTANCE_FLOOR_BY_ROLE: Record<BriefRole, number> = {
 const PROPRIETARY_TRUTH_LEVELS: ReadonlySet<BlockTruthLevel> =
   new Set<BlockTruthLevel>(['db_owned', 'sourced']);
 
-interface ProjectionBlock {
-  role?: string;
-  block_kind?: string;
-  content?: {
-    content_md?: string;
-    source_ids?: string[];
-    truth_level?: BlockTruthLevel;
-    section?: string;
-    usefulness_target?: string;
-  } | null;
-}
-
-interface ProjectionEnvelope {
-  entity_id: string;
-  entity_type: string;
-  slug: string;
-  facts: unknown[];
-  blocks: ProjectionBlock[];
-}
+// Types d'enveloppe/bloc de projection : possédés par `SeoProjectionReaderService` (C0).
 
 // ── Fonctions PURES (déterministes, sans I/O — le cœur testable du gate, partagé avec D2) ──
 
@@ -112,7 +95,9 @@ export function extractSubstanceElements(
     out.push({
       text: (c.content_md ?? '').slice(0, 200),
       source_id: sids[0] ?? null,
-      truth_level: tl,
+      // `truth_level` arrive brut (string) de la RPC ; re-narrow au domaine brief (valeur
+      // garantie par le contrat WIKI ; une valeur hors-union échoue simplement le test propriétaire).
+      truth_level: tl as BlockTruthLevel,
       field: c.section ?? c.usefulness_target ?? b.block_kind ?? 'block',
     });
   }
@@ -175,17 +160,13 @@ export function evaluateSubstanceGate(
 }
 
 @Injectable()
-export class SeoBriefService extends SupabaseBaseService {
-  protected override readonly logger = new Logger(SeoBriefService.name);
+export class SeoBriefService {
+  private readonly logger = new Logger(SeoBriefService.name);
 
   constructor(
-    configService: ConfigService,
-    @Optional() rpcGate?: RpcGateService,
+    private readonly projectionReader: SeoProjectionReaderService,
     @Optional() private readonly featureFlags?: FeatureFlagsService,
-  ) {
-    super(configService);
-    if (rpcGate) this.rpcGate = rpcGate;
-  }
+  ) {}
 
   /**
    * Compose un brief evidence-driven depuis la projection WIKI. Dégrade **observable** (wiki_available=false)
@@ -207,35 +188,19 @@ export class SeoBriefService extends SupabaseBaseService {
       return this.degraded(entityId, pageRole, 'SEO_BRIEF_WIKI_ENABLED=false');
     }
 
-    let env: ProjectionEnvelope | null = null;
-    try {
-      const { data, error } = await this.callRpc<ProjectionEnvelope | null>(
-        'get_active_seo_projection',
-        { p_entity_id: entityId, p_role: projRole },
-        { source: 'api' },
+    // Lecture d'enveloppe déléguée au reader unique (C0). Dégradation observable (null +
+    // degradeReason, déjà loggée par le reader) → on retombe sur keyword-first, jamais de fabrication.
+    const { envelope, degradeReason } =
+      await this.projectionReader.readActiveProjection(entityId, projRole);
+    if (!envelope) {
+      return this.degraded(
+        entityId,
+        pageRole,
+        degradeReason ?? 'projection absente',
       );
-      if (error) {
-        this.logger.warn(
-          `projection RPC error ${entityId}: ${error.message} → keyword-first (observable)`,
-        );
-        return this.degraded(entityId, pageRole, `RPC error: ${error.message}`);
-      }
-      env = (data as ProjectionEnvelope | null) ?? null;
-    } catch (e) {
-      this.logger.warn(
-        `projection RPC exception ${entityId}: ${String(e)} → keyword-first (observable)`,
-      );
-      return this.degraded(entityId, pageRole, 'RPC exception');
     }
 
-    if (!env) {
-      this.logger.log(
-        `projection vide ${entityId} (non projetée) → keyword-first (observable)`,
-      );
-      return this.degraded(entityId, pageRole, 'projection absente');
-    }
-
-    const elements = extractSubstanceElements(env.blocks ?? [], projRole);
+    const elements = extractSubstanceElements(envelope.blocks ?? [], projRole);
     const gate = evaluateSubstanceGate(elements, pageRole);
 
     return {

--- a/backend/src/modules/seo-projection/seo-projection-read.module.ts
+++ b/backend/src/modules/seo-projection/seo-projection-read.module.ts
@@ -1,0 +1,19 @@
+/**
+ * SeoProjectionReadModule — module de LECTURE léger (moindre-privilège) pour la projection SEO.
+ *
+ * Fournit le seul `SeoProjectionReaderService` (RPC `get_active_seo_projection`). N'importe **PAS**
+ * `DatabaseModule` ni le write-side (`SeoProjectionModule` = writer + gate `service_role` + queues) :
+ * un consommateur de lecture (admin brief aujourd'hui ; consumers R* plus tard) ne doit jamais tirer
+ * la capacité d'écriture. `SupabaseBaseService` se construit avec `ConfigService` seul ; `RpcGateService`
+ * est `@Global`. **DARK** : aucune activation de lecture publique, aucun flag de canary ici.
+ */
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SeoProjectionReaderService } from './seo-projection-reader.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [SeoProjectionReaderService],
+  exports: [SeoProjectionReaderService],
+})
+export class SeoProjectionReadModule {}

--- a/backend/src/modules/seo-projection/seo-projection-reader.service.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-reader.service.test.ts
@@ -1,13 +1,31 @@
 /**
  * SeoProjectionReaderService (C0) — propriétaire unique de la lecture `get_active_seo_projection`.
- * Vérifie : mapping (entityId, role) → params RPC {p_entity_id, p_role} + context {source:'api'},
- * et les 3 dégradations OBSERVABLES (RPC error / exception / projection absente) + le happy-path.
- * Instancié via Object.create (bypass du constructeur SupabaseBaseService lourd) ; callRpc stubbé.
+ * Vérifie :
+ *  1. logique readActiveProjection : mapping (entityId, role) → params RPC {p_entity_id, p_role} +
+ *     context {source:'api'} + les 3 dégradations OBSERVABLES + le happy-path (via Object.create,
+ *     bypass du constructeur SupabaseBaseService lourd ; callRpc stubbé) ;
+ *  2. **gate RPC obligatoire** : le constructeur assigne systématiquement `RpcGateService` (mock
+ *     explicite) — jamais optionnel ;
+ *  3. **fail-closed DI** : sans `RpcGateService` disponible, le boot Nest du module de lecture est
+ *     REFUSÉ ; avec `RpcGateModule` global (comme l'AppModule réel), le boot est VERT. Preuve
+ *     qu'une mauvaise composition ne peut plus se transformer silencieusement en
+ *     `GATE_NOT_INJECTED → ALLOW`.
  */
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { RpcGateModule } from '@security/rpc-gate/rpc-gate.module';
+import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
+import { SeoProjectionReadModule } from './seo-projection-read.module';
 import {
   SeoProjectionReaderService,
   type ProjectionEnvelope,
 } from './seo-projection-reader.service';
+
+/** Env minimal pour que SupabaseBaseService.createClient réussisse (pas de connexion réelle). */
+const SUPABASE_TEST_ENV = {
+  SUPABASE_URL: 'http://localhost:54321',
+  SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key-not-a-real-secret',
+};
 
 type RpcOut = {
   data: unknown;
@@ -94,5 +112,66 @@ describe('SeoProjectionReaderService.readActiveProjection', () => {
     );
     expect(r.degradeReason).toBeNull();
     expect(r.envelope).toEqual(env);
+  });
+});
+
+describe('SeoProjectionReaderService — gate RPC obligatoire (constructeur)', () => {
+  const mockConfig = {
+    get: (k: string) => (SUPABASE_TEST_ENV as Record<string, string>)[k],
+  } as unknown as ConfigService;
+
+  it('assigne systématiquement le RpcGateService fourni (jamais optionnel)', () => {
+    const mockGate = {
+      evaluate: () => ({ decision: 'ALLOW', reason: 'test' }),
+      log: () => {},
+    } as unknown as RpcGateService;
+    const svc = new SeoProjectionReaderService(mockConfig, mockGate);
+    // rpcGate est protected sur SupabaseBaseService → accès via cast pour la preuve.
+    expect((svc as unknown as { rpcGate?: RpcGateService }).rpcGate).toBe(
+      mockGate,
+    );
+  });
+});
+
+/**
+ * Fail-closed DI : le module de lecture ne peut PAS booter sans RpcGateService.
+ * (Preuve qu'une mauvaise composition Nest échoue au boot au lieu d'exécuter la RPC sans gate.)
+ */
+describe('SeoProjectionReadModule — fail-closed DI sur RpcGateService', () => {
+  it('SANS RpcGateModule global → boot Nest REFUSÉ (dépendance RpcGateService non résolue)', async () => {
+    await expect(
+      Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            ignoreEnvFile: true,
+            load: [() => SUPABASE_TEST_ENV],
+          }),
+          // RpcGateModule volontairement ABSENT → RpcGateService non fourni.
+          SeoProjectionReadModule,
+        ],
+      }).compile(),
+    ).rejects.toThrow(/RpcGateService/);
+  });
+
+  it('AVEC RpcGateModule global (comme l’AppModule réel) → boot VERT + reader résolu avec gate', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          ignoreEnvFile: true,
+          load: [() => SUPABASE_TEST_ENV],
+        }),
+        RpcGateModule, // @Global — fournit RpcGateService à toute l'app (parité AppModule)
+        SeoProjectionReadModule,
+      ],
+    }).compile();
+
+    const reader = moduleRef.get(SeoProjectionReaderService);
+    expect(reader).toBeInstanceOf(SeoProjectionReaderService);
+    expect(
+      (reader as unknown as { rpcGate?: RpcGateService }).rpcGate,
+    ).toBeDefined();
+    await moduleRef.close();
   });
 });

--- a/backend/src/modules/seo-projection/seo-projection-reader.service.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-reader.service.test.ts
@@ -1,0 +1,98 @@
+/**
+ * SeoProjectionReaderService (C0) — propriétaire unique de la lecture `get_active_seo_projection`.
+ * Vérifie : mapping (entityId, role) → params RPC {p_entity_id, p_role} + context {source:'api'},
+ * et les 3 dégradations OBSERVABLES (RPC error / exception / projection absente) + le happy-path.
+ * Instancié via Object.create (bypass du constructeur SupabaseBaseService lourd) ; callRpc stubbé.
+ */
+import {
+  SeoProjectionReaderService,
+  type ProjectionEnvelope,
+} from './seo-projection-reader.service';
+
+type RpcOut = {
+  data: unknown;
+  error: { message: string } | null;
+};
+
+function makeReader(
+  rpc: (
+    name: string,
+    params: Record<string, unknown>,
+    ctx: unknown,
+  ) => Promise<RpcOut>,
+) {
+  const svc = Object.create(SeoProjectionReaderService.prototype) as Record<
+    string,
+    unknown
+  >;
+  svc.logger = { warn() {}, log() {}, error() {} };
+  svc.callRpc = rpc;
+  return svc as unknown as {
+    readActiveProjection: SeoProjectionReaderService['readActiveProjection'];
+  };
+}
+
+describe('SeoProjectionReaderService.readActiveProjection', () => {
+  it('mappe (entityId, role) → RPC get_active_seo_projection {p_entity_id, p_role} + source api', async () => {
+    let seen: {
+      name: string;
+      params: Record<string, unknown>;
+      ctx: unknown;
+    } | null = null;
+    const reader = makeReader((name, params, ctx) => {
+      seen = { name, params, ctx };
+      return Promise.resolve({ data: null, error: null });
+    });
+    await reader.readActiveProjection('gamme:filtre-a-huile', 'R3_CONSEILS');
+    expect(seen!.name).toBe('get_active_seo_projection');
+    expect(seen!.params).toEqual({
+      p_entity_id: 'gamme:filtre-a-huile',
+      p_role: 'R3_CONSEILS',
+    });
+    expect(seen!.ctx).toEqual({ source: 'api' });
+  });
+
+  it('RPC error → { envelope: null, degradeReason: "RPC error: <msg>" }', async () => {
+    const reader = makeReader(() =>
+      Promise.resolve({ data: null, error: { message: 'boom' } }),
+    );
+    const r = await reader.readActiveProjection('gamme:x', 'R3_CONSEILS');
+    expect(r.envelope).toBeNull();
+    expect(r.degradeReason).toBe('RPC error: boom');
+  });
+
+  it('RPC exception → { envelope: null, degradeReason: "RPC exception" }', async () => {
+    const reader = makeReader(() => Promise.reject(new Error('kaboom')));
+    const r = await reader.readActiveProjection('gamme:x', 'R3_CONSEILS');
+    expect(r.envelope).toBeNull();
+    expect(r.degradeReason).toBe('RPC exception');
+  });
+
+  it('projection absente (data null, error null) → degradeReason "projection absente"', async () => {
+    const reader = makeReader(() =>
+      Promise.resolve({ data: null, error: null }),
+    );
+    const r = await reader.readActiveProjection('gamme:x', 'R3_CONSEILS');
+    expect(r.envelope).toBeNull();
+    expect(r.degradeReason).toBe('projection absente');
+  });
+
+  it('projection présente → { envelope, degradeReason: null }', async () => {
+    const env: ProjectionEnvelope = {
+      entity_id: 'gamme:filtre-a-huile',
+      entity_type: 'gamme',
+      slug: 'filtre-a-huile',
+      facts: [],
+      blocks: [{ role: 'R3_CONSEILS', content: { content_md: 'x' } }],
+    };
+    const reader = makeReader(() =>
+      Promise.resolve({ data: env, error: null }),
+    );
+    const r = await reader.readActiveProjection(
+      'gamme:filtre-a-huile',
+      'R3_CONSEILS',
+    );
+    expect(r.degradeReason).toBeNull();
+    expect(r.envelope).toEqual(env);
+  });
+});

--- a/backend/src/modules/seo-projection/seo-projection-reader.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-reader.service.ts
@@ -10,10 +10,20 @@
  * absente → `{ envelope: null, degradeReason }` + log, JAMAIS de fabrication ni de repli silencieux.
  * L'appelant décide quoi faire du null (SeoBriefService retombe sur son chemin keyword-first).
  *
+ * **Fail-closed sur la gouvernance RPC** : `RpcGateService` est une dépendance **obligatoire**
+ * (jamais `@Optional()`). Absent, `SupabaseBaseService.callRpc()` retomberait sur
+ * `GATE_NOT_INJECTED → ALLOW` (fail-open) ; ce reader étant la surface partagée qu'importeront les
+ * futurs consumers, une mauvaise composition Nest DOIT échouer au boot, pas exécuter la RPC sans gate.
+ * `RpcGateModule` est `@Global` → l'AppModule le résout sans tirer le write-side ni `DatabaseModule`.
+ *
+ * **Moindre-privilège au niveau MODULE et surface d'appel** (read découplé du writer/Gate service_role/
+ * queues) — PAS un principal DB SELECT-only : `SupabaseBaseService` construit toujours le client avec
+ * la clé service_role en PROD (nécessaire à la RPC actuelle, hors mode READ_ONLY anon d'ADR-028).
+ *
  * **DARK** : aucun consumer public ne l'utilise encore (aucune route/loader ne sert la projection) ;
  * ce module ne fait qu'unifier la lecture existante côté admin. Pas de flag de lecture, pas de canary.
  */
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
@@ -56,12 +66,11 @@ export class SeoProjectionReaderService extends SupabaseBaseService {
     SeoProjectionReaderService.name,
   );
 
-  constructor(
-    configService: ConfigService,
-    @Optional() rpcGate?: RpcGateService,
-  ) {
+  constructor(configService: ConfigService, rpcGate: RpcGateService) {
     super(configService);
-    if (rpcGate) this.rpcGate = rpcGate;
+    // Gate OBLIGATOIRE (jamais optionnel) : garantit qu'aucune composition ne peut
+    // exécuter la RPC via le fallback GATE_NOT_INJECTED → ALLOW de SupabaseBaseService.
+    this.rpcGate = rpcGate;
   }
 
   /**

--- a/backend/src/modules/seo-projection/seo-projection-reader.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-reader.service.ts
@@ -1,0 +1,102 @@
+/**
+ * SeoProjectionReaderService — propriétaire UNIQUE de la lecture d'enveloppe de projection SEO
+ * (RPC `get_active_seo_projection`, ADR-059 PR-7). Extraction behavior-identical depuis
+ * `SeoBriefService` (C0) : découple le READ du WRITE (moindre-privilège — le module lourd
+ * `SeoProjectionModule` exporte le WRITER + Gate `service_role` + queues, dont un consommateur
+ * de lecture n'a pas besoin).
+ *
+ * **Flag-neutre** : ne consulte AUCUN feature flag (le gating d'activation appartient à l'appelant).
+ * **Dégradation observable** (CLAUDE.md no-silent-fallback) : RPC en erreur / exception / projection
+ * absente → `{ envelope: null, degradeReason }` + log, JAMAIS de fabrication ni de repli silencieux.
+ * L'appelant décide quoi faire du null (SeoBriefService retombe sur son chemin keyword-first).
+ *
+ * **DARK** : aucun consumer public ne l'utilise encore (aucune route/loader ne sert la projection) ;
+ * ce module ne fait qu'unifier la lecture existante côté admin. Pas de flag de lecture, pas de canary.
+ */
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
+
+/** Bloc de contenu projeté (forme réglée par PR-0 : champs dans `content`). `truth_level` brut RPC. */
+export interface ProjectionBlock {
+  role?: string;
+  block_kind?: string;
+  content?: {
+    content_md?: string;
+    source_ids?: string[];
+    /** Brut depuis la RPC ; l'appelant (brief) le re-narrow en son propre `BlockTruthLevel`. */
+    truth_level?: string;
+    section?: string;
+    usefulness_target?: string;
+  } | null;
+}
+
+/** Enveloppe renvoyée par `get_active_seo_projection` (forme PR-7). */
+export interface ProjectionEnvelope {
+  entity_id: string;
+  entity_type: string;
+  slug: string;
+  facts: unknown[];
+  blocks: ProjectionBlock[];
+}
+
+/**
+ * Résultat de lecture. `envelope` non-null ⟺ `degradeReason` null. Sinon `degradeReason` porte la
+ * cause OBSERVABLE (`RPC error: <msg>` | `RPC exception` | `projection absente`) — jamais un null muet.
+ */
+export interface ProjectionReadResult {
+  envelope: ProjectionEnvelope | null;
+  degradeReason: string | null;
+}
+
+@Injectable()
+export class SeoProjectionReaderService extends SupabaseBaseService {
+  protected override readonly logger = new Logger(
+    SeoProjectionReaderService.name,
+  );
+
+  constructor(
+    configService: ConfigService,
+    @Optional() rpcGate?: RpcGateService,
+  ) {
+    super(configService);
+    if (rpcGate) this.rpcGate = rpcGate;
+  }
+
+  /**
+   * Lit la projection active pour `(entityId, role)` via la RPC `get_active_seo_projection`.
+   * Dégrade **observable** (null + `degradeReason` + log) sur erreur / exception / absence. Flag-neutre.
+   */
+  async readActiveProjection(
+    entityId: string,
+    role: string,
+  ): Promise<ProjectionReadResult> {
+    try {
+      const { data, error } = await this.callRpc<ProjectionEnvelope | null>(
+        'get_active_seo_projection',
+        { p_entity_id: entityId, p_role: role },
+        { source: 'api' },
+      );
+      if (error) {
+        this.logger.warn(
+          `projection RPC error ${entityId}: ${error.message} → dégradé (observable)`,
+        );
+        return { envelope: null, degradeReason: `RPC error: ${error.message}` };
+      }
+      const envelope = (data as ProjectionEnvelope | null) ?? null;
+      if (!envelope) {
+        this.logger.log(
+          `projection vide ${entityId} (non projetée) → dégradé (observable)`,
+        );
+        return { envelope: null, degradeReason: 'projection absente' };
+      }
+      return { envelope, degradeReason: null };
+    } catch (e) {
+      this.logger.warn(
+        `projection RPC exception ${entityId}: ${String(e)} → dégradé (observable)`,
+      );
+      return { envelope: null, degradeReason: 'RPC exception' };
+    }
+  }
+}

--- a/log.md
+++ b/log.md
@@ -567,3 +567,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/p2r3b-producer`
 - **Décision** : fix(seo-projection): idempotent regress-draft, per-run manifest, empty-export guard (+2 other commits)
 - **Sortie** : PR #1282 | commits b7f8c7601 18ae1a0ed 91d7a7dbd
+
+## 2026-07-16 — feat/c0-projection-read-module (auto)
+
+- **Branche** : `feat/c0-projection-read-module`
+- **Décision** : feat(seo-projection): extract dark projection reader (C0, behavior-identical)
+- **Sortie** : PR #1284 | commits 6c5d82c82


### PR DESCRIPTION
## C0 — Reader de projection unique, extraction **behavior-identical** (DARK)

Fondation du pilote-zéro P2-R3 (ADR-059 forward-writer, tronc commun). Extraction
**moindre-privilège** de la lecture d'enveloppe de projection hors de `SeoBriefService`
vers un propriétaire unique, sans aucun changement de comportement public et **sans
allumer quoi que ce soit**.

### Ce que fait cette PR

| Fichier | Changement |
|---|---|
| `seo-projection-reader.service.ts` **(nouveau)** | `SeoProjectionReaderService`, propriétaire **unique** de `callRpc('get_active_seo_projection', {p_entity_id, p_role}, {source:'api'})`. Dégradation **observable** (`{envelope:null, degradeReason}` + log) sur RPC error / exception / projection absente. **Flag-neutre** — le gating d'activation appartient à l'appelant. |
| `seo-projection-read.module.ts` **(nouveau)** | `SeoProjectionReadModule` **léger** : `imports:[ConfigModule]` uniquement. **Pas** de `DatabaseModule`, **pas** de write-side. `RpcGate`/`FeatureFlags` sont `@Global`, `ConfigModule` est `isGlobal` → la DI résout sans tirer le module lourd. |
| `seo-brief.service.ts` | Ne dérive **plus** de `SupabaseBaseService` ; **consomme** le reader (1 seule implémentation). Types `ProjectionBlock`/`ProjectionEnvelope` déplacés vers le reader. Comportement identique. |
| `admin.module.ts` | Importe `SeoProjectionReadModule` (jamais re-déclaré en `providers[]`). |
| `*.test.ts` | Golden de caractérisation `composeBrief` + unitaire reader. |

### Motivation

Découplage **READ / WRITE**. Le module lourd `SeoProjectionModule` exporte le **WRITER**
+ Gate `service_role` + queues — un consommateur de **lecture** n'en a pas besoin. C0
prépare le reader partagé du tronc commun (consommé plus tard par R3/R4/R6/R8), **sans**
introduire de dépendance write-side/Admin dans un futur runtime public.

### DARK — ce que cette PR ne fait PAS

- ❌ Aucun consumer public (aucune route/loader ne sert la projection).
- ❌ Aucun flag de lecture, aucune canary, aucune allowlist.
- ❌ Aucune activation PREPROD/PROD, aucun grant anon élargi.
- ❌ Aucune dépendance `BlogModule → AdminModule` (le câblage Blog viendra en PR-D).
- ❌ Aucune écriture, aucun changement de projection servie.

### Preuves *behavior-identical*

- **Golden `composeBrief`** (6 scénarios : flag OFF → 0 read, RPC error, RPC exception,
  projection absente, dérivation `vehicleSlug`, projection valide gate PASS) — **verts
  avant/après** l'extraction (stub `callRpc` avant, stub reader après → mêmes assertions).
- **Unitaire reader** (5) : mapping params `{p_entity_id, p_role}` + `{source:'api'}`, +
  les 3 dégradations observables + happy-path.
- Suites `seo-projection` + `admin` : **17 suites / 161 tests verts**. `tsc` 0, `eslint` 0,
  `check-role-purity` 0 contamination.

### Déploiement

Merge `main` = **PREPROD uniquement** (E2E Smoke + Lighthouse CI). **Pas** de PROD
(réservé au tag `v*`, GO owner). Reste **DARK** en PREPROD comme en PROD.

Réf. plan P2-R3-C0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
