### PR TITLE
feat(seo-projection): add dark r3 projection mapper (P2-R3-C, pure)

### DIFF
--- a/backend/src/modules/seo-projection/projection-r3.mapper.test.ts
+++ b/backend/src/modules/seo-projection/projection-r3.mapper.test.ts
@@ -9,7 +9,10 @@
  * (exports-seo.schema.json v1.1.0, ADR-086 — post-RPC : champs sous `content`,
  * source_ids préfixés db:|web:|oem:, truth_level ∈ db_owned|sourced|inferred|editorial).
  */
-import { PLANNABLE_SECTIONS } from '@config/keyword-plan.constants';
+import {
+  PLANNABLE_SECTIONS,
+  type PlannableSection,
+} from '@config/keyword-plan.constants';
 import type { ProjectionEnvelope } from './seo-projection-reader.service';
 import { mapR3Projection, R3_MAPPER_ROLE } from './projection-r3.mapper';
 
@@ -259,6 +262,163 @@ describe('mapR3Projection — 8. envelope vide ou sans R3 → résultat explicit
     const r = mapR3Projection(envelope(blocks));
     expect(r.mapped).toEqual([]);
     expect(r.ignoredNonR3).toBe(1);
+    expect(r.ready).toBe(false);
+  });
+});
+
+/**
+ * 9. Validation STRUCTURELLE des blocs (fail-closed) — un bloc R3 à section canonique dont les
+ * champs requis du contrat (exports-seo.schema.json v1.1.0 / SeoProjectionBlock) sont absents ou
+ * mal typés ne doit produire AUCUN slot : jamais de valeur synthétique ('' / []).
+ */
+describe('mapR3Projection — 9. bloc hors contrat → block_contract_invalid, aucun slot', () => {
+  it('section canonique + content_md absent → aucun slot, block_contract_invalid, ready=false', () => {
+    // Cas exact signalé en revue : le bloc ne porte que sa section.
+    const r = mapR3Projection(
+      envelope([{ role: 'R3_CONSEILS', content: { section: 'S1' } }]),
+    );
+    expect(r.slots.S1).toBeUndefined();
+    expect(r.mapped).toEqual([]);
+    expect(r.invalid).toHaveLength(1);
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.invalid[0].section).toBe('S1');
+    expect(r.invalid[0].detail).toContain('content_md');
+    expect(r.ready).toBe(false);
+  });
+
+  it('section canonique + content_md chaîne vide → block_contract_invalid', () => {
+    const r = mapR3Projection(
+      envelope([r3Block('S1', '', ['db:x'], 'db_owned')]),
+    );
+    expect(r.slots.S1).toBeUndefined();
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.invalid[0].detail).toContain('content_md');
+    expect(r.ready).toBe(false);
+  });
+
+  it('section canonique + truth_level inconnu → aucun slot, block_contract_invalid', () => {
+    const r = mapR3Projection(
+      envelope([r3Block('S1', 'contenu', ['db:x'], 'rag_generated')]),
+    );
+    expect(r.slots.S1).toBeUndefined();
+    expect(r.mapped).toEqual([]);
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.invalid[0].detail).toContain('truth_level');
+    expect(r.ready).toBe(false);
+  });
+
+  it('section canonique + source_ids non-array → aucun slot, block_contract_invalid', () => {
+    const r = mapR3Projection(
+      envelope([
+        {
+          role: 'R3_CONSEILS',
+          content: {
+            section: 'S1',
+            content_md: 'contenu',
+            source_ids: 'db:x',
+            truth_level: 'db_owned',
+          },
+        },
+      ]),
+    );
+    expect(r.slots.S1).toBeUndefined();
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.invalid[0].detail).toContain('source_ids');
+    expect(r.ready).toBe(false);
+  });
+
+  it('section canonique + source_ids contenant un non-string → aucun slot, block_contract_invalid', () => {
+    const r = mapR3Projection(
+      envelope([
+        {
+          role: 'R3_CONSEILS',
+          content: {
+            section: 'S1',
+            content_md: 'contenu',
+            source_ids: ['db:x', 42],
+            truth_level: 'db_owned',
+          },
+        },
+      ]),
+    );
+    expect(r.slots.S1).toBeUndefined();
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.invalid[0].detail).toContain('source_ids');
+    expect(r.ready).toBe(false);
+  });
+
+  it('section canonique + usefulness_target ni string ni null → block_contract_invalid', () => {
+    const r = mapR3Projection(
+      envelope([
+        {
+          role: 'R3_CONSEILS',
+          content: {
+            section: 'S1',
+            content_md: 'contenu',
+            source_ids: ['db:x'],
+            truth_level: 'db_owned',
+            usefulness_target: 7,
+          },
+        },
+      ]),
+    );
+    expect(r.slots.S1).toBeUndefined();
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.invalid[0].detail).toContain('usefulness_target');
+    expect(r.ready).toBe(false);
+  });
+
+  it('content absent / non-objet → aucun slot (section illisible → unmapped, jamais synthétique)', () => {
+    const r = mapR3Projection(
+      envelope([
+        { role: 'R3_CONSEILS' },
+        { role: 'R3_CONSEILS', content: null },
+        { role: 'R3_CONSEILS', content: 'pas-un-objet' },
+      ]),
+    );
+    expect(r.slots).toEqual({});
+    expect(r.mapped).toEqual([]);
+    expect(r.unmapped).toHaveLength(3);
+    expect(r.unmapped.every((u) => u.reason === 'missing_section')).toBe(true);
+    expect(r.ready).toBe(false);
+  });
+
+  it('un bloc hors contrat n’empêche pas les blocs valides d’être mappés, mais ready reste false', () => {
+    const r = mapR3Projection(
+      envelope([
+        r3Block('S1', 'valide', ['db:x'], 'db_owned'),
+        { role: 'R3_CONSEILS', content: { section: 'S3' } },
+      ]),
+    );
+    expect(r.mapped).toEqual(['S1']);
+    expect(r.slots.S3).toBeUndefined();
+    expect(r.invalid[0].kind).toBe('block_contract_invalid');
+    expect(r.ready).toBe(false);
+  });
+});
+
+/**
+ * 10. Durcissement `requiredSections` — une valeur hors canon est une FAUTE DE CONFIGURATION
+ * (ex. S2_DIAGNOSTIC au lieu de S2_DIAG), pas un simple contenu manquant.
+ */
+describe('mapR3Projection — 10. requiredSections hors canon → required_section_unknown', () => {
+  it('section requise hors canon → required_section_unknown (jamais required_slot_missing), ready=false', () => {
+    const r = mapR3Projection(
+      envelope([r3Block('S1', 'ok', ['db:x'], 'db_owned')]),
+      // Simule un requis venu d'un pack JSON/DB avec une faute de frappe.
+      { requiredSections: ['S2_DIAGNOSTIC'] as unknown as PlannableSection[] },
+    );
+    expect(r.invalid).toEqual([
+      {
+        kind: 'required_section_unknown',
+        section: 'S2_DIAGNOSTIC',
+        detail:
+          'section requise S2_DIAGNOSTIC hors vocabulaire canonique R3 (faute de configuration)',
+      },
+    ]);
+    expect(r.invalid.some((i) => i.kind === 'required_slot_missing')).toBe(
+      false,
+    );
     expect(r.ready).toBe(false);
   });
 });

--- a/backend/src/modules/seo-projection/projection-r3.mapper.test.ts
+++ b/backend/src/modules/seo-projection/projection-r3.mapper.test.ts
@@ -1,0 +1,264 @@
+/**
+ * ProjectionR3Mapper (P2-R3-C) — mapper PUR/DÉTERMINISTE ProjectionEnvelope → DTO R3.
+ *
+ * Ne teste QUE le mapping (aucune I/O, RPC, Supabase, flag, cache). Le vocabulaire de
+ * sections est le vocabulaire CANONIQUE existant (`PLANNABLE_SECTIONS` = enum
+ * `page-contract-r3.json` section_terms) — aucun vocabulaire fabriqué.
+ *
+ * Fixture réaliste : blocs conformes au contrat d'export/projection actuel
+ * (exports-seo.schema.json v1.1.0, ADR-086 — post-RPC : champs sous `content`,
+ * source_ids préfixés db:|web:|oem:, truth_level ∈ db_owned|sourced|inferred|editorial).
+ */
+import { PLANNABLE_SECTIONS } from '@config/keyword-plan.constants';
+import type { ProjectionEnvelope } from './seo-projection-reader.service';
+import { mapR3Projection, R3_MAPPER_ROLE } from './projection-r3.mapper';
+
+// Le vocabulaire canonique existant EST le référentiel de slots reconnus.
+const CANON = PLANNABLE_SECTIONS as readonly string[];
+
+/** Bloc de projection R3 conforme au contrat (post-RPC : champs sous `content`). */
+function r3Block(
+  section: string | null,
+  content_md: string,
+  source_ids: string[],
+  truth_level: string,
+  usefulness_target: string | null = null,
+) {
+  return {
+    role: 'R3_CONSEILS',
+    content: {
+      content_md,
+      source_ids,
+      truth_level,
+      section,
+      usefulness_target,
+    },
+  };
+}
+
+function envelope(
+  blocks: unknown[],
+  entity_id = 'gamme:filtre-a-huile',
+): ProjectionEnvelope {
+  return {
+    entity_id,
+    entity_type: 'gamme',
+    slug: 'filtre-a-huile',
+    facts: [],
+    blocks: blocks as ProjectionEnvelope['blocks'],
+  };
+}
+
+/** 3 blocs R3 canoniques réalistes (S1, S2_DIAG, S4_DEPOSE). */
+function threeValidR3() {
+  return [
+    r3Block(
+      'S1',
+      '## Checklist\n- vérifier le filtre',
+      ['db:pieces_gamme'],
+      'db_owned',
+    ),
+    r3Block(
+      'S2_DIAG',
+      '| symptôme | cause |\n|---|---|\n| perte puissance | filtre colmaté |',
+      ['web:evidence-42', 'oem:bosch-1'],
+      'sourced',
+      'diagnostic',
+    ),
+    r3Block(
+      'S4_DEPOSE',
+      '1. Débrancher\n2. Déposer',
+      ['specialist:garage-durand'],
+      'sourced',
+    ),
+  ];
+}
+
+describe('mapR3Projection — sanity du référentiel canonique', () => {
+  it('les section_id de test appartiennent au vocabulaire canonique (0 invention)', () => {
+    expect(CANON).toContain('S1');
+    expect(CANON).toContain('S2_DIAG');
+    expect(CANON).toContain('S4_DEPOSE');
+    expect(R3_MAPPER_ROLE).toBe('R3_CONSEILS');
+  });
+});
+
+describe('mapR3Projection — 1. projection R3 valide → DTO exact attendu', () => {
+  it('mappe chaque section canonique dans son slot, verbatim, ready=true', () => {
+    const r = mapR3Projection(envelope(threeValidR3()));
+    expect(r.role).toBe('R3_CONSEILS');
+    expect(r.entityId).toBe('gamme:filtre-a-huile');
+    expect(r.mapped).toEqual(['S1', 'S2_DIAG', 'S4_DEPOSE']);
+    expect(r.unmapped).toEqual([]);
+    expect(r.invalid).toEqual([]);
+    expect(r.ignoredNonR3).toBe(0);
+    expect(r.ready).toBe(true);
+    expect(r.slots.S1).toEqual({
+      section: 'S1',
+      content_md: '## Checklist\n- vérifier le filtre',
+      source_ids: ['db:pieces_gamme'],
+      truth_level: 'db_owned',
+      usefulness_target: null,
+    });
+    expect(r.slots.S2_DIAG).toEqual({
+      section: 'S2_DIAG',
+      content_md:
+        '| symptôme | cause |\n|---|---|\n| perte puissance | filtre colmaté |',
+      source_ids: ['web:evidence-42', 'oem:bosch-1'],
+      truth_level: 'sourced',
+      usefulness_target: 'diagnostic',
+    });
+  });
+});
+
+describe('mapR3Projection — 2. mélange R3/R4/R6 → seuls les blocs R3 mappés', () => {
+  it('ignore les rôles non-R3 (comptés) et ne mappe que R3', () => {
+    const blocks = [
+      r3Block('S1', 'conseil R3', ['db:x'], 'db_owned'),
+      {
+        role: 'R4_REFERENCE',
+        content: {
+          content_md: 'ref R4',
+          source_ids: ['db:y'],
+          truth_level: 'db_owned',
+          section: 'S1',
+          usefulness_target: null,
+        },
+      },
+      {
+        role: 'R6_GUIDE_ACHAT',
+        content: {
+          content_md: 'guide R6',
+          source_ids: ['db:z'],
+          truth_level: 'db_owned',
+          section: 'S3',
+          usefulness_target: null,
+        },
+      },
+    ];
+    const r = mapR3Projection(envelope(blocks));
+    expect(r.mapped).toEqual(['S1']);
+    expect(Object.keys(r.slots)).toEqual(['S1']);
+    expect(r.ignoredNonR3).toBe(2);
+    expect(r.slots.S1.content_md).toBe('conseil R3');
+  });
+});
+
+describe('mapR3Projection — 3. ordre des blocs inversé → résultat identique', () => {
+  it('produit un DTO identique quel que soit l’ordre d’entrée', () => {
+    const fwd = mapR3Projection(envelope(threeValidR3()));
+    const rev = mapR3Projection(envelope([...threeValidR3()].reverse()));
+    expect(rev).toEqual(fwd);
+  });
+});
+
+describe('mapR3Projection — 4. section inconnue → exclue + diagnostic observable', () => {
+  it('exclut les sections non canoniques / manquantes sans les interpréter', () => {
+    const blocks = [
+      r3Block('S1', 'ok', ['db:x'], 'db_owned'),
+      r3Block('S99_INVENTED', 'section hors canon', ['web:e1'], 'sourced'),
+      r3Block(null, 'section absente', ['web:e2'], 'sourced'),
+    ];
+    const r = mapR3Projection(envelope(blocks));
+    expect(r.mapped).toEqual(['S1']);
+    expect(Object.keys(r.slots)).toEqual(['S1']);
+    expect(r.unmapped).toEqual([
+      { section: null, reason: 'missing_section', truth_level: 'sourced' },
+      {
+        section: 'S99_INVENTED',
+        reason: 'unknown_section',
+        truth_level: 'sourced',
+      },
+    ]);
+    // Section inconnue = exclue + observable, PAS invalid.
+    expect(r.invalid).toEqual([]);
+  });
+});
+
+describe('mapR3Projection — 5. deux blocs → même slot → invalid, pas de last-write-wins', () => {
+  it('refuse la collision : aucun slot émis, résultat invalid', () => {
+    const blocks = [
+      r3Block('S1', 'PREMIER contenu', ['db:a'], 'db_owned'),
+      r3Block('S1', 'SECOND contenu', ['db:b'], 'sourced'),
+    ];
+    const r = mapR3Projection(envelope(blocks));
+    expect(r.slots.S1).toBeUndefined(); // pas de last-write-wins
+    expect(r.mapped).not.toContain('S1');
+    expect(r.invalid).toEqual([
+      {
+        kind: 'slot_collision',
+        section: 'S1',
+        detail: '2 blocs R3 revendiquent le slot S1',
+      },
+    ]);
+    expect(r.ready).toBe(false);
+  });
+});
+
+describe('mapR3Projection — 6. slot requis absent → invalid/incomplet, jamais prêt', () => {
+  it('marque required_slot_missing et ready=false quand un requis manque', () => {
+    const r = mapR3Projection(
+      envelope([r3Block('S1', 'seul S1', ['db:x'], 'db_owned')]),
+      { requiredSections: ['S1', 'S2_DIAG'] },
+    );
+    expect(r.mapped).toEqual(['S1']);
+    expect(r.invalid).toEqual([
+      {
+        kind: 'required_slot_missing',
+        section: 'S2_DIAG',
+        detail: 'slot requis S2_DIAG absent de la projection',
+      },
+    ]);
+    expect(r.ready).toBe(false);
+  });
+});
+
+describe('mapR3Projection — 7. provenance et contenu conservés byte-for-byte', () => {
+  it('préserve content_md/source_ids/truth_level/usefulness_target verbatim et ne mute pas l’entrée', () => {
+    const md = 'Ligne 1\r\n  espaces  \nÉÀÇ — “guillemets” 日本語';
+    const sids = ['db:pieces_gamme', 'web:ev-7', 'oem:mann-9'];
+    const block = r3Block('S3', md, sids, 'sourced', 'compatibility');
+    const env = envelope([block]);
+    const snapshotIn = JSON.stringify(env);
+
+    const r = mapR3Projection(env);
+    expect(r.slots.S3.content_md).toBe(md);
+    expect(r.slots.S3.source_ids).toEqual(sids);
+    expect(r.slots.S3.truth_level).toBe('sourced');
+    expect(r.slots.S3.usefulness_target).toBe('compatibility');
+    // Aucune reformulation / complétion.
+    expect(r.slots.S3.content_md.length).toBe(md.length);
+    // Entrée non mutée.
+    expect(JSON.stringify(env)).toBe(snapshotIn);
+  });
+});
+
+describe('mapR3Projection — 8. envelope vide ou sans R3 → résultat explicite, aucune exception', () => {
+  it('blocks vide → résultat explicite non-prêt sans throw', () => {
+    const r = mapR3Projection(envelope([]));
+    expect(r.mapped).toEqual([]);
+    expect(r.slots).toEqual({});
+    expect(r.unmapped).toEqual([]);
+    expect(r.invalid).toEqual([]);
+    expect(r.ready).toBe(false);
+  });
+
+  it('aucun bloc R3 (que du R4) → explicite, ignoredNonR3 comptés, non-prêt', () => {
+    const blocks = [
+      {
+        role: 'R4_REFERENCE',
+        content: {
+          content_md: 'r4',
+          source_ids: ['db:y'],
+          truth_level: 'db_owned',
+          section: 'S1',
+          usefulness_target: null,
+        },
+      },
+    ];
+    const r = mapR3Projection(envelope(blocks));
+    expect(r.mapped).toEqual([]);
+    expect(r.ignoredNonR3).toBe(1);
+    expect(r.ready).toBe(false);
+  });
+});

--- a/backend/src/modules/seo-projection/projection-r3.mapper.ts
+++ b/backend/src/modules/seo-projection/projection-r3.mapper.ts
@@ -12,10 +12,17 @@
  * préfixée db:|web:|oem:…) / `truth_level` / `usefulness_target` **verbatim**. Rien n'est généré,
  * complété ni reformulé.
  *
+ * **Fail-closed sur le contrat de bloc** : un bloc qui revendique un slot canonique DOIT satisfaire
+ * le contrat (`content_md` non-vide · `source_ids` tableau de chaînes · `truth_level` ∈
+ * `BlockTruthLevel` · `usefulness_target` string|null si présent). Sinon → `block_contract_invalid`,
+ * **aucun slot émis** : jamais de valeur synthétique (`''` / `[]`) substituée à un champ requis —
+ * ce serait un fail-open déguisé en « verbatim ». Un `content` absent/non-objet rend la section
+ * illisible : le bloc ne revendique aucun slot → `unmapped`.
+ *
  * **Classification observable** : `mapped` (slot rempli) · `unmapped` (bloc R3 dont la section est
- * absente ou hors-canon — exclu, jamais interprété) · `invalid` (collision de slot OU slot requis
- * absent). `ready` = aucun `invalid` ET au moins un slot mappé — une projection vide/incomplète
- * n'est JAMAIS présentée comme prête.
+ * absente ou hors-canon — exclu, jamais interprété) · `invalid` (collision de slot · bloc hors
+ * contrat · slot requis absent · section requise hors canon). `ready` = aucun `invalid` ET au moins
+ * un slot mappé — une projection vide/incomplète n'est JAMAIS présentée comme prête.
  *
  * **Politique de complétude déléguée** : `requiredSections` est **injecté par l'appelant** (des
  * section_id canoniques ; défaut vide). Le mapper n'affirme aucun contrat de rendu non ratifié
@@ -24,7 +31,11 @@
  *
  * **DARK** : aucun consumer public ne l'appelle (le branchement runtime R3 = PR P2-R3-D, séparée).
  */
-import { PLANNABLE_SECTIONS } from '@config/keyword-plan.constants';
+import {
+  PLANNABLE_SECTIONS,
+  type PlannableSection,
+} from '@config/keyword-plan.constants';
+import type { BlockTruthLevel } from './seo-projection.types';
 import type {
   ProjectionBlock,
   ProjectionEnvelope,
@@ -36,6 +47,25 @@ export const R3_MAPPER_ROLE = 'R3_CONSEILS' as const;
 /** Vocabulaire canonique des sections R3 (SoT existant — aucune invention locale). */
 const CANONICAL_R3_SECTIONS: readonly string[] = PLANNABLE_SECTIONS;
 
+/**
+ * Valeurs contractuelles de `truth_level` (SoT : `BlockTruthLevel`, miroir de
+ * `exports-seo.schema.json`). Le `Record` force l'**exhaustivité** : ajouter/retirer une valeur au
+ * type casse la compilation ici — aucune liste parallèle qui dériverait en silence.
+ */
+const CONTRACT_TRUTH_LEVELS: Record<BlockTruthLevel, true> = {
+  db_owned: true,
+  sourced: true,
+  inferred: true,
+  editorial: true,
+};
+
+function isContractTruthLevel(value: unknown): value is BlockTruthLevel {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(CONTRACT_TRUTH_LEVELS, value)
+  );
+}
+
 /** Rang canonique d'une section (ordre déterministe des sorties). -1 si hors-canon. */
 function canonicalRank(section: string): number {
   return CANONICAL_R3_SECTIONS.indexOf(section);
@@ -46,12 +76,49 @@ function strcmp(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+/** Contenu de bloc VALIDÉ contre le contrat — aucun champ requis absent ni mal typé. */
+interface ValidatedR3Content {
+  content_md: string;
+  source_ids: string[];
+  truth_level: BlockTruthLevel;
+  usefulness_target?: string | null;
+}
+
+/**
+ * Champs du bloc hors contrat (`SeoProjectionBlock` / `exports-seo.schema.json` v1.1.0 :
+ * `content_md`, `source_ids`, `truth_level` REQUIS ; `usefulness_target` optionnel `string|null`).
+ * Renvoie la liste des champs fautifs, dans un ordre fixe (déterminisme du `detail`).
+ */
+function blockContractViolations(content: Record<string, unknown>): string[] {
+  const bad: string[] = [];
+  if (
+    typeof content.content_md !== 'string' ||
+    content.content_md.length === 0
+  ) {
+    bad.push('content_md');
+  }
+  if (
+    !Array.isArray(content.source_ids) ||
+    !content.source_ids.every((s) => typeof s === 'string')
+  ) {
+    bad.push('source_ids');
+  }
+  if (!isContractTruthLevel(content.truth_level)) {
+    bad.push('truth_level');
+  }
+  const target = content.usefulness_target;
+  if (target !== undefined && target !== null && typeof target !== 'string') {
+    bad.push('usefulness_target');
+  }
+  return bad;
+}
+
 /** Slot R3 mappé — contenu de bloc préservé verbatim (aucune transformation). */
 export interface R3Slot {
   section: string;
   content_md: string;
   source_ids: string[];
-  truth_level: string;
+  truth_level: BlockTruthLevel;
   usefulness_target: string | null;
 }
 
@@ -62,9 +129,18 @@ export interface R3UnmappedBlock {
   truth_level: string | null;
 }
 
-/** Entrée invalide : collision de slot ou slot requis manquant. */
+/**
+ * Entrée invalide. `block_contract_invalid` = bloc revendiquant un slot canonique mais violant le
+ * contrat (fail-closed : aucun slot, aucune valeur synthétique). `required_section_unknown` =
+ * faute de configuration des requis (ex. `S2_DIAGNOSTIC` au lieu de `S2_DIAG`), jamais présentée
+ * comme un simple contenu manquant.
+ */
 export interface R3InvalidEntry {
-  kind: 'slot_collision' | 'required_slot_missing';
+  kind:
+    | 'slot_collision'
+    | 'required_slot_missing'
+    | 'block_contract_invalid'
+    | 'required_section_unknown';
   section: string;
   detail: string;
 }
@@ -85,22 +161,26 @@ export interface R3MapperResult {
 }
 
 export interface R3MapperOptions {
-  /** Sections canoniques requises (injectées par l'appelant ; défaut : aucune). */
-  requiredSections?: readonly string[];
+  /**
+   * Sections canoniques requises (injectées par l'appelant ; défaut : aucune). Typées via le SoT
+   * `PlannableSection`, MAIS revalidées au runtime : les requis pourront venir d'un pack JSON ou
+   * de la DB, hors garantie du compilateur.
+   */
+  requiredSections?: readonly PlannableSection[];
 }
 
-/** Copie verbatim du contenu d'un bloc dans un slot (aucune reformulation). */
-function toSlot(
-  section: string,
-  content: NonNullable<ProjectionBlock['content']>,
-): R3Slot {
+/**
+ * Copie verbatim du contenu VALIDÉ dans un slot. Aucune valeur synthétique : les champs requis ont
+ * déjà été vérifiés par `blockContractViolations` (un bloc fautif n'arrive jamais ici).
+ */
+function toSlot(section: string, content: ValidatedR3Content): R3Slot {
   return {
     section,
-    content_md: content.content_md ?? '',
-    source_ids: Array.isArray(content.source_ids)
-      ? [...content.source_ids]
-      : [],
-    truth_level: content.truth_level ?? '',
+    content_md: content.content_md,
+    source_ids: [...content.source_ids],
+    truth_level: content.truth_level,
+    // Champ OPTIONNEL du contrat (`string | null`) : absent ⇒ null. Normalisation d'un optionnel,
+    // jamais une valeur de remplacement pour un champ requis.
     usefulness_target: content.usefulness_target ?? null,
   };
 }
@@ -125,24 +205,32 @@ export function mapR3Projection(
   const invalid: R3InvalidEntry[] = [];
   let ignoredNonR3 = 0;
 
-  // Regroupe les blocs R3 par section canonique (order-independent : seul le comptage compte).
-  const bySection = new Map<
-    string,
-    NonNullable<ProjectionBlock['content']>[]
-  >();
+  // Regroupe les blocs R3 VALIDÉS par section canonique (order-independent : seul le comptage compte).
+  const bySection = new Map<string, ValidatedR3Content[]>();
 
   for (const block of blocks) {
     if (block?.role !== R3_MAPPER_ROLE) {
       ignoredNonR3 += 1;
       continue;
     }
-    const content = block.content ?? {};
+    const raw: unknown = block.content;
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      // `content` absent / non-objet ⇒ section illisible ⇒ le bloc ne revendique aucun slot.
+      unmapped.push({
+        section: null,
+        reason: 'missing_section',
+        truth_level: null,
+      });
+      continue;
+    }
+    const content = raw as Record<string, unknown>;
+    const rawTruth = content.truth_level;
+    const truthLevel = typeof rawTruth === 'string' ? rawTruth : null;
     const section = content.section;
-    const truthLevel = content.truth_level ?? null;
 
     if (typeof section !== 'string' || section.length === 0) {
       unmapped.push({
-        section: typeof section === 'string' ? section : null,
+        section: null,
         reason: 'missing_section',
         truth_level: truthLevel,
       });
@@ -156,8 +244,20 @@ export function mapR3Projection(
       });
       continue;
     }
+
+    // Le bloc revendique un slot canonique ⇒ le contrat de bloc devient OBLIGATOIRE (fail-closed).
+    const violations = blockContractViolations(content);
+    if (violations.length > 0) {
+      invalid.push({
+        kind: 'block_contract_invalid',
+        section,
+        detail: `champs hors contrat : ${violations.join(', ')}`,
+      });
+      continue; // aucun slot émis, aucune valeur synthétique ('' / [])
+    }
+
     const group = bySection.get(section) ?? [];
-    group.push(content);
+    group.push(content as unknown as ValidatedR3Content);
     bySection.set(section, group);
   }
 
@@ -178,8 +278,18 @@ export function mapR3Projection(
     }
   }
 
-  // Slots requis absents (politique injectée par l'appelant).
+  // Slots requis (politique injectée par l'appelant) — revalidés au runtime.
   for (const section of requiredSections) {
+    if (canonicalRank(section) < 0) {
+      // Faute de configuration (ex. S2_DIAGNOSTIC vs S2_DIAG) : ne JAMAIS la présenter comme un
+      // simple contenu manquant, sinon un requis mal orthographié deviendrait indétectable.
+      invalid.push({
+        kind: 'required_section_unknown',
+        section,
+        detail: `section requise ${section} hors vocabulaire canonique R3 (faute de configuration)`,
+      });
+      continue;
+    }
     if (!(section in slots)) {
       invalid.push({
         kind: 'required_slot_missing',
@@ -199,7 +309,9 @@ export function mapR3Projection(
   invalid.sort(
     (a, b) =>
       canonicalRank(a.section) - canonicalRank(b.section) ||
-      strcmp(a.kind, b.kind),
+      strcmp(a.section, b.section) ||
+      strcmp(a.kind, b.kind) ||
+      strcmp(a.detail, b.detail),
   );
 
   return {

--- a/backend/src/modules/seo-projection/projection-r3.mapper.ts
+++ b/backend/src/modules/seo-projection/projection-r3.mapper.ts
@@ -1,0 +1,215 @@
+/**
+ * ProjectionR3Mapper (P2-R3-C) — mappe une `ProjectionEnvelope` (sortie du reader C0,
+ * RPC `get_active_seo_projection`) vers un **DTO R3 final**. ADR-059 forward-writer, tronc commun.
+ *
+ * **PUR & DÉTERMINISTE** : fonction sans I/O, sans RPC, sans Supabase, sans feature flag, sans cache,
+ * sans dépendance au writer, sans import de route publique, sans fallback legacy. Même entrée (à
+ * l'ordre des blocs près) ⇒ même sortie.
+ *
+ * **Ne fabrique aucun contenu** : sélectionne les blocs `R3_CONSEILS`, mappe UNIQUEMENT les sections
+ * du vocabulaire CANONIQUE existant (`PLANNABLE_SECTIONS` = enum `page-contract-r3.json` section_terms
+ * — 0 vocabulaire inventé) vers leur slot, et préserve `content_md` / `source_ids` (provenance
+ * préfixée db:|web:|oem:…) / `truth_level` / `usefulness_target` **verbatim**. Rien n'est généré,
+ * complété ni reformulé.
+ *
+ * **Classification observable** : `mapped` (slot rempli) · `unmapped` (bloc R3 dont la section est
+ * absente ou hors-canon — exclu, jamais interprété) · `invalid` (collision de slot OU slot requis
+ * absent). `ready` = aucun `invalid` ET au moins un slot mappé — une projection vide/incomplète
+ * n'est JAMAIS présentée comme prête.
+ *
+ * **Politique de complétude déléguée** : `requiredSections` est **injecté par l'appelant** (des
+ * section_id canoniques ; défaut vide). Le mapper n'affirme aucun contrat de rendu non ratifié
+ * (D1-contracts `ProjectionRenderContract` = décision vault) ; la source canonique éventuelle des
+ * requis est le pack conseil (`requiredSections` par niveau de pack).
+ *
+ * **DARK** : aucun consumer public ne l'appelle (le branchement runtime R3 = PR P2-R3-D, séparée).
+ */
+import { PLANNABLE_SECTIONS } from '@config/keyword-plan.constants';
+import type {
+  ProjectionBlock,
+  ProjectionEnvelope,
+} from './seo-projection-reader.service';
+
+/** Rôle exact traité par ce mapper (page conseils). */
+export const R3_MAPPER_ROLE = 'R3_CONSEILS' as const;
+
+/** Vocabulaire canonique des sections R3 (SoT existant — aucune invention locale). */
+const CANONICAL_R3_SECTIONS: readonly string[] = PLANNABLE_SECTIONS;
+
+/** Rang canonique d'une section (ordre déterministe des sorties). -1 si hors-canon. */
+function canonicalRank(section: string): number {
+  return CANONICAL_R3_SECTIONS.indexOf(section);
+}
+
+/** Comparaison de chaînes par code-point — déterministe, indépendante de la locale ICU. */
+function strcmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Slot R3 mappé — contenu de bloc préservé verbatim (aucune transformation). */
+export interface R3Slot {
+  section: string;
+  content_md: string;
+  source_ids: string[];
+  truth_level: string;
+  usefulness_target: string | null;
+}
+
+/** Bloc R3 non mappé (section absente ou hors-canon) — signalé, jamais interprété. */
+export interface R3UnmappedBlock {
+  section: string | null;
+  reason: 'missing_section' | 'unknown_section';
+  truth_level: string | null;
+}
+
+/** Entrée invalide : collision de slot ou slot requis manquant. */
+export interface R3InvalidEntry {
+  kind: 'slot_collision' | 'required_slot_missing';
+  section: string;
+  detail: string;
+}
+
+/** DTO R3 final produit par le mapper. */
+export interface R3MapperResult {
+  entityId: string;
+  role: typeof R3_MAPPER_ROLE;
+  /** true ⟺ 0 `invalid` ET ≥1 slot mappé. Une projection vide/incomplète n'est jamais « prête ». */
+  ready: boolean;
+  /** Slots mappés, clés = section_id canonique (ordre d'insertion = ordre canonique). */
+  slots: Record<string, R3Slot>;
+  mapped: string[];
+  unmapped: R3UnmappedBlock[];
+  invalid: R3InvalidEntry[];
+  /** Nombre de blocs non-R3 ignorés (observabilité). */
+  ignoredNonR3: number;
+}
+
+export interface R3MapperOptions {
+  /** Sections canoniques requises (injectées par l'appelant ; défaut : aucune). */
+  requiredSections?: readonly string[];
+}
+
+/** Copie verbatim du contenu d'un bloc dans un slot (aucune reformulation). */
+function toSlot(
+  section: string,
+  content: NonNullable<ProjectionBlock['content']>,
+): R3Slot {
+  return {
+    section,
+    content_md: content.content_md ?? '',
+    source_ids: Array.isArray(content.source_ids)
+      ? [...content.source_ids]
+      : [],
+    truth_level: content.truth_level ?? '',
+    usefulness_target: content.usefulness_target ?? null,
+  };
+}
+
+/**
+ * Mappe la projection vers le DTO R3. Pur/déterministe. Ne lève jamais sur enveloppe vide/sans R3 :
+ * renvoie un résultat explicite non-prêt.
+ */
+export function mapR3Projection(
+  envelope: ProjectionEnvelope,
+  options: R3MapperOptions = {},
+): R3MapperResult {
+  const entityId = envelope?.entity_id ?? '';
+  const requiredSections = options.requiredSections ?? [];
+  const blocks: ProjectionBlock[] = Array.isArray(envelope?.blocks)
+    ? envelope.blocks
+    : [];
+
+  const slots: Record<string, R3Slot> = {};
+  const mapped: string[] = [];
+  const unmapped: R3UnmappedBlock[] = [];
+  const invalid: R3InvalidEntry[] = [];
+  let ignoredNonR3 = 0;
+
+  // Regroupe les blocs R3 par section canonique (order-independent : seul le comptage compte).
+  const bySection = new Map<
+    string,
+    NonNullable<ProjectionBlock['content']>[]
+  >();
+
+  for (const block of blocks) {
+    if (block?.role !== R3_MAPPER_ROLE) {
+      ignoredNonR3 += 1;
+      continue;
+    }
+    const content = block.content ?? {};
+    const section = content.section;
+    const truthLevel = content.truth_level ?? null;
+
+    if (typeof section !== 'string' || section.length === 0) {
+      unmapped.push({
+        section: typeof section === 'string' ? section : null,
+        reason: 'missing_section',
+        truth_level: truthLevel,
+      });
+      continue;
+    }
+    if (canonicalRank(section) < 0) {
+      unmapped.push({
+        section,
+        reason: 'unknown_section',
+        truth_level: truthLevel,
+      });
+      continue;
+    }
+    const group = bySection.get(section) ?? [];
+    group.push(content);
+    bySection.set(section, group);
+  }
+
+  // Émission des slots / collisions en ordre canonique (déterministe).
+  for (const section of CANONICAL_R3_SECTIONS) {
+    const group = bySection.get(section);
+    if (!group || group.length === 0) continue;
+    if (group.length === 1) {
+      slots[section] = toSlot(section, group[0]);
+      mapped.push(section);
+    } else {
+      // Collision : aucun slot émis (jamais de last-write-wins).
+      invalid.push({
+        kind: 'slot_collision',
+        section,
+        detail: `${group.length} blocs R3 revendiquent le slot ${section}`,
+      });
+    }
+  }
+
+  // Slots requis absents (politique injectée par l'appelant).
+  for (const section of requiredSections) {
+    if (!(section in slots)) {
+      invalid.push({
+        kind: 'required_slot_missing',
+        section,
+        detail: `slot requis ${section} absent de la projection`,
+      });
+    }
+  }
+
+  // Tris déterministes (indépendants de l'ordre d'entrée ET de la locale).
+  unmapped.sort(
+    (a, b) =>
+      strcmp(a.section ?? '', b.section ?? '') ||
+      strcmp(a.reason, b.reason) ||
+      strcmp(a.truth_level ?? '', b.truth_level ?? ''),
+  );
+  invalid.sort(
+    (a, b) =>
+      canonicalRank(a.section) - canonicalRank(b.section) ||
+      strcmp(a.kind, b.kind),
+  );
+
+  return {
+    entityId,
+    role: R3_MAPPER_ROLE,
+    ready: invalid.length === 0 && mapped.length > 0,
+    slots,
+    mapped,
+    unmapped,
+    invalid,
+    ignoredNonR3,
+  };
+}

--- a/log.md
+++ b/log.md
@@ -573,3 +573,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/c0-projection-read-module`
 - **Décision** : feat(seo-projection): extract dark projection reader (C0, behavior-identical)
 - **Sortie** : PR #1284 | commits 6c5d82c82
+
+## 2026-07-16 — feat/p2-r3c-projection-r3-mapper (auto)
+
+- **Branche** : `feat/p2-r3c-projection-r3-mapper`
+- **Décision** : feat(seo-projection): add dark r3 projection mapper (P2-R3-C, pure)
+- **Sortie** : PR #1286 | commits 645e33eea


### PR DESCRIPTION
## P2-R3-C — `ProjectionR3Mapper`, mapper **pur/déterministe** (DARK)

Fondation du pilote-zéro P2-R3 (ADR-059 forward-writer, tronc commun). **Uniquement le mapper** —
aucun consumer public, aucun branchement runtime. Le branchement R3 (reader → consumer, flag,
allowlist, cache/headers, rendu public) = **PR P2-R3-D séparée**, GO owner distinct.

### Contrat

`(ProjectionEnvelope, rôle R3_CONSEILS)` → **DTO R3 final** + diagnostics explicites. Fonction pure :
```ts
mapR3Projection(envelope, { requiredSections? }) → { entityId, role, ready, slots, mapped, unmapped, invalid, ignoredNonR3 }
```

### Garanties (toutes testées)

- **Pur** : sans I/O · RPC · Supabase · feature flag · cache · dépendance writer · import de route
  publique · fallback legacy.
- **Sélection R3 seule** : ne mappe que les blocs `R3_CONSEILS` ; les autres rôles sont ignorés et
  **comptés** (`ignoredNonR3`).
- **Vocabulaire canonique existant** : mappe uniquement les sections de `PLANNABLE_SECTIONS`
  (= enum `page-contract-r3.json` `section_terms`) — **0 vocabulaire inventé**.
- **Verbatim** : `content_md` / `source_ids` (provenance préfixée `db:`|`web:`|`oem:`…) /
  `truth_level` / `usefulness_target` préservés byte-for-byte. Rien n'est généré, complété ni reformulé.
  L'entrée n'est jamais mutée.
- **Inconnu ≠ interprété** : section absente/hors-canon → `unmapped` (exclue + observable), pas invalid.
- **Collisions refusées** : deux blocs → même slot ⇒ **aucun slot émis** (pas de last-write-wins),
  entrée `invalid`.
- **Déterministe** : même résultat quel que soit l'ordre des blocs (regroupement + tri par code-point,
  hors-locale).
- **Classification claire** : `mapped` / `unmapped` / `invalid` ; `ready` = 0 `invalid` **ET** ≥1 slot
  mappé — une projection vide/incomplète n'est **jamais** présentée comme prête.

### Complétude déléguée (anti-invention de canon)

`requiredSections` est **injecté par l'appelant** (section_id canoniques ; défaut vide). Le mapper
**n'affirme aucun** `ProjectionRenderContract` non ratifié (D1-contracts = décision vault). Source
canonique éventuelle des requis = le pack conseil (`requiredSections` par niveau).

### TDD + fixture réaliste

8 tests mandatés (+ sanity du référentiel) écrits **d'abord** et vus échouer (module absent), puis
implémentation minimale : (1) projection valide → DTO exact · (2) mélange R3/R4/R6 → seuls R3 mappés ·
(3) ordre inversé → identique · (4) section inconnue → exclue + diagnostic · (5) collision → invalid,
pas de last-write-wins · (6) slot requis absent → invalid/non-prêt · (7) provenance/contenu byte-for-byte ·
(8) envelope vide/sans R3 → explicite, sans exception. Fixture conforme au contrat d'export/projection
actuel (`exports-seo.schema.json` v1.1.0, ADR-086).

### Portée & vérif

Purement **additif** : 2 fichiers (`projection-r3.mapper.ts` + test). **0** module / route / loader /
meta / flag / Redis / table / grant modifié. `tsc` 0 · `eslint` 0 · `check-role-purity` 0 ·
`seo-projection` : **7 suites / 57 tests verts**.

### DARK / déploiement

Merge `main` = **PREPROD only**. **Pas** de PROD (tag `v*` + GO owner). Le mapper peut être mergé
sans rendre une seule projection publique — merge soumis à revue owner.

Réf. plan P2-R3-C. Suivant (NO-GO tant que C non revu+vert) : **P2-R3-D** en PR séparée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
