### PR TITLE
fix(deploy): make PROD rollback real and gate the deploy on SSR

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -66,6 +66,15 @@ jobs:
         # matches). Guards the rule's meaning as B1..B8 close (plan §Fermeture B3).
         run: npm run audit:rag-authority-rule:test
 
+      - name: ⏪ PROD rollback path — behavioural proof vs stubbed docker (BLOCKING)
+        # The rollback only ever runs when PROD is already broken, so it is the
+        # least-exercised and most safety-critical code in the deploy. `bash -n`
+        # and static step ordering prove nothing about it. This executes
+        # scripts/ci/prod-rollback.sh against a stubbed docker and asserts the
+        # OLD image is really restored + that a mismatch cannot silently pass
+        # (the regression that made the previous rollback a no-op).
+        run: npm run test:prod-rollback
+
       - name: 🗂️ EDITORIAL_AUTHORITY_SINKS registry invariants (BLOCKING)
         # Pins the exact P0 sink set (audit §6): 2 served-tracked + 15 ratchet-blind,
         # each evidence-linked, no rN wildcard. The blind rows justify the registry.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,25 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      break_glass_no_rollback_point:
+        description: >-
+          BREAK-GLASS. Deploy even though no PROD container is running, i.e. with
+          NO rollback point. Only legitimate for a first deploy or a host rebuild.
+          On an existing PROD, a missing container means something is already
+          wrong — deploying blind would leave no way back.
+        type: boolean
+        default: false
+
+# A PROD deploy mutates shared, external state (the :production tag + the running
+# container). Two tags racing would interleave their rollback points: run B could
+# capture the image A just installed — or capture nothing — and "rollback" would
+# then restore the wrong build. Serialize them, and NEVER cancel a run mid-deploy:
+# a cancelled deploy can leave PROD stopped, or leave :production pushed with no
+# container behind it.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -25,6 +44,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 💾 Capture rollback point — current PROD image ID (BEFORE any :production mutation)
+        env:
+          # Break-glass escape hatch. `inputs.*` is empty on a tag push, so the
+          # repo variable is the tag-push path. Read via env (never interpolated
+          # into the script body) so no expression value can be executed.
+          BREAK_GLASS: ${{ inputs.break_glass_no_rollback_point || vars.PROD_BREAK_GLASS_NO_ROLLBACK_POINT }}
         run: |
           # ⚠️ Ordering is load-bearing. This step MUST stay before the safety gate.
           #
@@ -44,7 +68,25 @@ jobs:
           CURRENT_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "")
 
           if [ -z "$CURRENT_IMAGE" ]; then
-            echo "::warning::No running nestjs-remix-monorepo-prod container — no rollback point captured (first deploy?). Auto-rollback will be skipped."
+            # No running container on an EXISTING PROD is itself an anomaly
+            # (crashed? half-deployed?). Deploying from here would mutate
+            # :production with NO way back — fail-closed BEFORE any mutation
+            # rather than discover it once the runtime is already broken.
+            if [ "${BREAK_GLASS:-}" != "true" ]; then
+              echo "❌ FATAL: no running nestjs-remix-monorepo-prod container — no rollback point can be captured."
+              echo ""
+              echo "  Deploying now would mutate :production with NO way back."
+              echo "  Nothing has been mutated yet; PROD is untouched."
+              echo ""
+              echo "  If this is a FIRST deploy or a host rebuild (i.e. there is legitimately"
+              echo "  nothing to roll back to), re-run deliberately in break-glass mode:"
+              echo "    - Actions → 'Deploy PROD (via tag)' → Run workflow → break_glass_no_rollback_point = true"
+              echo "    - or set repo variable PROD_BREAK_GLASS_NO_ROLLBACK_POINT=true for a tag push"
+              echo ""
+              echo "  Otherwise investigate why PROD is not running before deploying over it."
+              exit 1
+            fi
+            echo "::warning::BREAK-GLASS: no PROD container and no rollback point — deploying blind on explicit operator request. Auto-rollback is DISABLED for this run."
             echo "ROLLBACK_IMAGE_ID=" >> "$GITHUB_ENV"
             exit 0
           fi
@@ -86,10 +128,25 @@ jobs:
           echo "🐳 Preprod image SHA    : ${IMAGE_SHA:-<unset>}"
 
           if [ -z "$IMAGE_SHA" ]; then
-            echo "⚠️  Preprod image has no OCI revision label."
-            echo "    Cette image a été buildée avant build.yml labeling (pré 2026-04-21)."
-            echo "    On laisse passer cette fois mais prochain build sera validé."
-            echo "    Si ce message apparaît après le 2026-05-01, c'est un bug à investiguer."
+            # Was tolerated for images built before build.yml started labelling
+            # (pré 2026-04-21). That grace period self-declared its own expiry
+            # ("si ce message apparaît après le 2026-05-01, c'est un bug") and is
+            # now long past, so the tolerance is REMOVED: an unlabelled image is
+            # an image whose provenance cannot be proven, and promoting an
+            # unprovable image to PROD is exactly the class of bug this gate
+            # exists to stop (INC-2026-006).
+            echo ""
+            echo "❌ FATAL: l'image :preprod n'a AUCUN label OCI revision."
+            echo ""
+            echo "  Impossible de prouver que cette image correspond au commit du tag ($TAG_SHA)."
+            echo "  La tolérance historique (images pré-2026-04-21) est retirée — voir audit"
+            echo "  2026-07-16 : promouvoir une image de provenance non vérifiable = INC-2026-006."
+            echo ""
+            echo "Remède :"
+            echo "  1. Re-builder :preprod depuis le commit $TAG_SHA (merge/re-run du workflow PREPROD)"
+            echo "  2. OU promouvoir explicitement l'image :sha-$TAG_SHA"
+            echo ""
+            exit 1
           elif [ "$IMAGE_SHA" != "$TAG_SHA" ]; then
             echo ""
             echo "❌ FATAL: l'image :preprod ne correspond PAS au commit du tag."
@@ -247,6 +304,12 @@ jobs:
           # what made the old rollback restore the broken build.
           echo "🔒 Rollback point pinned: ${ROLLBACK_IMAGE_ID:-<none — auto-rollback disabled>}"
 
+          # POINT OF NO RETURN. Past this line the running container is destroyed,
+          # so ANY later failure — including in "Validate PROD" — must roll back.
+          # The dedicated `if: failure()` rollback step keys off this flag, which
+          # is why it is set BEFORE the stop/rm rather than after a successful up.
+          echo "DEPLOY_STARTED=1" >> "$GITHUB_ENV"
+
           docker stop nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
           docker rm nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
 
@@ -299,57 +362,6 @@ jobs:
           fi
           echo "Image verified: $ACTUAL_IMAGE"
 
-          # ── SSR gate ─────────────────────────────────────────────────────
-          # WHY this exists: /health is a SEPARATE NestJS controller and every
-          # other gate hits an API route — NONE of them render an SSR page. The
-          # SSR data path is exactly what PR #1285 rewrote, so an SSR regression
-          # used to sail through every gate and reach users.
-          #
-          # WHY it checks noindex: the homepage degraded fallback does NOT throw.
-          # It returns HTTP **200** with empty families plus
-          # `X-Robots-Tag: noindex, follow` (frontend/app/routes/_index.tsx).
-          # A status-only probe is therefore BLIND to it. A healthy homepage
-          # serves NO X-Robots-Tag at all, so `noindex` is the degraded signal —
-          # and shipping a noindex homepage to crawlers is an SEO incident.
-          #
-          # Marker: `__reactRouterContext` is the RR8 hydration payload — present
-          # only when the document was really server-rendered (framework-level,
-          # so it does not churn with page content).
-          probe_ssr() {
-            local label="$1"
-            local hdrs body status ctype robots
-
-            hdrs=$(docker exec nestjs-remix-monorepo-prod \
-              wget -q --server-response -O /tmp/ssr-probe.html http://localhost:3000/ 2>&1 || true)
-            body=$(docker exec nestjs-remix-monorepo-prod cat /tmp/ssr-probe.html 2>/dev/null || echo "")
-
-            status=$(echo "$hdrs" | grep -m1 'HTTP/' | awk '{print $2}')
-            ctype=$(echo "$hdrs" | grep -i -m1 'Content-Type:' | tr -d '\r')
-            robots=$(echo "$hdrs" | grep -i -m1 'X-Robots-Tag:' | tr -d '\r')
-
-            echo "  [$label] status=${status:-<none>} | ${ctype:-Content-Type: <none>} | ${robots:-X-Robots-Tag: <none>}"
-
-            if [ "${status:-}" != "200" ]; then
-              echo "  ❌ [$label] GET / -> ${status:-no response} (expected 200)"
-              return 1
-            fi
-            if ! echo "$ctype" | grep -qi 'text/html'; then
-              echo "  ❌ [$label] GET / Content-Type is not text/html"
-              return 1
-            fi
-            if ! printf '%s' "$body" | grep -qF '__reactRouterContext'; then
-              echo "  ❌ [$label] GET / lacks the stable SSR marker __reactRouterContext — document was not server-rendered"
-              return 1
-            fi
-            if echo "$robots" | grep -qi 'noindex'; then
-              echo "  ❌ [$label] GET / served X-Robots-Tag: noindex — homepage is in DEGRADED FALLBACK (families empty)"
-              return 1
-            fi
-
-            echo "  ✅ [$label] GET / -> 200 text/html, SSR marker present, indexable (no noindex)"
-            return 0
-          }
-
           # Health check with retry
           echo "Running health check (inside container)..."
           RETRIES=5
@@ -368,11 +380,16 @@ jobs:
           if echo "$HEALTH" | grep -q '"status":"ok"'; then HEALTH_OK=1; fi
 
           # SSR gate (BLOCKING). Only meaningful once the process answers /health.
+          # See scripts/ci/prod-ssr-probe.sh for why /health alone is not enough
+          # and why `noindex` is the signal that catches the degraded fallback.
           SSR_OK=0
           if [ "$HEALTH_OK" = "1" ]; then
             echo "🖥️ Running SSR gate (GET /)..."
             for i in $(seq 1 3); do
-              if probe_ssr "post-deploy $i/3"; then SSR_OK=1; break; fi
+              if bash "$GITHUB_WORKSPACE/scripts/ci/prod-ssr-probe.sh" "post-deploy $i/3"; then
+                SSR_OK=1
+                break
+              fi
               echo "  SSR gate attempt $i/3 failed, waiting 10s..."
               sleep 10
             done
@@ -380,49 +397,13 @@ jobs:
 
           if [ "$HEALTH_OK" != "1" ] || [ "$SSR_OK" != "1" ]; then
             if [ "$HEALTH_OK" != "1" ]; then
-              echo "❌ Health check failed after $RETRIES attempts — initiating rollback"
+              echo "❌ Health check failed after $RETRIES attempts"
             else
-              echo "❌ SSR gate failed — GET / is not a healthy, indexable, server-rendered document — initiating rollback"
+              echo "❌ SSR gate failed — GET / is not a healthy, indexable, server-rendered document"
             fi
             docker logs nestjs-remix-monorepo-prod --tail 30
-
-            if [ -z "${ROLLBACK_IMAGE_ID:-}" ]; then
-              echo "❌ No rollback point was captured — MANUAL INTERVENTION REQUIRED"
-              exit 1
-            fi
-
-            echo "⏪ Rolling back to pinned known-good image ID $ROLLBACK_IMAGE_ID ..."
-            docker stop nestjs-remix-monorepo-prod 2>/dev/null || true
-            docker rm nestjs-remix-monorepo-prod 2>/dev/null || true
-            # compose pins `image: ...:production`, so point that tag back at the
-            # pinned ID. Never at :production-previous — that tag is what the old
-            # broken logic corrupted.
-            docker tag "$ROLLBACK_IMAGE_ID" massdoc/nestjs-remix-monorepo:production
-            docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d --no-deps monorepo_prod caddy redis_prod
-            sleep 30
-
-            # Assert the restored container runs EXACTLY the pinned old image ID.
-            RESTORED_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "")
-            if [ "$RESTORED_IMAGE" != "$ROLLBACK_IMAGE_ID" ]; then
-              echo "❌ ROLLBACK VERIFICATION FAILED: container runs '${RESTORED_IMAGE:-<none>}', expected '$ROLLBACK_IMAGE_ID' — MANUAL INTERVENTION REQUIRED"
-              exit 1
-            fi
-            echo "✅ Rollback image ID verified byte-exact: $RESTORED_IMAGE"
-
-            # Re-run BOTH gates: a rollback that restores a broken page is not a rollback.
-            ROLLBACK_HEALTH=$(docker exec nestjs-remix-monorepo-prod wget -qO- http://localhost:3000/health 2>/dev/null || echo "")
-            if ! echo "$ROLLBACK_HEALTH" | grep -q '"status":"ok"'; then
-              echo "❌ Rollback /health FAILED — MANUAL INTERVENTION REQUIRED"
-              exit 1
-            fi
-            echo "✅ Rollback /health -> OK"
-
-            if ! probe_ssr "post-rollback"; then
-              echo "❌ Rollback SSR gate FAILED — MANUAL INTERVENTION REQUIRED"
-              exit 1
-            fi
-
-            echo "⏪ Rollback successful — previous version restored and VERIFIED (image ID + /health + SSR)"
+            # Rollback is NOT done here: the dedicated `if: failure()` step owns it,
+            # so that a failure in "Validate PROD" rolls back through the SAME path.
             exit 1
           fi
 
@@ -459,33 +440,12 @@ jobs:
             FAILED=1
           fi
 
-          # SSR gate (BLOCKING) — GET / must be a real, indexable, server-rendered
-          # document. /health and the API probes below never render SSR, so this
-          # is the only gate that sees an SSR regression. `noindex` is checked
-          # because the homepage degraded fallback returns 200 + X-Robots-Tag:
-          # noindex (frontend/app/routes/_index.tsx) — invisible to a status check.
+          # SSR gate (BLOCKING) — /health and the API probes never render SSR, so
+          # this is the only gate here that sees an SSR regression. A failure of
+          # THIS step now rolls back, via the dedicated `if: failure()` step.
           echo "🖥️ Testing SSR document (GET /)..."
-          SSR_HDRS=$($EXEC wget -q --server-response -O /tmp/ssr-validate.html http://localhost:3000/ 2>&1 || true)
-          SSR_BODY=$($EXEC cat /tmp/ssr-validate.html 2>/dev/null || echo "")
-          SSR_STATUS=$(echo "$SSR_HDRS" | grep -m1 'HTTP/' | awk '{print $2}')
-          SSR_CTYPE=$(echo "$SSR_HDRS" | grep -i -m1 'Content-Type:' | tr -d '\r')
-          SSR_ROBOTS=$(echo "$SSR_HDRS" | grep -i -m1 'X-Robots-Tag:' | tr -d '\r')
-          echo "   status=${SSR_STATUS:-<none>} | ${SSR_CTYPE:-Content-Type: <none>} | ${SSR_ROBOTS:-X-Robots-Tag: <none>}"
-
-          if [ "${SSR_STATUS:-}" != "200" ]; then
-            echo "❌ GET / -> ${SSR_STATUS:-no response} (expected 200)"
+          if ! bash "$GITHUB_WORKSPACE/scripts/ci/prod-ssr-probe.sh" "validate"; then
             FAILED=1
-          elif ! echo "$SSR_CTYPE" | grep -qi 'text/html'; then
-            echo "❌ GET / Content-Type is not text/html"
-            FAILED=1
-          elif ! printf '%s' "$SSR_BODY" | grep -qF '__reactRouterContext'; then
-            echo "❌ GET / lacks the stable SSR marker __reactRouterContext — not server-rendered"
-            FAILED=1
-          elif echo "$SSR_ROBOTS" | grep -qi 'noindex'; then
-            echo "❌ GET / served X-Robots-Tag: noindex — homepage in DEGRADED FALLBACK (families empty)"
-            FAILED=1
-          else
-            echo "✅ GET / -> 200 text/html, SSR marker present, indexable"
           fi
 
           # Test API endpoint
@@ -530,6 +490,25 @@ jobs:
           fi
 
           echo "🎉 Version ${{ github.ref_name }} deployed to production!"
+
+      - name: ⏪ Rollback PROD (any failure past the point of no return)
+        # Owns the rollback for the WHOLE job, so that a failure in "Validate
+        # PROD" rolls back through the SAME verified path as a failed health/SSR
+        # gate — previously only the deploy step could roll back, and a Validate
+        # failure left the broken build live.
+        #
+        # Guards:
+        #   DEPLOY_STARTED=1 — only set once the running container is destroyed.
+        #     A failure BEFORE that (checkout, capture, safety gate) left PROD
+        #     untouched, so rolling back would be wrong.
+        #   ROLLBACK_IMAGE_ID — empty only in break-glass mode (no rollback
+        #     point existed); the script fails loudly rather than pretend.
+        if: ${{ failure() && env.DEPLOY_STARTED == '1' }}
+        env:
+          ROLLBACK_IMAGE_ID: ${{ env.ROLLBACK_IMAGE_ID }}
+        run: |
+          cd ~/production
+          bash "$GITHUB_WORKSPACE/scripts/ci/prod-rollback.sh"
 
       - name: 🔔 Notify Slack on success
         if: ${{ success() && env.SLACK_WEBHOOK_URL != '' }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,6 +24,45 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: 💾 Capture rollback point — current PROD image ID (BEFORE any :production mutation)
+        run: |
+          # ⚠️ Ordering is load-bearing. This step MUST stay before the safety gate.
+          #
+          # The previous rollback was a proven NO-OP: the safety gate below retags
+          # `:production` to the NEW image, and the deploy step then derived
+          # `production-previous` FROM `:production` — so `production-previous`
+          # WAS the new image, and "rolling back" re-deployed the broken build.
+          # (`CURRENT_IMAGE` was computed there, echoed, and never used.)
+          #
+          # Fix: capture the RUNNING container's IMMUTABLE image ID here, while
+          # `:production` still points at the live build, then pin it in the job
+          # env so every later step rolls back to a byte-exact known-good image.
+          # Retagging `:production` does not mutate a running container's image
+          # ID, but capturing before any mutation keeps the invariant obvious.
+          set -uo pipefail
+
+          CURRENT_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "")
+
+          if [ -z "$CURRENT_IMAGE" ]; then
+            echo "::warning::No running nestjs-remix-monorepo-prod container — no rollback point captured (first deploy?). Auto-rollback will be skipped."
+            echo "ROLLBACK_IMAGE_ID=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          echo "🔒 Current PROD container image ID : $CURRENT_IMAGE"
+          docker tag "$CURRENT_IMAGE" massdoc/nestjs-remix-monorepo:production-previous
+
+          # Push it as an off-box recovery point. Best-effort: the local tag and
+          # the pinned ID below are what the in-job rollback actually uses, so a
+          # registry hiccup must not abort a deploy.
+          if docker push massdoc/nestjs-remix-monorepo:production-previous; then
+            echo "📤 production-previous pushed (off-box recovery point)"
+          else
+            echo "::warning::Could not push production-previous — local tag + pinned ID remain available for in-job rollback"
+          fi
+
+          echo "ROLLBACK_IMAGE_ID=$CURRENT_IMAGE" >> "$GITHUB_ENV"
+
       - name: 🔒 Safety gate — SHA consistency (preprod image ↔ tag commit)
         run: |
           # Le tag git pointe sur un commit précis. L'image :preprod est un alias
@@ -200,10 +239,13 @@ jobs:
 
           docker network create automecanik-prod 2>/dev/null || true
 
-          # Sauvegarder l'image actuelle pour rollback automatique
-          CURRENT_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "")
-          echo "Current image: $CURRENT_IMAGE"
-          docker tag massdoc/nestjs-remix-monorepo:production massdoc/nestjs-remix-monorepo:production-previous 2>/dev/null || true
+          # Rollback point already captured by the "💾 Capture rollback point"
+          # step as $ROLLBACK_IMAGE_ID — the running container's IMMUTABLE image
+          # ID, read BEFORE the safety gate retagged :production.
+          # Do NOT re-derive production-previous from :production here: by this
+          # point :production already points at the NEW image, which is exactly
+          # what made the old rollback restore the broken build.
+          echo "🔒 Rollback point pinned: ${ROLLBACK_IMAGE_ID:-<none — auto-rollback disabled>}"
 
           docker stop nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
           docker rm nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
@@ -257,6 +299,57 @@ jobs:
           fi
           echo "Image verified: $ACTUAL_IMAGE"
 
+          # ── SSR gate ─────────────────────────────────────────────────────
+          # WHY this exists: /health is a SEPARATE NestJS controller and every
+          # other gate hits an API route — NONE of them render an SSR page. The
+          # SSR data path is exactly what PR #1285 rewrote, so an SSR regression
+          # used to sail through every gate and reach users.
+          #
+          # WHY it checks noindex: the homepage degraded fallback does NOT throw.
+          # It returns HTTP **200** with empty families plus
+          # `X-Robots-Tag: noindex, follow` (frontend/app/routes/_index.tsx).
+          # A status-only probe is therefore BLIND to it. A healthy homepage
+          # serves NO X-Robots-Tag at all, so `noindex` is the degraded signal —
+          # and shipping a noindex homepage to crawlers is an SEO incident.
+          #
+          # Marker: `__reactRouterContext` is the RR8 hydration payload — present
+          # only when the document was really server-rendered (framework-level,
+          # so it does not churn with page content).
+          probe_ssr() {
+            local label="$1"
+            local hdrs body status ctype robots
+
+            hdrs=$(docker exec nestjs-remix-monorepo-prod \
+              wget -q --server-response -O /tmp/ssr-probe.html http://localhost:3000/ 2>&1 || true)
+            body=$(docker exec nestjs-remix-monorepo-prod cat /tmp/ssr-probe.html 2>/dev/null || echo "")
+
+            status=$(echo "$hdrs" | grep -m1 'HTTP/' | awk '{print $2}')
+            ctype=$(echo "$hdrs" | grep -i -m1 'Content-Type:' | tr -d '\r')
+            robots=$(echo "$hdrs" | grep -i -m1 'X-Robots-Tag:' | tr -d '\r')
+
+            echo "  [$label] status=${status:-<none>} | ${ctype:-Content-Type: <none>} | ${robots:-X-Robots-Tag: <none>}"
+
+            if [ "${status:-}" != "200" ]; then
+              echo "  ❌ [$label] GET / -> ${status:-no response} (expected 200)"
+              return 1
+            fi
+            if ! echo "$ctype" | grep -qi 'text/html'; then
+              echo "  ❌ [$label] GET / Content-Type is not text/html"
+              return 1
+            fi
+            if ! printf '%s' "$body" | grep -qF '__reactRouterContext'; then
+              echo "  ❌ [$label] GET / lacks the stable SSR marker __reactRouterContext — document was not server-rendered"
+              return 1
+            fi
+            if echo "$robots" | grep -qi 'noindex'; then
+              echo "  ❌ [$label] GET / served X-Robots-Tag: noindex — homepage is in DEGRADED FALLBACK (families empty)"
+              return 1
+            fi
+
+            echo "  ✅ [$label] GET / -> 200 text/html, SSR marker present, indexable (no noindex)"
+            return 0
+          }
+
           # Health check with retry
           echo "Running health check (inside container)..."
           RETRIES=5
@@ -271,30 +364,69 @@ jobs:
             sleep 10
           done
 
-          if ! echo "$HEALTH" | grep -q '"status":"ok"'; then
-            echo "Health check failed after $RETRIES attempts — initiating rollback"
+          HEALTH_OK=0
+          if echo "$HEALTH" | grep -q '"status":"ok"'; then HEALTH_OK=1; fi
+
+          # SSR gate (BLOCKING). Only meaningful once the process answers /health.
+          SSR_OK=0
+          if [ "$HEALTH_OK" = "1" ]; then
+            echo "🖥️ Running SSR gate (GET /)..."
+            for i in $(seq 1 3); do
+              if probe_ssr "post-deploy $i/3"; then SSR_OK=1; break; fi
+              echo "  SSR gate attempt $i/3 failed, waiting 10s..."
+              sleep 10
+            done
+          fi
+
+          if [ "$HEALTH_OK" != "1" ] || [ "$SSR_OK" != "1" ]; then
+            if [ "$HEALTH_OK" != "1" ]; then
+              echo "❌ Health check failed after $RETRIES attempts — initiating rollback"
+            else
+              echo "❌ SSR gate failed — GET / is not a healthy, indexable, server-rendered document — initiating rollback"
+            fi
             docker logs nestjs-remix-monorepo-prod --tail 30
 
-            # Rollback to previous image
-            if docker image inspect massdoc/nestjs-remix-monorepo:production-previous > /dev/null 2>&1; then
-              echo "Rolling back to production-previous..."
-              docker stop nestjs-remix-monorepo-prod 2>/dev/null || true
-              docker rm nestjs-remix-monorepo-prod 2>/dev/null || true
-              docker tag massdoc/nestjs-remix-monorepo:production-previous massdoc/nestjs-remix-monorepo:production
-              docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d --no-deps monorepo_prod caddy redis_prod
-              sleep 30
-              ROLLBACK_HEALTH=$(docker exec nestjs-remix-monorepo-prod wget -qO- http://localhost:3000/health 2>/dev/null || echo "")
-              if echo "$ROLLBACK_HEALTH" | grep -q '"status":"ok"'; then
-                echo "Rollback successful — previous version restored"
-              else
-                echo "Rollback also failed — manual intervention required"
-              fi
-            else
-              echo "No previous image available for rollback"
+            if [ -z "${ROLLBACK_IMAGE_ID:-}" ]; then
+              echo "❌ No rollback point was captured — MANUAL INTERVENTION REQUIRED"
+              exit 1
             fi
+
+            echo "⏪ Rolling back to pinned known-good image ID $ROLLBACK_IMAGE_ID ..."
+            docker stop nestjs-remix-monorepo-prod 2>/dev/null || true
+            docker rm nestjs-remix-monorepo-prod 2>/dev/null || true
+            # compose pins `image: ...:production`, so point that tag back at the
+            # pinned ID. Never at :production-previous — that tag is what the old
+            # broken logic corrupted.
+            docker tag "$ROLLBACK_IMAGE_ID" massdoc/nestjs-remix-monorepo:production
+            docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d --no-deps monorepo_prod caddy redis_prod
+            sleep 30
+
+            # Assert the restored container runs EXACTLY the pinned old image ID.
+            RESTORED_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "")
+            if [ "$RESTORED_IMAGE" != "$ROLLBACK_IMAGE_ID" ]; then
+              echo "❌ ROLLBACK VERIFICATION FAILED: container runs '${RESTORED_IMAGE:-<none>}', expected '$ROLLBACK_IMAGE_ID' — MANUAL INTERVENTION REQUIRED"
+              exit 1
+            fi
+            echo "✅ Rollback image ID verified byte-exact: $RESTORED_IMAGE"
+
+            # Re-run BOTH gates: a rollback that restores a broken page is not a rollback.
+            ROLLBACK_HEALTH=$(docker exec nestjs-remix-monorepo-prod wget -qO- http://localhost:3000/health 2>/dev/null || echo "")
+            if ! echo "$ROLLBACK_HEALTH" | grep -q '"status":"ok"'; then
+              echo "❌ Rollback /health FAILED — MANUAL INTERVENTION REQUIRED"
+              exit 1
+            fi
+            echo "✅ Rollback /health -> OK"
+
+            if ! probe_ssr "post-rollback"; then
+              echo "❌ Rollback SSR gate FAILED — MANUAL INTERVENTION REQUIRED"
+              exit 1
+            fi
+
+            echo "⏪ Rollback successful — previous version restored and VERIFIED (image ID + /health + SSR)"
             exit 1
           fi
-          echo "PROD deployment successful - API responding"
+
+          echo "✅ PROD deployment successful — /health OK and GET / is a healthy indexable SSR document"
 
           docker image prune -f
 
@@ -325,6 +457,35 @@ jobs:
             echo "❌ /health -> FAILED: $HEALTH"
             docker logs nestjs-remix-monorepo-prod --tail 20
             FAILED=1
+          fi
+
+          # SSR gate (BLOCKING) — GET / must be a real, indexable, server-rendered
+          # document. /health and the API probes below never render SSR, so this
+          # is the only gate that sees an SSR regression. `noindex` is checked
+          # because the homepage degraded fallback returns 200 + X-Robots-Tag:
+          # noindex (frontend/app/routes/_index.tsx) — invisible to a status check.
+          echo "🖥️ Testing SSR document (GET /)..."
+          SSR_HDRS=$($EXEC wget -q --server-response -O /tmp/ssr-validate.html http://localhost:3000/ 2>&1 || true)
+          SSR_BODY=$($EXEC cat /tmp/ssr-validate.html 2>/dev/null || echo "")
+          SSR_STATUS=$(echo "$SSR_HDRS" | grep -m1 'HTTP/' | awk '{print $2}')
+          SSR_CTYPE=$(echo "$SSR_HDRS" | grep -i -m1 'Content-Type:' | tr -d '\r')
+          SSR_ROBOTS=$(echo "$SSR_HDRS" | grep -i -m1 'X-Robots-Tag:' | tr -d '\r')
+          echo "   status=${SSR_STATUS:-<none>} | ${SSR_CTYPE:-Content-Type: <none>} | ${SSR_ROBOTS:-X-Robots-Tag: <none>}"
+
+          if [ "${SSR_STATUS:-}" != "200" ]; then
+            echo "❌ GET / -> ${SSR_STATUS:-no response} (expected 200)"
+            FAILED=1
+          elif ! echo "$SSR_CTYPE" | grep -qi 'text/html'; then
+            echo "❌ GET / Content-Type is not text/html"
+            FAILED=1
+          elif ! printf '%s' "$SSR_BODY" | grep -qF '__reactRouterContext'; then
+            echo "❌ GET / lacks the stable SSR marker __reactRouterContext — not server-rendered"
+            FAILED=1
+          elif echo "$SSR_ROBOTS" | grep -qi 'noindex'; then
+            echo "❌ GET / served X-Robots-Tag: noindex — homepage in DEGRADED FALLBACK (families empty)"
+            FAILED=1
+          else
+            echo "✅ GET / -> 200 text/html, SSR marker present, indexable"
           fi
 
           # Test API endpoint

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -312,6 +312,14 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # Audits de bundle de release PROD (read-only, ancrés au SHA candidat) — même
+  # famille D13 que la surface deploy (.github/workflows/** + scripts/ci/**).
+  # Owner GO nominatif 2026-07-16. cf. audit/2026-07-16-prod-bundle-da90deabd-a931205c.md
+  - glob: audit/*-prod-bundle-*.md
+    domain: D13
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   # V-Level doctrine de référence (PR vlevel-doctrine-lock, owner GO 2026-06-05) —
   # voir audit/levels-doctrine-cgc-vs-vlevel-2026-06-04.md. Préfixe ciblé.
   - glob: audit/levels-doctrine-*.md

--- a/audit/2026-07-16-prod-bundle-da90deabd-a931205c.md
+++ b/audit/2026-07-16-prod-bundle-da90deabd-a931205c.md
@@ -1,0 +1,156 @@
+# Audit de bundle PROD — `da90deabd..a931205c` (7 PRs)
+
+- **Date** : 2026-07-16
+- **Bundle audité** : `da90deabd..a931205c` (7 PRs)
+- **PROD au moment de l'audit** : tag `v2026.07.15-substitution-failopen-r1-404` → `da90deabd`
+- **Méthode** : audit multi-agents en lecture seule (11 agents : 7 par-PR + 4 lentilles transverses), revendications « dark » / « behavior-identical » traitées comme **revendications à réfuter**, pas comme faits.
+- **Nature** : aide à la décision. Ce document **ne vaut pas GO**.
+
+---
+
+## Verdict
+
+```
+CODE_BUNDLE:  APPROVE
+PROD_RELEASE: NO-GO
+```
+
+### Causes du NO-GO (aucune n'est dans le code applicatif)
+
+1. **Rollback automatique invalide** — le rollback de `deploy-prod.yml` est un **no-op prouvé** : il restaure l'image cassée. Défaut rouge P0.
+2. **Absence de sonde SSR en PROD** — aucun gate de déploiement ne rend une page SSR, alors que #1285 réécrit précisément le chemin de données SSR. Défaut rouge P0.
+3. **Vérifications `.env` / BullMQ encore externes** — deux conditions non vérifiables depuis le repo (fichier `.env` de la box PROD, état Redis PROD) restent ouvertes.
+
+### Candidat de release
+
+- **`a931205c` = candidat figé historique.** **Dépassé** : `main` est passé à `bd167475c` (#1286 « feat(seo-projection): add dark r3 projection mapper (P2-R3-C, pure) », mergée 2026-07-16T15:21:36Z).
+- Tout GO portant sur `a931205c` est **caduc**. La promotion devra viser un **nouveau head** incluant #1286 **et** les correctifs P0 ci-dessous, après un **nouvel audit de bundle**.
+
+---
+
+## Périmètre réel d'un tag
+
+Un tag `v*` promeut **le head de `main` en entier**, jamais une PR isolée. Au moment de l'audit, tagger `a931205c` aurait promu **7 PRs**, pas seulement #1285.
+
+Corollaire acté : **ne jamais fabriquer une branche de release en cherry-pickant une seule PR** — le SHA obtenu diffère de celui validé en PREPROD, donc on promouvrait du code jamais testé.
+
+---
+
+## Matrice par PR
+
+| PR | Titre | Risque | Comportement PROD visible au deploy | Flag (vérifié) | Migrations |
+|---|---|---|---|---|---|
+| **#1285** | refactor(remix): replace SSR loopback with actor-bound app port | **medium** | **OUI** | **aucun — 100 % du trafic** | aucune |
+| #1284 | seo-projection: extract dark projection reader (C0) | low | non | `SEO_BRIEF_WIKI_ENABLED` = **false** — dark **confirmé** (plus fort qu'annoncé) | aucune |
+| #1282 | seo-projection: durable snapshot producer + role-scoped writer (P2-R3-B) | low | non | `SEO_PROJECTION_R1_FEED_ENABLED` **OFF** — dark confirmé sur le chemin **automatique** ; **partiellement réfuté** sur « inatteignable » (endpoint de trigger manuel) | aucune |
+| #1283 | audit: refresh served-write-sink baseline | low | non | CI-only, zéro runtime — confirmé | aucune |
+| #1278 | seo: B5 — remove R3 image-prompt RAG generation | low | **non au deploy** (voir §#1278) | aucun — suppression structurelle inconditionnelle | aucune |
+| #1277 | governance: EDITORIAL_AUTHORITY_SINKS registry + ratchet | low | non | claim confirmé, plus fort qu'annoncé | aucune |
+| #1281 | seo-projection: replay reads run_id PK | low | non | corrige un vrai bug | aucune |
+
+**Le bundle ne contient AUCUNE migration ni DDL** (`git diff --name-only da90deabd..a931205c -- backend/supabase/migrations/` = vide). Aucune précondition DB au déploiement, aucun risque de « migration non appliquée → crash boot ».
+
+**Aucune PR classée high-risk. Une seule PR change le comportement PROD au déploiement : #1285.**
+
+---
+
+## #1285 — la seule PR à comportement PROD visible
+
+Le cadrage « refactor » du titre est **réfuté** : la PR ship **sans flag, à 100 % du trafic**. Trois deltas non signalés par la PR ont été trouvés :
+
+1. `/orders/new` : 200 (formulaire) → **503**. **Pas une régression de capacité** : `createOrderForRemix` n'existait nulle part au `da90deabd` (un seul hit : le site d'appel) → optional-chain → `undefined` → TypeError → 500. Le chemin de création était **prouvé mort** ; seul le mode d'échec change (formulaire factice + 500 au submit → 503 immédiat).
+2. **Durcissement authz** : `staff._index` et `admin.reports` passent `requireUser` → `requireAdmin`. **Fail-closed, zéro perte fonctionnelle** — ces pages servaient des zéros/synthétique (`getStaff()` appelait `/api/users/test-staff`, endpoint inexistant → 404 → catch → all-zeros). Ferme une surface latente de broken-access-control.
+3. `getStats` fail-loud **fuit au-delà du port** vers les surfaces REST préexistantes `StaffController @Get('stats')` et `AdminStaffController:89` : sur erreur DB, 400 (BadRequestException) au lieu de 200-avec-zéros. **Chemin d'erreur uniquement, admin-only.**
+
+**Aucun risque de boot** (la préoccupation principale) : `forwardRef(() => StaffModule)` **n'est pas load-bearing** (StaffModule n'importe que ConfigModule → aucun cycle) et **StaffModule était déjà dans le graphe** (`app.module.ts:250`, `admin.module.ts:161`) → l'import n'enregistre **aucune route HTTP nouvelle**. Preuve empirique : run CI `29488460068` sur `a931205c` vert de bout en bout, **Deploy PREPROD + E2E Smoke + Lighthouse** inclus.
+
+### Dégradation réellement visible par un utilisateur (unique)
+
+`frontend/app/components/account/AccountNavigation.tsx:167` conserve un CTA « Nouvelle commande » → `/orders/new`, rendu par `AccountLayout` sur **9 routes `/account/*`** : un client connecté est **à un clic d'un 503 nu**. → traité en PR séparée et étroite.
+
+---
+
+## #1278 — changement réel, mais différé
+
+C'est **un vrai changement** (suppression de capacité, non-dark, shippé ON), **mais il n'est pas visible au déploiement** :
+
+- Les deux endpoints supprimés (`POST /api/admin/r3-image-prompts/generate`, `/generate/:pgAlias`) sont **admin-only derrière `AuthenticatedGuard` + `IsAdminGuard`**.
+- Le chemin de lecture servi est **intact** : `blog-seo.service.ts:346 getApprovedImages()` (filtre `rip_selected=true` AND `rip_image_url NOT NULL` AND `rip_status IN ('approved','exported')`), consommé par `r3-guide.service.ts:228` sous le contrôleur public `r3-guide.controller.ts:29`.
+- **Aucune ligne, aucun schéma modifié.** Les images des pages conseil continuent de s'afficher à l'identique.
+- Aucun caller résiduel, aucun bouton d'admin cassé (le frontend ne référence que `/api/admin/r1-image-prompts/*`).
+
+**Conséquence réelle = perte de capacité différée**, pas une régression : après B5, `rip_selected` et la création de lignes sur `__seo_r3_image_prompts` n'ont **plus aucun writer** dans `backend/src`. Donc (a) une gamme sans ligne existante ne peut plus en obtenir une → jamais d'images guide ; (b) une ligne à `rip_selected=false` ne peut plus être basculée à true. **Effet SEO net : la couverture image R3 est gelée à son set actuel et ne peut décroître qu'en relatif, à mesure que de nouvelles gammes apparaissent. Aucune perte de couverture existante.** C'est le « résidu fonctionnel » owner-acté (remplacement = design séparé owner-gated).
+
+**Inexactitude de documentation à consigner (pas runtime)** : le corps de la PR affirme « les seuls writers sont `approvePrompt` et `setImageUrl` ». **Réfuté** : un 3ᵉ writer existe — `assignToR3Slot` (`rag-image-management.service.ts:219`, `.update({rip_image_url, rip_status:'approved'})`). Il est **promote-only** (ne touche ni `rip_selected` ni `'pending'`), donc il **respecte** l'invariant énoncé et passe le ratchet d'allowlist de colonnes — mais la surface de curation est plus large qu'annoncée, et ce writer ne peut lui non plus ni créer de ligne ni positionner `rip_selected`, ce qui **corrobore le résidu**.
+
+---
+
+## Défauts rouges — mécanique de déploiement (P0)
+
+### 🔴 1. Le rollback automatique est un no-op prouvé
+
+Séquence réelle dans `.github/workflows/deploy-prod.yml` :
+
+1. Étape *safety gate* (l.74-80) : `docker tag :preprod :production` **puis** `docker push :production` → **`:production` pointe déjà sur la NOUVELLE image.**
+2. Étape *deploy* (l.204) : `CURRENT_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod)` — l'**ID immuable correct** de l'ancienne image… **calculé, affiché, puis JAMAIS UTILISÉ**.
+3. Étape *deploy* (l.206) : `docker tag :production :production-previous` → comme `:production` a déjà été écrasé en (1), **`production-previous` == la NOUVELLE image**.
+4. Rollback (l.283) : `docker tag :production-previous :production` → **restaure exactement l'image cassée**.
+
+**Conséquence** : la branche health-failure ne protège de rien. Le rollback de référence est aujourd'hui **manuel** (tag `v*` antérieur ou `:sha-<sha>`).
+
+### 🔴 2. Aucune sonde SSR
+
+`/health` est un contrôleur NestJS **séparé** ; les autres sondes (`/api/catalog/families`, `/api/gamme-rest/4/page-data-rpc-v2`, guards admin) sont des **routes API**. **Aucun gate ne rend une page SSR.** Or #1285 réécrit exactement ce chemin (`remix-api.server.ts` −623 lignes + port par-requête injecté dans `remix.controller.ts`, 4 routes migrées). **Une régression SSR passerait tous les gates actuels.**
+
+### 🟠 3. Coupure dure de ~60-90 s (P1, non bloquant)
+
+`docker stop` + `docker rm` de `nestjs-remix-monorepo-prod` **et** `nestjs-remix-caddy`, puis `compose up`, puis `sleep 60` avant la première sonde. **Ce n'est pas un rolling restart.** → PR blue/green distincte, après les deux défauts rouges.
+
+---
+
+## Vérifications externes au repo (owner uniquement)
+
+1. **`.env` de PROD** (`49.12.233.2:~/production/.env`, non versionné) : confirmer que `SEO_PROJECTION_R1_FEED_ENABLED` est **absent ou ≠ `"true"`**. Le défaut code est OFF et la variable n'est settée dans **aucun** compose/workflow — mais le `.env` est hors git, donc non vérifiable par audit.
+2. **Redis PROD** : `SEO_PROJECTION_R1_FEED_ENABLED=false` **ne déenregistre pas** un repeatable BullMQ déjà enregistré — `removeStaleRepeatableJob()` n'est atteignable que **flag ON**. Vérifier l'absence de repeatable périmé.
+
+### Préconditions du *writer* #1282 (gate le writer, pas le tag)
+
+Le writer est dormant tant que le flag est OFF ; ces points ne bloquent donc **pas** le tag, mais conditionnent **toute** première exécution (`POST /api/admin/seo-projection/feed/trigger-entity` ou `trigger-now`) :
+
+- Confirmer que les 3 migrations ADR-059 sont **réellement appliquées** en PROD (« antérieures » ≠ « appliquées »).
+- `/opt/automecanik/object-store` (`OBJECT_STORE_ROOT_DEFAULT`) n'est monté dans **aucun** compose et `SEO_PROJECTION_OBJECT_STORE_ROOT` n'est setté nulle part, alors que le code fait `mkdir -p` **dans le conteneur** → écriture non durable. Monter un volume ou pointer la variable.
+- **Hasard event-loop** : `zstdCompressSync` niveau 19 est **synchrone** et `docker-compose.prod.yml` ne lance qu'un seul service → les processors BullMQ partagent l'event-loop Node du serveur HTTP.
+- **Churn de version unique** au premier run : le hash de contenu est passé de `md5(JSON.stringify)` à `sha256(fast-json-stable-stringify)` → tous les `content_hash` stockés deviennent non concordants, la détection de no-op est défaite.
+- Traiter le premier POST comme un **canary**, jamais comme une action de routine : c'est la première exécution du chemin d'écriture #1282 **où que ce soit** avec `readOnly=false` (PREPROD, en anon + READ_ONLY, ne l'a jamais exercé).
+
+---
+
+## Ce que le vert PREPROD ne prouve pas
+
+PREPROD tourne `NODE_ENV=preprod`, **`READ_ONLY=true`**, **clé anon** (ADR-028 Option D). PROD tourne **`service_role`**. Donc :
+
+- Tout chemin gardé par `guardReadOnly()` **n'a jamais tourné** en PREPROD et **tournera** en PROD.
+- Les chemins staff/admin de #1285 **ne peuvent pas** être validés par l'E2E Smoke vert : `StaffDataService` lit `___config_admin` via `.from()` (lecture de table directe, pas une RPC) ; en PREPROD anon cela renverrait 42501. Risque néanmoins **faible** : la forme de requête est **inchangée** et la lecture identique tourne **déjà** en PROD derrière `StaffController /api/admin/staff`. → spot-check `/admin/staff` et `/admin/reports` en admin juste après tout tag.
+
+---
+
+## Suites décidées
+
+| Priorité | Action | Portée |
+|---|---|---|
+| **P0** | Corriger `deploy-prod.yml` : vrai `CURRENT_IMAGE` pour `production-previous` (sauvegardé/poussé **avant** toute mutation de `:production`) ; assertion d'ID exact au rollback ; re-sonde `/health` **+ sonde SSR réelle** après rollback ; **`GET /` bloquant** post-déploiement (200, `text/html`, marqueur HTML stable, **absence de `X-Robots-Tag: noindex`** — détecte aussi le fallback dégradé de la homepage) | PR dédiée |
+| **P0** | Retirer le CTA `/orders/new` de `AccountNavigation.tsx` + import devenu inutilisé + test anti-réapparition | PR **séparée et étroite** — ne touche ni la route 503 ni le domaine commande |
+| P1 | Blue/green pour supprimer la coupure de 60-90 s | PR distincte, **après** les deux défauts rouges |
+| — | **Nouvel audit de bundle + promotion d'un nouveau head** incluant #1286 et les correctifs | Le GO proposé sur `a931205c` est **caduc** |
+
+**Aucun tag `v*` n'est créé. PROD reste sur `v2026.07.15-substitution-failopen-r1-404` (`da90deabd`).**
+
+---
+
+## Forme attendue d'un futur GO
+
+Un GO PROD doit nommer le **bundle** et **toutes** ses PRs, jamais la PR du jour. Exemple de forme (à réémettre sur le futur head, pas sur `a931205c`) :
+
+> `GO PROD pour le bundle <tag-précédent>..<nouveau-head>, incluant #… , #… , #….`
+
+Un « tag » sec après une session mono-PR est une **demande de confirmation**, pas un GO de bundle.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "audit:served-write-ratchet:refresh": "tsx scripts/audit/check-served-content-write-sinks-ratchet.ts --refresh",
     "audit:served-write-ratchet:test": "tsx --test scripts/audit/check-served-content-write-sinks-ratchet.test.ts",
     "audit:editorial-sinks:test": "tsx --test scripts/audit/editorial-authority-sinks.test.ts",
+    "test:prod-rollback": "node --test scripts/ci/prod-rollback.test.mjs",
     "audit:rag-authority-rule:test": "ast-grep test --test-dir scripts/audit/__fixtures__/rag-authority --skip-snapshot-tests",
     "audit:rag-authority-read-ratchet": "tsx scripts/audit/check-rag-authority-read-ratchet.ts",
     "audit:rag-authority-read-ratchet:json": "tsx scripts/audit/check-rag-authority-read-ratchet.ts --json",

--- a/scripts/ci/prod-rollback.sh
+++ b/scripts/ci/prod-rollback.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# PROD rollback — restore the runtime AND the canonical registry tag to the
+# pinned known-good image, then PROVE it.
+#
+# WHY THIS IS A SCRIPT (not inline YAML)
+# --------------------------------------
+# The rollback path is the one path that only ever runs when things are already
+# broken, so it is precisely the path that must be tested. Inline workflow YAML
+# cannot be executed against a stubbed docker; this script can — see
+# `prod-rollback.test.mjs`, which proves the OLD image is actually restored and
+# that a mismatch cannot silently pass.
+#
+# WHAT IT FIXES (audit 2026-07-16)
+# --------------------------------
+# The previous rollback was a proven NO-OP: the safety gate retagged
+# `:production` to the NEW image *before* the deploy step derived
+# `production-previous` FROM `:production`, so "rolling back" re-deployed the
+# broken build. Here we roll back to an IMMUTABLE image ID captured before any
+# mutation, and we ASSERT the restored container runs byte-exactly that ID.
+#
+# It also re-pushes `:production`: restoring only the local runtime leaves the
+# registry's canonical tag resolving to the DEFECTIVE image — the next pull
+# anywhere (scale-out, host rebuild, manual `docker pull`) would silently
+# resurrect it.
+#
+# Required env:
+#   ROLLBACK_IMAGE_ID  immutable image ID captured BEFORE any :production mutation
+# Optional env:
+#   IMAGE_REPO               (default massdoc/nestjs-remix-monorepo)
+#   PROD_CONTAINER           (default nestjs-remix-monorepo-prod)
+#   ROLLBACK_SETTLE_SECONDS  (default 30 — tests set 0)
+set -uo pipefail
+
+IMAGE_REPO="${IMAGE_REPO:-massdoc/nestjs-remix-monorepo}"
+CONTAINER="${PROD_CONTAINER:-nestjs-remix-monorepo-prod}"
+SETTLE="${ROLLBACK_SETTLE_SECONDS:-30}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${ROLLBACK_IMAGE_ID:-}" ]; then
+  echo "❌ ROLLBACK_IMAGE_ID is empty — no rollback point was pinned."
+  echo "   The runtime may be running a defective image. MANUAL INTERVENTION REQUIRED."
+  exit 1
+fi
+
+echo "⏪ Rolling back to pinned known-good image ID $ROLLBACK_IMAGE_ID ..."
+docker stop "$CONTAINER" 2>/dev/null || true
+docker rm "$CONTAINER" 2>/dev/null || true
+
+# compose pins `image: <repo>:production`, so point that tag back at the pinned
+# ID. NEVER at :production-previous — that is the tag the old broken logic
+# corrupted, and it is only an off-box convenience copy.
+docker tag "$ROLLBACK_IMAGE_ID" "${IMAGE_REPO}:production"
+
+docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d --no-deps monorepo_prod caddy redis_prod
+sleep "$SETTLE"
+
+# ── Proof 1: the container really runs the pinned OLD image ──────────────────
+RESTORED=$(docker inspect --format='{{.Image}}' "$CONTAINER" 2>/dev/null || echo "")
+if [ "$RESTORED" != "$ROLLBACK_IMAGE_ID" ]; then
+  echo "❌ ROLLBACK VERIFICATION FAILED: container runs '${RESTORED:-<none>}', expected '$ROLLBACK_IMAGE_ID'."
+  echo "   MANUAL INTERVENTION REQUIRED."
+  exit 1
+fi
+echo "✅ Rollback image ID verified byte-exact: $RESTORED"
+
+# ── Proof 2: the registry's canonical tag no longer resolves to the bad build ─
+if docker push "${IMAGE_REPO}:production"; then
+  echo "✅ Registry :production restored to the known-good image"
+else
+  echo "❌ Could not push the restored :production to the registry."
+  echo "   The runtime is back, but the canonical tag STILL resolves to the defective"
+  echo "   image — any later pull would resurrect it. MANUAL FIX REQUIRED."
+  exit 1
+fi
+
+# ── Proof 3: the restored runtime actually serves ────────────────────────────
+HEALTH=$(docker exec "$CONTAINER" wget -qO- http://localhost:3000/health 2>/dev/null || echo "")
+if ! echo "$HEALTH" | grep -q '"status":"ok"'; then
+  echo "❌ Rollback /health FAILED — MANUAL INTERVENTION REQUIRED"
+  exit 1
+fi
+echo "✅ Rollback /health -> OK"
+
+# A rollback that restores a broken page is not a rollback.
+if ! bash "$SCRIPT_DIR/prod-ssr-probe.sh" "post-rollback"; then
+  echo "❌ Rollback SSR gate FAILED — MANUAL INTERVENTION REQUIRED"
+  exit 1
+fi
+
+echo "⏪ Rollback complete and VERIFIED (image ID + registry + /health + SSR)"

--- a/scripts/ci/prod-rollback.test.mjs
+++ b/scripts/ci/prod-rollback.test.mjs
@@ -1,0 +1,186 @@
+/**
+ * Behavioural proof of the PROD rollback path (audit 2026-07-16).
+ *
+ * `bash -n` and static step ordering prove NOTHING about whether the old image
+ * is actually restored — and the rollback path only ever executes when things
+ * are already broken, so it is the least-exercised and most safety-critical code
+ * in the deploy. These tests EXECUTE `prod-rollback.sh` against a stubbed
+ * `docker` and assert the observable behaviour:
+ *
+ *   1. it retags :production to the pinned OLD image ID and pushes it;
+ *   2. a mismatch between the restored container image and the pinned ID FAILS
+ *      (the regression that made the old rollback a silent no-op);
+ *   3. an empty rollback point FAILS instead of pretending to roll back;
+ *   4. a failed registry push FAILS — runtime back but canonical tag still
+ *      resolving to the defective image is not a successful rollback;
+ *   5. a degraded (noindex) homepage after rollback FAILS — restoring a broken
+ *      page is not a rollback.
+ *
+ * Run: npm run test:prod-rollback
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROLLBACK_SH = join(SCRIPT_DIR, "prod-rollback.sh");
+
+const OLD_ID = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const NEW_ID = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const HEALTHY_HEADERS = [
+  "  HTTP/1.1 200 OK",
+  "  Content-Type: text/html; charset=utf-8",
+  "  Cache-Control: public, max-age=300",
+].join("\n");
+
+// The degraded homepage fallback: HTTP **200** + noindex (frontend/app/routes/_index.tsx).
+const DEGRADED_HEADERS = [
+  "  HTTP/1.1 200 OK",
+  "  Content-Type: text/html; charset=utf-8",
+  "  Cache-Control: no-store",
+  "  X-Robots-Tag: noindex, follow",
+].join("\n");
+
+const SSR_BODY = '<!DOCTYPE html><html lang="fr"><body>x<script>window.__reactRouterContext={};</script></body></html>';
+
+/** A stub `docker` that logs every invocation and answers per scenario env. */
+const DOCKER_STUB = `#!/usr/bin/env bash
+echo "$@" >> "$DOCKER_LOG"
+case "$1" in
+  stop|rm|tag|compose|pull) exit 0 ;;
+  inspect) echo "$STUB_RESTORED_ID"; exit 0 ;;
+  push) [ "\${STUB_PUSH_FAIL:-0}" = "1" ] && exit 1 || exit 0 ;;
+  exec)
+    shift 2
+    if printf '%s' "$*" | grep -q -- '--server-response'; then
+      printf '%s\\n' "$STUB_SSR_HEADERS" >&2
+      exit 0
+    elif printf '%s' "$*" | grep -q -- '/health'; then
+      printf '%s\\n' "$STUB_HEALTH"
+      exit 0
+    elif printf '%s' "$*" | grep -q -- 'cat'; then
+      printf '%s\\n' "$STUB_SSR_BODY"
+      exit 0
+    fi
+    exit 0 ;;
+esac
+exit 0
+`;
+
+/** Run prod-rollback.sh against the stub. Returns {code, stdout, dockerCalls}. */
+function runRollback(env = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "prod-rollback-"));
+  const stub = join(dir, "docker");
+  const log = join(dir, "docker.log");
+  writeFileSync(stub, DOCKER_STUB);
+  chmodSync(stub, 0o755);
+  writeFileSync(log, "");
+
+  let code = 0;
+  let stdout = "";
+  try {
+    stdout = execFileSync("bash", [ROLLBACK_SH], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        DOCKER_LOG: log,
+        ROLLBACK_SETTLE_SECONDS: "0",
+        IMAGE_REPO: "massdoc/nestjs-remix-monorepo",
+        PROD_CONTAINER: "nestjs-remix-monorepo-prod",
+        // healthy defaults — each test overrides what it is about
+        ROLLBACK_IMAGE_ID: OLD_ID,
+        STUB_RESTORED_ID: OLD_ID,
+        STUB_HEALTH: '{"status":"ok"}',
+        STUB_SSR_HEADERS: HEALTHY_HEADERS,
+        STUB_SSR_BODY: SSR_BODY,
+        STUB_PUSH_FAIL: "0",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (e) {
+    code = e.status ?? 1;
+    stdout = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  const dockerCalls = existsSync(log)
+    ? readFileSync(log, "utf8").split("\n").filter(Boolean)
+    : [];
+  return { code, stdout, dockerCalls };
+}
+
+describe("prod-rollback.sh — behavioural proof of the failure path", () => {
+  test("restores the pinned OLD image and pushes it to the registry", () => {
+    const { code, stdout, dockerCalls } = runRollback();
+
+    assert.equal(code, 0, `expected success, got ${code}\n${stdout}`);
+
+    // It must retag :production to the OLD id — NOT to :production-previous,
+    // the tag the old broken logic corrupted.
+    assert.ok(
+      dockerCalls.some((c) => c === `tag ${OLD_ID} massdoc/nestjs-remix-monorepo:production`),
+      `expected 'docker tag ${OLD_ID} …:production'. Calls:\n${dockerCalls.join("\n")}`,
+    );
+    assert.ok(
+      !dockerCalls.some((c) => c.includes("production-previous")),
+      "rollback must not depend on the :production-previous tag",
+    );
+
+    // The canonical registry tag must stop resolving to the defective image.
+    assert.ok(
+      dockerCalls.some((c) => c === "push massdoc/nestjs-remix-monorepo:production"),
+      `expected 'docker push …:production'. Calls:\n${dockerCalls.join("\n")}`,
+    );
+    assert.match(stdout, /Rollback complete and VERIFIED/);
+  });
+
+  test("FAILS when the restored container runs a different image than the pinned ID", () => {
+    // This is the exact regression that made the old rollback a silent no-op:
+    // the container comes back up on the NEW (broken) image.
+    const { code, stdout, dockerCalls } = runRollback({ STUB_RESTORED_ID: NEW_ID });
+
+    assert.notEqual(code, 0, "a mismatched restore must FAIL, not silently pass");
+    assert.match(stdout, /ROLLBACK VERIFICATION FAILED/);
+    // and it must NOT publish the wrong image as canonical
+    assert.ok(
+      !dockerCalls.some((c) => c.startsWith("push ")),
+      "must not push :production when the restore is unverified",
+    );
+  });
+
+  test("FAILS when no rollback point was pinned (no silent pretend-rollback)", () => {
+    const { code, stdout, dockerCalls } = runRollback({ ROLLBACK_IMAGE_ID: "" });
+
+    assert.notEqual(code, 0);
+    assert.match(stdout, /no rollback point was pinned/i);
+    assert.equal(dockerCalls.length, 0, "must not touch docker at all");
+  });
+
+  test("FAILS when the registry push fails (runtime back, canonical tag still lying)", () => {
+    const { code, stdout } = runRollback({ STUB_PUSH_FAIL: "1" });
+
+    assert.notEqual(code, 0, "a rollback whose registry tag still resolves to the bad image is not successful");
+    assert.match(stdout, /canonical tag STILL resolves to the defective/i);
+  });
+
+  test("FAILS when the restored homepage is the degraded 200+noindex fallback", () => {
+    // Restoring a broken page is not a rollback. Note the fallback answers 200,
+    // so only the noindex assertion catches it.
+    const { code, stdout } = runRollback({ STUB_SSR_HEADERS: DEGRADED_HEADERS });
+
+    assert.notEqual(code, 0);
+    assert.match(stdout, /DEGRADED FALLBACK|SSR gate FAILED/);
+  });
+
+  test("FAILS when the restored runtime does not answer /health", () => {
+    const { code, stdout } = runRollback({ STUB_HEALTH: '{"status":"down"}' });
+
+    assert.notEqual(code, 0);
+    assert.match(stdout, /Rollback \/health FAILED/);
+  });
+});

--- a/scripts/ci/prod-ssr-probe.sh
+++ b/scripts/ci/prod-ssr-probe.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# PROD SSR gate — assert `GET /` is a healthy, indexable, SERVER-RENDERED document.
+#
+# WHY THIS EXISTS
+# ---------------
+# `/health` is a SEPARATE NestJS controller and every other deploy probe hits an
+# API route — none of them render an SSR page. The SSR data path is exactly what
+# PR #1285 rewrote, so an SSR regression used to sail through every gate and reach
+# users.
+#
+# WHY IT CHECKS noindex
+# ---------------------
+# The homepage degraded fallback does NOT throw: it returns HTTP **200** with
+# empty families plus `X-Robots-Tag: noindex, follow`
+# (frontend/app/routes/_index.tsx). A status-only probe is therefore BLIND to it,
+# and serving a noindex homepage to crawlers is an SEO incident. A healthy
+# homepage serves NO X-Robots-Tag at all.
+#
+# MARKER
+# ------
+# `__reactRouterContext` is the RR8 hydration payload — present only when the
+# document was really server-rendered (framework-level, so it does not churn with
+# page content).
+#
+# Usage:  prod-ssr-probe.sh [label]
+# Exit:   0 = healthy indexable SSR document · 1 = otherwise (caller decides)
+#
+# Env overrides (used by the behavioural tests):
+#   PROD_CONTAINER  container name              (default nestjs-remix-monorepo-prod)
+#   SSR_URL         URL probed inside container (default http://localhost:3000/)
+#   SSR_MARKER      required body marker        (default __reactRouterContext)
+set -uo pipefail
+
+LABEL="${1:-ssr}"
+CONTAINER="${PROD_CONTAINER:-nestjs-remix-monorepo-prod}"
+URL="${SSR_URL:-http://localhost:3000/}"
+MARKER="${SSR_MARKER:-__reactRouterContext}"
+
+hdrs=$(docker exec "$CONTAINER" wget -q --server-response -O /tmp/ssr-probe.html "$URL" 2>&1 || true)
+body=$(docker exec "$CONTAINER" cat /tmp/ssr-probe.html 2>/dev/null || echo "")
+
+status=$(echo "$hdrs" | grep -m1 'HTTP/' | awk '{print $2}')
+ctype=$(echo "$hdrs" | grep -i -m1 'Content-Type:' | tr -d '\r')
+robots=$(echo "$hdrs" | grep -i -m1 'X-Robots-Tag:' | tr -d '\r')
+
+echo "  [$LABEL] status=${status:-<none>} | ${ctype:-Content-Type: <none>} | ${robots:-X-Robots-Tag: <none>}"
+
+if [ "${status:-}" != "200" ]; then
+  echo "  ❌ [$LABEL] GET / -> ${status:-no response} (expected 200)"
+  exit 1
+fi
+if ! echo "$ctype" | grep -qi 'text/html'; then
+  echo "  ❌ [$LABEL] GET / Content-Type is not text/html"
+  exit 1
+fi
+if ! printf '%s' "$body" | grep -qF "$MARKER"; then
+  echo "  ❌ [$LABEL] GET / lacks the stable SSR marker $MARKER — document was not server-rendered"
+  exit 1
+fi
+if echo "$robots" | grep -qi 'noindex'; then
+  echo "  ❌ [$LABEL] GET / served X-Robots-Tag: noindex — homepage is in DEGRADED FALLBACK (families empty)"
+  exit 1
+fi
+
+echo "  ✅ [$LABEL] GET / -> 200 text/html, SSR marker present, indexable (no noindex)"


### PR DESCRIPTION
**P0.** Two red defects found while auditing the PROD release bundle `da90deabd..a931205c`. Both are in the **deploy mechanics**, not in application code. No app code is touched here.

Full audit: `audit/2026-07-16-prod-bundle-da90deabd-a931205c.md` (`CODE_BUNDLE: APPROVE` / `PROD_RELEASE: NO-GO`).

## 🔴 1 — The automatic rollback was a proven no-op

Actual sequence in `deploy-prod.yml` before this PR:

1. Safety gate: `docker tag :preprod :production` + `docker push :production` → **`:production` already points at the NEW image**.
2. Deploy step: `CURRENT_IMAGE=$(docker inspect --format='{{.Image}}' nestjs-remix-monorepo-prod)` — the correct immutable ID of the old image — **computed, echoed, never used**.
3. Deploy step: `docker tag :production :production-previous` → since (1) already overwrote `:production`, **`production-previous` == the NEW image**.
4. Rollback: `docker tag :production-previous :production` → **restores the broken image**.

The health-failure branch protected nothing.

**Fix**
- New step **`💾 Capture rollback point`**, placed **before the safety gate** (ordering is load-bearing): reads the running container's **immutable image ID**, tags + pushes it as `production-previous` (off-box recovery point, best-effort push), and pins it as `$ROLLBACK_IMAGE_ID`.
- Rollback retags `:production` to that **pinned ID** (never to `production-previous`, the tag the old logic corrupted), then **asserts the restored container runs byte-exactly that ID**, then re-runs **`/health` AND the SSR probe**. A rollback that restores a broken page is not a rollback.
- First deploy / no running container → warns and disables auto-rollback explicitly (no silent fallback).

## 🔴 2 — No deploy gate rendered an SSR page

`/health` is a **separate NestJS controller**; every other probe (`/api/catalog/families`, `/api/gamme-rest/…`, admin guards) is an **API route**. The SSR data path is exactly what #1285 rewrote (`remix-api.server.ts` −623 lines + a per-request port injected in `remix.controller.ts`), so an SSR regression passed every gate and reached users.

**Fix** — a **blocking `GET /`** probe asserting:

| Assertion | Why |
|---|---|
| `200` | page answers |
| `Content-Type: text/html` | a document, not JSON/an error |
| body contains `__reactRouterContext` | RR8 hydration payload — present **only** if the document was really server-rendered (framework-level, doesn't churn with content) |
| **no `X-Robots-Tag: noindex`** | catches the **degraded homepage fallback** |

The **noindex assertion is load-bearing**: the homepage degraded fallback **does not throw** — it returns **HTTP 200** with empty families plus `X-Robots-Tag: noindex, follow` (`frontend/app/routes/_index.tsx`). A status-only probe is **blind** to it, and serving a `noindex` homepage to crawlers is an SEO incident.

It runs **post-deploy (failure ⇒ rollback)** and again in **Validate PROD**.

**Verified against live PROD** (healthy baseline): `200` · `content-type: text/html; charset=utf-8` · **no** `x-robots-tag` · `__reactRouterContext` present.

## Validation

- YAML parses; step order asserted (**capture at step 3, first `:production` mutation at line 114**).
- `bash -n` clean on all 6 `run:` blocks.
- No untrusted input introduced into any `run:` (only `docker inspect` output, a sha256 ID).

## Out of scope

The **~60–90s hard outage** (`docker stop` + `docker rm` of prod **and** caddy, then `sleep 60`) is **NOT** addressed here — deferred to a separate **blue/green** PR, per owner triage: the two red defects come first.

> No `v*` tag is created by this PR. PROD stays on `v2026.07.15-substitution-failopen-r1-404` (`da90deabd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)