### PR TITLE
fix(account): remove the dangling /orders/new CTA

### DIFF
--- a/frontend/app/components/account/AccountNavigation.tsx
+++ b/frontend/app/components/account/AccountNavigation.tsx
@@ -5,7 +5,6 @@ import {
   Mail,
   Key,
   Home,
-  Package,
   LogOut,
   ChevronRight,
   AlertTriangle,
@@ -158,17 +157,19 @@ export function SideNavigation({ user, stats }: SideNavigationProps) {
           Actions rapides
         </h3>
         <div className="space-y-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full justify-start"
-            asChild
-          >
-            <Link to="/orders/new">
-              <Package className="w-4 h-4 mr-2" />
-              Nouvelle commande
-            </Link>
-          </Button>
+          {/*
+           * NO "Nouvelle commande" CTA here.
+           *
+           * `/orders/new` is intentionally disabled (loader + action return 503)
+           * until an authenticated, idempotent, audited order-create use case
+           * exists — the real contract (idempotency `order_idempotency` +
+           * `create_order_atomic` RPC + resume-token) lives in OrdersController.
+           * This nav is rendered by AccountLayout on every /account/* route, so a
+           * CTA here put every logged-in customer one click from a bare 503.
+           *
+           * Do NOT re-add a link to /orders/new until that use case ships.
+           * Guarded by frontend/tests/unit/no-orders-new-cta.test.ts.
+           */}
           <Button
             variant="outline"
             size="sm"

--- a/frontend/tests/unit/no-orders-new-cta.test.ts
+++ b/frontend/tests/unit/no-orders-new-cta.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guard — no UI link to `/orders/new` while order creation is disabled.
+ *
+ * `/orders/new` intentionally answers **503** (loader + action throw) until an
+ * authenticated, idempotent, audited order-create use case exists: the real
+ * contract (idempotency `order_idempotency` + `create_order_atomic` RPC +
+ * resume-token) lives in `OrdersController`, not in a service method a port
+ * could call as-is.
+ *
+ * Why this guard: `AccountNavigation` shipped a "Nouvelle commande" CTA pointing
+ * at that route, and it is rendered by `AccountLayout` on every `/account/*`
+ * route — so every logged-in customer was one click away from a bare 503 error
+ * page. Found during the PROD release-bundle audit
+ * (`audit/2026-07-16-prod-bundle-da90deabd-a931205c.md`).
+ *
+ * Scope discipline: this guard covers the **CTA only**. It deliberately does not
+ * touch the 503 route itself, nor anything in the order domain — re-enabling
+ * creation is a separate, owner-gated chantier.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const APP_DIR = join(dirname(fileURLToPath(import.meta.url)), "../../app");
+
+/** Recursively collect every .ts/.tsx source under frontend/app. */
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Matches a LINK TARGET only — `to="/orders/new"`, `to={"/orders/new"}`,
+ * `href='/orders/new'`, ``to={`/orders/new`}``.
+ *
+ * Deliberately does NOT match a bare `'/orders/new'` string: `app/lib/auth.ts`
+ * legitimately lists the path in its route-protection tables, the route module
+ * must keep existing (it answers 503 on purpose), and prose mentioning the path
+ * must stay allowed.
+ */
+const LINK_TO_ORDERS_NEW = /(?:\bto|\bhref)\s*=\s*\{?\s*["'`]\/orders\/new\b/;
+
+describe("no /orders/new CTA while order creation is disabled (503)", () => {
+  it("no component links to /orders/new", () => {
+    const offenders = sourceFiles(APP_DIR)
+      .filter((file) => LINK_TO_ORDERS_NEW.test(readFileSync(file, "utf8")))
+      .map((file) => relative(APP_DIR, file));
+
+    expect(
+      offenders,
+      `A UI link to /orders/new reappeared in: ${offenders.join(", ")}. ` +
+        `That route answers 503 by design — linking to it sends real users to an ` +
+        `error page. Do not re-add it until an authenticated, idempotent, audited ` +
+        `order-create use case ships (order domain = separate owner-gated chantier).`,
+    ).toEqual([]);
+  });
+
+  it("AccountNavigation keeps its other quick action (guard is not vacuous)", () => {
+    const src = readFileSync(
+      join(APP_DIR, "components/account/AccountNavigation.tsx"),
+      "utf8",
+    );
+
+    // The component still exists and still renders a quick-actions CTA...
+    expect(src).toContain("/account/messages/new");
+    // ...but none of them targets the disabled route.
+    expect(LINK_TO_ORDERS_NEW.test(src)).toBe(false);
+  });
+});


### PR DESCRIPTION
Narrow, single-purpose PR. **CTA only** — the 503 route and the order domain are untouched.

## Why

`/orders/new` answers **503 by design** (loader + action throw) until an authenticated, idempotent, audited order-create use case exists — the real contract (idempotency `order_idempotency` + `create_order_atomic` RPC + resume-token) lives in `OrdersController`, not in a service method a port could call as-is.

But `AccountNavigation` still rendered a **"Nouvelle commande" CTA** pointing at it, and `AccountLayout` renders that nav on **every `/account/*` route (9 routes)** — so **every logged-in customer was one click from a bare 503 error page**.

Found during the PROD release-bundle audit → `audit/2026-07-16-prod-bundle-da90deabd-a931205c.md`. It was the **only real user-facing degradation** in the bundle.

## What

- Remove the CTA (`<Link to="/orders/new">` + its `Button` wrapper).
- Remove the now-unused `Package` lucide import — it had **no other use** in the file (verified; eslint + typecheck confirm).
- Leave an explicit comment at the removal site stating why, so the next reader doesn't "helpfully" re-add it.
- Add **`frontend/tests/unit/no-orders-new-cta.test.ts`**.

## The guard test

Scans `frontend/app` for any `to=` / `href=` **link target** pointing at `/orders/new` and fails if one reappears — anywhere, not just in this component.

**Proven non-vacuous** — the regex matches the exact CTA form just removed:

| Input | Result |
|---|---|
| `<Link to="/orders/new">` (the removed CTA) | **MATCH** ✅ |
| `to={"/orders/new"}` | **MATCH** ✅ |
| `href="/orders/new"` | **MATCH** ✅ |
| `'/orders/new',` (auth.ts route-protection entry) | no match ✅ |
| `Do NOT re-add a link to /orders/new until…` (prose) | no match ✅ |

It deliberately does **not** match a bare `'/orders/new'` string, so `app/lib/auth.ts` keeps listing the path in its route-protection tables, the route module keeps existing (503 on purpose), and prose may mention it. A second assertion checks `AccountNavigation` still renders its other quick action, so the guard can't pass by the component being deleted.

## Validation

- `vitest tests/unit/no-orders-new-cta.test.ts` → **2/2 pass**
- eslint (touched files) → clean · frontend typecheck → **exit 0**

## Not in scope

Re-enabling order creation is a **separate, owner-gated chantier** (order domain). This PR does not touch `routes/orders.new.tsx`, `lib/auth.ts`, or anything under the order domain.

> No `v*` tag. PROD stays on `v2026.07.15-substitution-failopen-r1-404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)