### PR TITLE
feat(seo-projection): wire dark r3 projection decision chain (P2-R3-D)

### DIFF
--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-07-02'
+last_scan: '2026-07-16'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts
@@ -16,6 +16,7 @@ depends_on:
 - CacheModule
 - SearchModule
 - SeoModule
+- SeoProjectionReadModule
 ---
 
 # Module Blog

--- a/backend/src/config/conseil-pack.constants.ts
+++ b/backend/src/config/conseil-pack.constants.ts
@@ -3,6 +3,8 @@
  * Used by ConseilQualityScorerService, ConseilPriorityService, and conseil-batch agent.
  */
 
+import { type PlannableSection } from './keyword-plan.constants';
+
 // ── Pack levels ──────────────────────────────────────────
 
 export type PackLevel = 'standard' | 'pro' | 'eeat';
@@ -10,8 +12,14 @@ export type PackLevel = 'standard' | 'pro' | 'eeat';
 export interface PackDefinition {
   id: PackLevel;
   label: string;
-  requiredSections: string[];
-  optionalSections: string[];
+  /**
+   * Sections exigées, typées sur le vocabulaire canonique `PLANNABLE_SECTIONS` (SoT unique,
+   * miroir de l'enum `page-contract-r3.json`). Le typage empêche à la compilation une entrée
+   * hors canon (ex. `S2_DIAGNOSTIC` au lieu de `S2_DIAG`) que les consommateurs traiteraient
+   * sinon comme une section indéfiniment manquante.
+   */
+  requiredSections: PlannableSection[];
+  optionalSections: PlannableSection[];
   minSectionScore: number;
   minPackScore: number;
   minFaqCount: number;

--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -189,6 +189,28 @@ export class FeatureFlagsService {
     }
   }
 
+  // ── SEO projection READ (P2-R3-D) ──
+
+  /**
+   * Master flag de **LECTURE** de la projection SEO (ADR-059, P2-R3-D). Contrairement à
+   * `r1ContentPipelineEnabled` / `r8OwnedEditorialEnabled` qui gatent le chemin d'ÉCRITURE, celui-ci
+   * gate le **chemin servi** : OFF ⇒ le consumer ne lit RIEN (0 appel RPC) et sert le legacy.
+   * **Défaut OFF** — DARK au boot. L'activation d'une entité exige EN PLUS `seoProjectionReadCanary`.
+   */
+  get seoProjectionReadV1(): boolean {
+    return this.bool('SEO_PROJECTION_READ_V1', false);
+  }
+
+  /**
+   * Allowlist canary **role-scoped** de lecture : jetons `<ROLE>@<entity_id>` (ex.
+   * `R3_CONSEILS@gamme:filtre-a-huile`). Un GO R3 sur une gamme n'active JAMAIS R4/R6 de la même
+   * gamme — l'identité est la PAIRE, jamais l'entité seule. **Défaut vide = fail-closed** (aucune
+   * entité lue même si le master flag passe ON).
+   */
+  get seoProjectionReadCanary(): string[] {
+    return this.csv('SEO_PROJECTION_READ_CANARY');
+  }
+
   // ── Conseil Pack flags ──
 
   get conseilPackEnabled(): boolean {
@@ -394,6 +416,8 @@ export class FeatureFlagsService {
     'BRIEF_GATES_ENABLED',
     'BRIEF_GATES_OBSERVE_ONLY',
     'SEO_BRIEF_WIKI_ENABLED',
+    'SEO_PROJECTION_READ_V1',
+    'SEO_PROJECTION_READ_CANARY',
     'RAG_CATCHUP_ENABLED',
     'RAG_MERGE_DRY_RUN',
     'RAG_MERGE_ALLOWED_ROLES',

--- a/backend/src/modules/admin/services/conseil-quality-scorer.service.ts
+++ b/backend/src/modules/admin/services/conseil-quality-scorer.service.ts
@@ -203,8 +203,11 @@ export class ConseilQualityScorerService extends SupabaseBaseService {
       const scores = sections
         .filter(
           (s) =>
-            pack.requiredSections.includes(s.sgc_section_type) &&
-            s.sgc_quality_score !== null,
+            // `sgc_section_type` est une chaîne DB arbitraire testée pour appartenance à la
+            // liste canonique : on élargit le RÉCEPTEUR, sans affaiblir le type du pack.
+            (pack.requiredSections as readonly string[]).includes(
+              s.sgc_section_type,
+            ) && s.sgc_quality_score !== null,
         )
         .map((s) => s.sgc_quality_score!);
 

--- a/backend/src/modules/blog/blog.module.ts
+++ b/backend/src/modules/blog/blog.module.ts
@@ -28,6 +28,7 @@ import { BlogArticleRelationService } from './services/blog-article-relation.ser
 import { ConstructeurSearchService } from './services/constructeur-search.service';
 import { ConstructeurTransformService } from './services/constructeur-transform.service';
 import { AdviceTransformService } from './services/advice-transform.service';
+import { R3ProjectionDecisionService } from './services/r3-projection-decision.service';
 import { AdviceEnrichmentService } from './services/advice-enrichment.service';
 import { R3GuideService } from './services/r3-guide.service';
 import { R6GuideService } from './services/r6-guide.service';
@@ -35,6 +36,7 @@ import { R6GuideService } from './services/r6-guide.service';
 // Modules externes requis
 import { SearchModule } from '../search/search.module';
 import { SeoModule } from '../seo/seo.module';
+import { SeoProjectionReadModule } from '../seo-projection/seo-projection-read.module';
 
 /**
  * 📰 BlogModule - Module de gestion complète du contenu blog
@@ -69,6 +71,10 @@ import { SeoModule } from '../seo/seo.module';
     }),
     SearchModule, // Services Meilisearch et Supabase intégrés
     SeoModule, // 🔗 InternalLinkingService pour maillage interne
+    // Lecture seule de la projection SEO (ADR-059). Module LÉGER volontairement : jamais
+    // `SeoProjectionModule` (writer + gate service_role + queues) ni `AdminModule` — le runtime
+    // public ne doit tirer aucune capacité d'écriture.
+    SeoProjectionReadModule,
   ],
   controllers: [
     BlogController, // API générale blog et recherche
@@ -100,6 +106,7 @@ import { SeoModule } from '../seo/seo.module';
     ConstructeurTransformService,
     AdviceTransformService,
     AdviceEnrichmentService,
+    R3ProjectionDecisionService, // Chaîne de décision projection R3 (DARK — flags OFF)
     R3GuideService, // R3 page engine orchestrator
     R6GuideService, // R6 guide d'achat orchestrator
   ],

--- a/backend/src/modules/blog/interfaces/r3-guide.interfaces.ts
+++ b/backend/src/modules/blog/interfaces/r3-guide.interfaces.ts
@@ -5,8 +5,9 @@
 
 import type { BlogArticle } from './blog.interfaces';
 import type {
-  R3BodySource,
   R3FallbackReason,
+  R3ProjectionStatus,
+  R3ServedBodySource,
 } from '../services/r3-projection-decision.service';
 
 export interface R3GuidePage {
@@ -59,12 +60,15 @@ export interface R3GuideSection {
  * présence EST le signal de ciblage (elle commande le bypass de cache backend et le `no-store`
  * côté loader). Absent = hors canary = chemin legacy strictement inchangé.
  *
- * **P2-R3-D est une chaîne de décision, pas un rendu** : `decision: 'projection'` signifie « la
- * projection est complète et servable », PAS « le BODY ci-joint vient de la projection ». Le BODY
- * reste legacy dans TOUS les cas tant que le rendu md→HTML gouverné n'existe pas (P2-R3-E).
+ * **P2-R3-D est une chaîne de décision, pas un rendu.** Les deux champs sont distincts :
+ * `projectionStatus` = état de PRÉPARATION (`READY_FOR_RENDER` = DTO complet produit par le
+ * mapper) ; `servedBodySource` = source RÉELLEMENT rendue, figée au littéral `'legacy'` tant que
+ * le renderer md→HTML gouverné n'existe pas (P2-R3-E). `READY_FOR_RENDER` ne signifie JAMAIS
+ * « le BODY ci-joint vient de la projection ».
  */
 export interface R3ProjectionMeta {
-  decision: R3BodySource;
+  projectionStatus: R3ProjectionStatus;
+  servedBodySource: R3ServedBodySource;
   fallbackReason: R3FallbackReason | null;
   mappedCount: number;
   invalidCount: number;

--- a/backend/src/modules/blog/interfaces/r3-guide.interfaces.ts
+++ b/backend/src/modules/blog/interfaces/r3-guide.interfaces.ts
@@ -4,6 +4,10 @@
  */
 
 import type { BlogArticle } from './blog.interfaces';
+import type {
+  R3BodySource,
+  R3FallbackReason,
+} from '../services/r3-projection-decision.service';
 
 export interface R3GuidePage {
   pg_alias: string;
@@ -48,6 +52,24 @@ export interface R3GuideSection {
   image?: R3GuideSectionImage | null;
 }
 
+/**
+ * Verdict de la chaîne de décision projection (P2-R3-D).
+ *
+ * **Présent UNIQUEMENT si la paire `R3_CONSEILS@gamme:<alias>` est ciblée par la canary** — sa
+ * présence EST le signal de ciblage (elle commande le bypass de cache backend et le `no-store`
+ * côté loader). Absent = hors canary = chemin legacy strictement inchangé.
+ *
+ * **P2-R3-D est une chaîne de décision, pas un rendu** : `decision: 'projection'` signifie « la
+ * projection est complète et servable », PAS « le BODY ci-joint vient de la projection ». Le BODY
+ * reste legacy dans TOUS les cas tant que le rendu md→HTML gouverné n'existe pas (P2-R3-E).
+ */
+export interface R3ProjectionMeta {
+  decision: R3BodySource;
+  fallbackReason: R3FallbackReason | null;
+  mappedCount: number;
+  invalidCount: number;
+}
+
 export interface R3GuidePayload {
   page: R3GuidePage;
   s1Sections: R3GuideSection[];
@@ -62,4 +84,6 @@ export interface R3GuidePayload {
     previous: BlogArticle | null;
     next: BlogArticle | null;
   };
+  /** Voir {@link R3ProjectionMeta} — absent hors canary (donc absent partout tant que les flags sont OFF). */
+  projectionMeta?: R3ProjectionMeta;
 }

--- a/backend/src/modules/blog/services/r3-guide.service.test.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.test.ts
@@ -18,6 +18,7 @@ import { BlogArticleDataService } from './blog-article-data.service';
 import { BlogSeoService } from './blog-seo.service';
 import { BlogArticleRelationService } from './blog-article-relation.service';
 import { InternalLinkingService } from '../../seo/internal-linking.service';
+import { R3ProjectionDecisionService } from './r3-projection-decision.service';
 import { R3GuideService } from './r3-guide.service';
 
 interface CacheEntry {
@@ -97,7 +98,18 @@ function makeMocks() {
   const internalLinkingService = {
     processLinkGamme: jest.fn().mockImplementation(async (s: string) => s),
   };
-  return { dataService, seoService, relationService, internalLinkingService };
+  // Par défaut : HORS canary (flags OFF en prod) → le chemin legacy caché reste inchangé.
+  const projectionDecision = {
+    isTargeted: jest.fn().mockReturnValue(false),
+    decide: jest.fn(),
+  };
+  return {
+    dataService,
+    seoService,
+    relationService,
+    internalLinkingService,
+    projectionDecision,
+  };
 }
 
 async function buildService(): Promise<{
@@ -105,6 +117,7 @@ async function buildService(): Promise<{
   cache: InMemoryCacheServiceStub;
   dataService: ReturnType<typeof makeMocks>['dataService'];
   relationService: ReturnType<typeof makeMocks>['relationService'];
+  projectionDecision: ReturnType<typeof makeMocks>['projectionDecision'];
 }> {
   const cache = new InMemoryCacheServiceStub();
   const mocks = makeMocks();
@@ -120,6 +133,10 @@ async function buildService(): Promise<{
         provide: InternalLinkingService,
         useValue: mocks.internalLinkingService,
       },
+      {
+        provide: R3ProjectionDecisionService,
+        useValue: mocks.projectionDecision,
+      },
     ],
   }).compile();
 
@@ -129,6 +146,7 @@ async function buildService(): Promise<{
     cache,
     dataService: mocks.dataService,
     relationService: mocks.relationService,
+    projectionDecision: mocks.projectionDecision,
   };
 }
 
@@ -304,5 +322,118 @@ describe('R3GuideService — cache + single-flight + invalidation (PR-A)', () =>
 
       expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe('R3GuideService — canary projection (P2-R3-D, dark)', () => {
+  const TARGETED_DECISION = {
+    entityKey: `gamme:${PG_ALIAS}`,
+    projectionRole: 'R3_CONSEILS' as const,
+    bodySource: 'projection' as const,
+    fallbackReason: null,
+    mappedCount: 7,
+    invalidCount: 0,
+    slots: {},
+  };
+
+  it('hors canary : aucune décision projetée, aucun appel à decide(), payload legacy intact', async () => {
+    const { service, projectionDecision } = await buildService();
+
+    const payload = await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(projectionDecision.isTargeted).toHaveBeenCalledWith(PG_ALIAS);
+    expect(projectionDecision.decide).not.toHaveBeenCalled();
+    expect(payload?.projectionMeta).toBeUndefined();
+  });
+
+  it('hors canary : le cache Redis legacy sert toujours le 2e appel (chemin inchangé)', async () => {
+    const { service, dataService } = await buildService();
+
+    await service.getR3GuidePayload(PG_ALIAS);
+    await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+  });
+
+  it('canary ciblée : bypass total du cache — jamais de lecture ni écriture Redis', async () => {
+    const { service, cache, projectionDecision } = await buildService();
+    projectionDecision.isTargeted.mockReturnValue(true);
+    projectionDecision.decide.mockResolvedValue(TARGETED_DECISION);
+    const getSpy = jest.spyOn(cache, 'get');
+    const setSpy = jest.spyOn(cache, 'set');
+
+    await service.getR3GuidePayload(PG_ALIAS);
+    await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(getSpy).not.toHaveBeenCalled();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('canary ciblée : aucune clé legacy ne peut retenir un payload ciblé (recompute à chaque appel)', async () => {
+    const { service, dataService, projectionDecision } = await buildService();
+    projectionDecision.isTargeted.mockReturnValue(true);
+    projectionDecision.decide.mockResolvedValue(TARGETED_DECISION);
+
+    await service.getR3GuidePayload(PG_ALIAS);
+    await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
+  });
+
+  it('canary ciblée : attache projectionMeta (signal de ciblage) sans toucher le HEAD', async () => {
+    const { service, projectionDecision } = await buildService();
+    projectionDecision.isTargeted.mockReturnValue(true);
+    projectionDecision.decide.mockResolvedValue(TARGETED_DECISION);
+
+    const payload = await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(payload?.projectionMeta).toEqual({
+      decision: 'projection',
+      fallbackReason: null,
+      mappedCount: 7,
+      invalidCount: 0,
+    });
+    // HEAD (autorité SEO) strictement inchangé par la canary.
+    expect(payload?.page.sourceType).toBe('article');
+    expect(payload?.page.metaTitle).toBe(articleStub.title);
+  });
+
+  it('canary ciblée + repli : projectionMeta expose la cause, BODY legacy servi', async () => {
+    const { service, projectionDecision } = await buildService();
+    projectionDecision.isTargeted.mockReturnValue(true);
+    projectionDecision.decide.mockResolvedValue({
+      ...TARGETED_DECISION,
+      bodySource: 'legacy',
+      fallbackReason: 'PROJECTION_ABSENT',
+      mappedCount: 0,
+      slots: null,
+    });
+
+    const payload = await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(payload?.projectionMeta?.decision).toBe('legacy');
+    expect(payload?.projectionMeta?.fallbackReason).toBe('PROJECTION_ABSENT');
+
+    // BODY legacy COMPLET : hors projectionMeta, le payload est identique à celui servi
+    // hors canary. Aucune fusion partielle possible.
+    const legacy = await (
+      await buildService()
+    ).service.getR3GuidePayload(PG_ALIAS);
+    const { projectionMeta: _meta, ...targetedBody } = payload!;
+    expect(targetedBody).toEqual(legacy);
+  });
+
+  it('canary ciblée : un article introuvable reste 404 (null), sans appeler decide()', async () => {
+    const { service, dataService, projectionDecision } = await buildService();
+    projectionDecision.isTargeted.mockReturnValue(true);
+    dataService.getArticleByGamme.mockResolvedValueOnce({
+      article: null,
+      gammeData: null,
+    });
+
+    const payload = await service.getR3GuidePayload(PG_ALIAS);
+
+    expect(payload).toBeNull();
+    expect(projectionDecision.decide).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/blog/services/r3-guide.service.test.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.test.ts
@@ -329,7 +329,8 @@ describe('R3GuideService — canary projection (P2-R3-D, dark)', () => {
   const TARGETED_DECISION = {
     entityKey: `gamme:${PG_ALIAS}`,
     projectionRole: 'R3_CONSEILS' as const,
-    bodySource: 'projection' as const,
+    projectionStatus: 'READY_FOR_RENDER' as const,
+    servedBodySource: 'legacy' as const,
     fallbackReason: null,
     mappedCount: 7,
     invalidCount: 0,
@@ -388,7 +389,9 @@ describe('R3GuideService — canary projection (P2-R3-D, dark)', () => {
     const payload = await service.getR3GuidePayload(PG_ALIAS);
 
     expect(payload?.projectionMeta).toEqual({
-      decision: 'projection',
+      projectionStatus: 'READY_FOR_RENDER',
+      // Prête à être rendue, mais le BODY servi reste legacy : D n'a pas de renderer.
+      servedBodySource: 'legacy',
       fallbackReason: null,
       mappedCount: 7,
       invalidCount: 0,
@@ -403,7 +406,7 @@ describe('R3GuideService — canary projection (P2-R3-D, dark)', () => {
     projectionDecision.isTargeted.mockReturnValue(true);
     projectionDecision.decide.mockResolvedValue({
       ...TARGETED_DECISION,
-      bodySource: 'legacy',
+      projectionStatus: 'FALLBACK',
       fallbackReason: 'PROJECTION_ABSENT',
       mappedCount: 0,
       slots: null,
@@ -411,7 +414,8 @@ describe('R3GuideService — canary projection (P2-R3-D, dark)', () => {
 
     const payload = await service.getR3GuidePayload(PG_ALIAS);
 
-    expect(payload?.projectionMeta?.decision).toBe('legacy');
+    expect(payload?.projectionMeta?.projectionStatus).toBe('FALLBACK');
+    expect(payload?.projectionMeta?.servedBodySource).toBe('legacy');
     expect(payload?.projectionMeta?.fallbackReason).toBe('PROJECTION_ABSENT');
 
     // BODY legacy COMPLET : hors projectionMeta, le payload est identique à celui servi

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -22,6 +22,7 @@ import type {
   R3GuidePage,
   R3GuideSection,
 } from '../interfaces/r3-guide.interfaces';
+import { R3ProjectionDecisionService } from './r3-projection-decision.service';
 import {
   slugifyTitle,
   normalizeStepHtml,
@@ -70,6 +71,7 @@ export class R3GuideService {
     private readonly seoService: BlogSeoService,
     private readonly relationService: BlogArticleRelationService,
     private readonly internalLinkingService: InternalLinkingService,
+    private readonly projectionDecision: R3ProjectionDecisionService,
   ) {}
 
   /**
@@ -97,6 +99,14 @@ export class R3GuideService {
    * 9-fanout, but cached null risks delaying legitimate publishes.
    */
   async getR3GuidePayload(pg_alias: string): Promise<R3GuidePayload | null> {
+    // Canary ciblée → bypass TOTAL du cache (lecture ET écriture). Sans cela, la clé partagée
+    // `r3-guide:v2:<alias>` pourrait contenir alternativement un payload ciblé et un payload
+    // hors-canary selon qui l'a peuplée en premier — empoisonnement croisé. Décision synchrone,
+    // 0 RPC : hors canary, le chemin ci-dessous reste strictement inchangé.
+    if (this.projectionDecision.isTargeted(pg_alias)) {
+      return this.computeTargetedPayload(pg_alias);
+    }
+
     const cacheKey = `${R3_CACHE_PREFIX}${pg_alias}`;
     const startedAt = Date.now();
 
@@ -152,6 +162,32 @@ export class R3GuideService {
 
     this.inflight.set(cacheKey, promise);
     return promise;
+  }
+
+  /**
+   * Chemin canary ciblé — hors cache Redis (ni lecture, ni écriture, ni single-flight partagé).
+   *
+   * Compose le BODY **legacy** puis attache le verdict de la chaîne de décision. En P2-R3-D le
+   * BODY servi reste legacy même quand `decision === 'projection'` : cette PR prouve le câblage
+   * gouverné (flag → allowlist → reader → mapper → ready) et l'observabilité du repli, pas le
+   * rendu — le rendu md→HTML de la projection est le périmètre de P2-R3-E.
+   */
+  private async computeTargetedPayload(
+    pg_alias: string,
+  ): Promise<R3GuidePayload | null> {
+    const payload = await this.computeLegacyPayload(pg_alias);
+    if (payload === null) return null;
+
+    const decision = await this.projectionDecision.decide(pg_alias);
+    return {
+      ...payload,
+      projectionMeta: {
+        decision: decision.bodySource,
+        fallbackReason: decision.fallbackReason,
+        mappedCount: decision.mappedCount,
+        invalidCount: decision.invalidCount,
+      },
+    };
   }
 
   /**

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -168,9 +168,9 @@ export class R3GuideService {
    * Chemin canary ciblé — hors cache Redis (ni lecture, ni écriture, ni single-flight partagé).
    *
    * Compose le BODY **legacy** puis attache le verdict de la chaîne de décision. En P2-R3-D le
-   * BODY servi reste legacy même quand `decision === 'projection'` : cette PR prouve le câblage
-   * gouverné (flag → allowlist → reader → mapper → ready) et l'observabilité du repli, pas le
-   * rendu — le rendu md→HTML de la projection est le périmètre de P2-R3-E.
+   * BODY servi reste legacy même quand `projectionStatus === 'READY_FOR_RENDER'` : cette PR prouve
+   * le câblage gouverné (flag → allowlist → reader → mapper → ready) et l'observabilité du repli,
+   * pas le rendu — le rendu md→HTML de la projection est le périmètre de P2-R3-E.
    */
   private async computeTargetedPayload(
     pg_alias: string,
@@ -182,7 +182,8 @@ export class R3GuideService {
     return {
       ...payload,
       projectionMeta: {
-        decision: decision.bodySource,
+        projectionStatus: decision.projectionStatus,
+        servedBodySource: decision.servedBodySource,
         fallbackReason: decision.fallbackReason,
         mappedCount: decision.mappedCount,
         invalidCount: decision.invalidCount,

--- a/backend/src/modules/blog/services/r3-projection-decision.service.test.ts
+++ b/backend/src/modules/blog/services/r3-projection-decision.service.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests P2-R3-D — chaîne de décision DARK du consumer R3.
+ *
+ * Prouve l'ORDRE imposé (entityKey → master flag → allowlist rôle+entité → reader → mapper →
+ * ready → bodySource) et surtout l'invariant : master flag OFF **ou** paire non allowlistée
+ * ⇒ **0 appel RPC**. Les flags sont OFF par défaut → tout le monde reste sur le legacy.
+ */
+import { Logger } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { FeatureFlagsService } from '@config/feature-flags.service';
+import { PACK_DEFINITIONS } from '@config/conseil-pack.constants';
+import { SeoProjectionReaderService } from '@modules/seo-projection/seo-projection-reader.service';
+import type { ProjectionEnvelope } from '@modules/seo-projection/seo-projection-reader.service';
+import {
+  R3ProjectionDecisionService,
+  R3_PROJECTION_ROLE,
+} from './r3-projection-decision.service';
+
+const PILOT_ALIAS = 'filtre-a-huile';
+const PILOT_ENTITY_KEY = `gamme:${PILOT_ALIAS}`;
+const PILOT_TOKEN = `${R3_PROJECTION_ROLE}@${PILOT_ENTITY_KEY}`;
+
+/** Bloc R3 conforme au contrat d'export (exports-seo.schema.json v1.1.0). */
+function r3Block(
+  section: string,
+  content_md: string,
+  source_ids: string[] = ['db:pieces_gamme'],
+  truth_level = 'db_owned',
+) {
+  return {
+    role: R3_PROJECTION_ROLE,
+    content: {
+      content_md,
+      source_ids,
+      truth_level,
+      section,
+      usefulness_target: null,
+    },
+  };
+}
+
+/** Enveloppe couvrant TOUTES les sections requises du pack `standard`. */
+function completeEnvelope(): ProjectionEnvelope {
+  return {
+    entity_id: PILOT_ENTITY_KEY,
+    entity_type: 'gamme',
+    slug: PILOT_ALIAS,
+    facts: [],
+    blocks: PACK_DEFINITIONS.standard.requiredSections.map((s) =>
+      r3Block(s, `# ${s}\n\nContenu **verbatim** de ${s}.`),
+    ) as ProjectionEnvelope['blocks'],
+  };
+}
+
+describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
+  let service: R3ProjectionDecisionService;
+  let reader: { readActiveProjection: jest.Mock };
+  let flags: {
+    seoProjectionReadV1: boolean;
+    seoProjectionReadCanary: string[];
+  };
+
+  beforeEach(async () => {
+    reader = { readActiveProjection: jest.fn() };
+    flags = { seoProjectionReadV1: false, seoProjectionReadCanary: [] };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        R3ProjectionDecisionService,
+        { provide: SeoProjectionReaderService, useValue: reader },
+        { provide: FeatureFlagsService, useValue: flags },
+      ],
+    }).compile();
+
+    service = moduleRef.get(R3ProjectionDecisionService);
+  });
+
+  // ── 1. Master flag ────────────────────────────────────────────────────────
+
+  it('flag OFF (défaut) → legacy + MASTER_OFF, sans AUCUN appel RPC', async () => {
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.bodySource).toBe('legacy');
+    expect(decision.fallbackReason).toBe('MASTER_OFF');
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  it('flag OFF alors même que la paire est allowlistée → MASTER_OFF, 0 RPC (le master prime)', async () => {
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.fallbackReason).toBe('MASTER_OFF');
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  // ── 2. Allowlist rôle + entité ────────────────────────────────────────────
+
+  it('flag ON + allowlist vide → legacy + NOT_ALLOWLISTED, 0 RPC', async () => {
+    flags.seoProjectionReadV1 = true;
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.bodySource).toBe('legacy');
+    expect(decision.fallbackReason).toBe('NOT_ALLOWLISTED');
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  it('flag ON + autre ENTITÉ allowlistée → NOT_ALLOWLISTED, 0 RPC', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [
+      `${R3_PROJECTION_ROLE}@gamme:plaquette-de-frein`,
+    ];
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.fallbackReason).toBe('NOT_ALLOWLISTED');
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  it("un GO R4 sur la MÊME gamme n'active JAMAIS R3 (allowlist role-scoped)", async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [`R4_REFERENCE@${PILOT_ENTITY_KEY}`];
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.fallbackReason).toBe('NOT_ALLOWLISTED');
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  it("l'entité seule (sans rôle) dans l'allowlist n'active PAS la lecture", async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_ENTITY_KEY];
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.fallbackReason).toBe('NOT_ALLOWLISTED');
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  // ── 3. Identité canonique + appel du reader ───────────────────────────────
+
+  it('paire allowlistée → lit avec entityKey namespacé `gamme:<alias>` et le rôle R3_CONSEILS', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    reader.readActiveProjection.mockResolvedValue({
+      envelope: completeEnvelope(),
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(reader.readActiveProjection).toHaveBeenCalledTimes(1);
+    expect(reader.readActiveProjection).toHaveBeenCalledWith(
+      PILOT_ENTITY_KEY,
+      R3_PROJECTION_ROLE,
+    );
+    expect(decision.entityKey).toBe(PILOT_ENTITY_KEY);
+    expect(decision.projectionRole).toBe(R3_PROJECTION_ROLE);
+  });
+
+  // ── 4. Dégradations observables du reader ─────────────────────────────────
+
+  it.each([
+    ['RPC error: permission denied', 'RPC_ERROR'],
+    ['RPC exception', 'RPC_EXCEPTION'],
+    ['projection absente', 'PROJECTION_ABSENT'],
+  ])(
+    'dégradation reader « %s » → legacy + %s',
+    async (degradeReason, expected) => {
+      flags.seoProjectionReadV1 = true;
+      flags.seoProjectionReadCanary = [PILOT_TOKEN];
+      reader.readActiveProjection.mockResolvedValue({
+        envelope: null,
+        degradeReason,
+      });
+
+      const decision = await service.decide(PILOT_ALIAS);
+
+      expect(decision.bodySource).toBe('legacy');
+      expect(decision.fallbackReason).toBe(expected);
+    },
+  );
+
+  // ── 5. Verdicts du mapper ─────────────────────────────────────────────────
+
+  it('bloc hors contrat → legacy + MAPPER_INVALID (jamais de projection partielle)', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    const envelope = completeEnvelope();
+    // content_md absent → block_contract_invalid côté mapper
+    (envelope.blocks as unknown[])[0] = {
+      role: R3_PROJECTION_ROLE,
+      content: { section: 'S1', source_ids: [], truth_level: 'db_owned' },
+    };
+    reader.readActiveProjection.mockResolvedValue({
+      envelope,
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.bodySource).toBe('legacy');
+    expect(decision.fallbackReason).toBe('MAPPER_INVALID');
+    expect(decision.invalidCount).toBeGreaterThan(0);
+  });
+
+  it('section requise du pack absente → legacy + MAPPER_INCOMPLETE', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    const envelope = completeEnvelope();
+    envelope.blocks = (envelope.blocks as unknown[]).slice(
+      1,
+    ) as ProjectionEnvelope['blocks']; // retire S1 (requis)
+    reader.readActiveProjection.mockResolvedValue({
+      envelope,
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.bodySource).toBe('legacy');
+    expect(decision.fallbackReason).toBe('MAPPER_INCOMPLETE');
+  });
+
+  it('enveloppe sans aucun bloc R3 → legacy + MAPPER_INCOMPLETE (jamais une page vide)', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    reader.readActiveProjection.mockResolvedValue({
+      envelope: { ...completeEnvelope(), blocks: [] },
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.bodySource).toBe('legacy');
+    expect(decision.fallbackReason).toBe('MAPPER_INCOMPLETE');
+  });
+
+  // ── 6. Chemin nominal + complétude via le pack `standard` ─────────────────
+
+  it('projection complète (pack standard satisfait) → bodySource=projection, 0 fallback', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    reader.readActiveProjection.mockResolvedValue({
+      envelope: completeEnvelope(),
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.bodySource).toBe('projection');
+    expect(decision.fallbackReason).toBeNull();
+    expect(decision.invalidCount).toBe(0);
+    expect(decision.mappedCount).toBe(
+      PACK_DEFINITIONS.standard.requiredSections.length,
+    );
+  });
+
+  it('la complétude est jugée sur les sections requises du pack `standard`', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    // Une seule section présente : suffisant pour le mapper, PAS pour le pack.
+    reader.readActiveProjection.mockResolvedValue({
+      envelope: {
+        ...completeEnvelope(),
+        blocks: [r3Block('S1', '# S1')] as never,
+      },
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.fallbackReason).toBe('MAPPER_INCOMPLETE');
+    expect(decision.bodySource).toBe('legacy');
+  });
+
+  // ── 7. Caractérisation : 0 reformulation intermédiaire ────────────────────
+
+  it('le DTO projeté transporte le content_md du mapper byte-for-byte', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    const envelope = completeEnvelope();
+    reader.readActiveProjection.mockResolvedValue({
+      envelope,
+      degradeReason: null,
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.slots).not.toBeNull();
+    for (const block of envelope.blocks as unknown as Array<{
+      content: { section: string; content_md: string };
+    }>) {
+      expect(decision.slots?.[block.content.section].content_md).toBe(
+        block.content.content_md,
+      );
+    }
+  });
+
+  it('aucun slot exposé quand le BODY servi est legacy (pas de fuite de projection partielle)', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    reader.readActiveProjection.mockResolvedValue({
+      envelope: null,
+      degradeReason: 'projection absente',
+    });
+
+    const decision = await service.decide(PILOT_ALIAS);
+
+    expect(decision.slots).toBeNull();
+  });
+
+  // ── 8. Signal de ciblage (bypass cache) — sans RPC ────────────────────────
+
+  it('isTargeted : false quand le flag est OFF, sans appel RPC', () => {
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+
+    expect(service.isTargeted(PILOT_ALIAS)).toBe(false);
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  it('isTargeted : true seulement pour la paire exacte rôle+entité, sans appel RPC', () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+
+    expect(service.isTargeted(PILOT_ALIAS)).toBe(true);
+    expect(service.isTargeted('plaquette-de-frein')).toBe(false);
+    expect(reader.readActiveProjection).not.toHaveBeenCalled();
+  });
+
+  // ── 9. Observabilité ──────────────────────────────────────────────────────
+
+  it('journalise la décision avec les champs de diagnostic exigés', async () => {
+    flags.seoProjectionReadV1 = true;
+    flags.seoProjectionReadCanary = [PILOT_TOKEN];
+    reader.readActiveProjection.mockResolvedValue({
+      envelope: null,
+      degradeReason: 'projection absente',
+    });
+    const logSpy = jest
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
+
+    await service.decide(PILOT_ALIAS);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_key: PILOT_ENTITY_KEY,
+        projection_role: R3_PROJECTION_ROLE,
+        decision: 'legacy',
+        fallback_reason: 'PROJECTION_ABSENT',
+        mapped_count: 0,
+        invalid_count: 0,
+      }),
+    );
+    logSpy.mockRestore();
+  });
+});

--- a/backend/src/modules/blog/services/r3-projection-decision.service.test.ts
+++ b/backend/src/modules/blog/services/r3-projection-decision.service.test.ts
@@ -2,7 +2,7 @@
  * Tests P2-R3-D — chaîne de décision DARK du consumer R3.
  *
  * Prouve l'ORDRE imposé (entityKey → master flag → allowlist rôle+entité → reader → mapper →
- * ready → bodySource) et surtout l'invariant : master flag OFF **ou** paire non allowlistée
+ * ready → projectionStatus) et surtout l'invariant : master flag OFF **ou** paire non allowlistée
  * ⇒ **0 appel RPC**. Les flags sont OFF par défaut → tout le monde reste sur le legacy.
  */
 import { Logger } from '@nestjs/common';
@@ -11,7 +11,9 @@ import { FeatureFlagsService } from '@config/feature-flags.service';
 import { PACK_DEFINITIONS } from '@config/conseil-pack.constants';
 import { SeoProjectionReaderService } from '@modules/seo-projection/seo-projection-reader.service';
 import type { ProjectionEnvelope } from '@modules/seo-projection/seo-projection-reader.service';
+import type { R3InvalidEntry } from '@modules/seo-projection/projection-r3.mapper';
 import {
+  classifyMapperFallback,
   R3ProjectionDecisionService,
   R3_PROJECTION_ROLE,
 } from './r3-projection-decision.service';
@@ -80,7 +82,8 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
   it('flag OFF (défaut) → legacy + MASTER_OFF, sans AUCUN appel RPC', async () => {
     const decision = await service.decide(PILOT_ALIAS);
 
-    expect(decision.bodySource).toBe('legacy');
+    expect(decision.projectionStatus).toBe('FALLBACK');
+    expect(decision.servedBodySource).toBe('legacy');
     expect(decision.fallbackReason).toBe('MASTER_OFF');
     expect(reader.readActiveProjection).not.toHaveBeenCalled();
   });
@@ -101,7 +104,8 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
 
     const decision = await service.decide(PILOT_ALIAS);
 
-    expect(decision.bodySource).toBe('legacy');
+    expect(decision.projectionStatus).toBe('FALLBACK');
+    expect(decision.servedBodySource).toBe('legacy');
     expect(decision.fallbackReason).toBe('NOT_ALLOWLISTED');
     expect(reader.readActiveProjection).not.toHaveBeenCalled();
   });
@@ -177,7 +181,8 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
 
       const decision = await service.decide(PILOT_ALIAS);
 
-      expect(decision.bodySource).toBe('legacy');
+      expect(decision.projectionStatus).toBe('FALLBACK');
+      expect(decision.servedBodySource).toBe('legacy');
       expect(decision.fallbackReason).toBe(expected);
     },
   );
@@ -200,7 +205,8 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
 
     const decision = await service.decide(PILOT_ALIAS);
 
-    expect(decision.bodySource).toBe('legacy');
+    expect(decision.projectionStatus).toBe('FALLBACK');
+    expect(decision.servedBodySource).toBe('legacy');
     expect(decision.fallbackReason).toBe('MAPPER_INVALID');
     expect(decision.invalidCount).toBeGreaterThan(0);
   });
@@ -219,7 +225,8 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
 
     const decision = await service.decide(PILOT_ALIAS);
 
-    expect(decision.bodySource).toBe('legacy');
+    expect(decision.projectionStatus).toBe('FALLBACK');
+    expect(decision.servedBodySource).toBe('legacy');
     expect(decision.fallbackReason).toBe('MAPPER_INCOMPLETE');
   });
 
@@ -233,13 +240,14 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
 
     const decision = await service.decide(PILOT_ALIAS);
 
-    expect(decision.bodySource).toBe('legacy');
+    expect(decision.projectionStatus).toBe('FALLBACK');
+    expect(decision.servedBodySource).toBe('legacy');
     expect(decision.fallbackReason).toBe('MAPPER_INCOMPLETE');
   });
 
   // ── 6. Chemin nominal + complétude via le pack `standard` ─────────────────
 
-  it('projection complète (pack standard satisfait) → bodySource=projection, 0 fallback', async () => {
+  it('projection complète (pack standard satisfait) → READY_FOR_RENDER, 0 fallback', async () => {
     flags.seoProjectionReadV1 = true;
     flags.seoProjectionReadCanary = [PILOT_TOKEN];
     reader.readActiveProjection.mockResolvedValue({
@@ -249,8 +257,10 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
 
     const decision = await service.decide(PILOT_ALIAS);
 
-    expect(decision.bodySource).toBe('projection');
+    expect(decision.projectionStatus).toBe('READY_FOR_RENDER');
     expect(decision.fallbackReason).toBeNull();
+    // Prête ≠ servie : D n'a pas de renderer, le BODY reste legacy.
+    expect(decision.servedBodySource).toBe('legacy');
     expect(decision.invalidCount).toBe(0);
     expect(decision.mappedCount).toBe(
       PACK_DEFINITIONS.standard.requiredSections.length,
@@ -272,7 +282,8 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
     const decision = await service.decide(PILOT_ALIAS);
 
     expect(decision.fallbackReason).toBe('MAPPER_INCOMPLETE');
-    expect(decision.bodySource).toBe('legacy');
+    expect(decision.projectionStatus).toBe('FALLBACK');
+    expect(decision.servedBodySource).toBe('legacy');
   });
 
   // ── 7. Caractérisation : 0 reformulation intermédiaire ────────────────────
@@ -348,12 +359,68 @@ describe('R3ProjectionDecisionService (P2-R3-D, dark)', () => {
       expect.objectContaining({
         entity_key: PILOT_ENTITY_KEY,
         projection_role: R3_PROJECTION_ROLE,
-        decision: 'legacy',
+        projection_status: 'FALLBACK',
+        served_body_source: 'legacy',
         fallback_reason: 'PROJECTION_ABSENT',
         mapped_count: 0,
         invalid_count: 0,
       }),
     );
     logSpy.mockRestore();
+  });
+});
+
+// ── 10. Classification fail-closed des verdicts mapper (fonction pure) ──────
+//
+// Testée directement : `requiredSections` est typé `PlannableSection[]`, donc un
+// `required_section_unknown` est INATTEIGNABLE via le pack canonique — le prouver au niveau du
+// service exigerait de casser le typage. La fonction pure est le vrai point de contrat.
+describe('classifyMapperFallback (fail-closed)', () => {
+  const entry = (kind: R3InvalidEntry['kind']): R3InvalidEntry => ({
+    kind,
+    section: 'S1',
+    detail: 'peu importe',
+  });
+
+  it('required_slot_missing uniquement → MAPPER_INCOMPLETE (seul vrai manque de contenu)', () => {
+    expect(
+      classifyMapperFallback([
+        entry('required_slot_missing'),
+        entry('required_slot_missing'),
+      ]),
+    ).toBe('MAPPER_INCOMPLETE');
+  });
+
+  it.each<[R3InvalidEntry['kind']]>([
+    ['block_contract_invalid'],
+    ['slot_collision'],
+    ['required_section_unknown'],
+  ])('%s → MAPPER_INVALID', (kind) => {
+    expect(classifyMapperFallback([entry(kind)])).toBe('MAPPER_INVALID');
+  });
+
+  it('required_section_unknown = faute de CONFIGURATION, jamais un contenu manquant', () => {
+    // Mélangé à de vrais manques de contenu, il doit continuer de dominer : sinon un
+    // S2_DIAGNOSTIC mal orthographié se lirait comme « en attente de rédaction », et on
+    // attendrait indéfiniment un contenu impossible à produire.
+    expect(
+      classifyMapperFallback([
+        entry('required_slot_missing'),
+        entry('required_section_unknown'),
+      ]),
+    ).toBe('MAPPER_INVALID');
+  });
+
+  it('aucune entrée invalide (ready=false inattendu) → MAPPER_INVALID, jamais INCOMPLETE', () => {
+    expect(classifyMapperFallback([])).toBe('MAPPER_INVALID');
+  });
+
+  it('invalidité FUTURE inconnue → MAPPER_INVALID (fail-closed par défaut)', () => {
+    const future = {
+      kind: 'some_future_kind',
+      section: 'S1',
+      detail: '',
+    } as unknown as R3InvalidEntry;
+    expect(classifyMapperFallback([future])).toBe('MAPPER_INVALID');
   });
 });

--- a/backend/src/modules/blog/services/r3-projection-decision.service.ts
+++ b/backend/src/modules/blog/services/r3-projection-decision.service.ts
@@ -1,0 +1,200 @@
+/**
+ * R3ProjectionDecisionService — chaîne de décision DARK du consumer R3 (P2-R3-D, ADR-059).
+ *
+ * Décide, pour une gamme, si le BODY servi doit venir de la **projection** (RAW → WIKI → exports
+ * → projection) ou rester **legacy**. Ne rend RIEN : le rendu md→HTML est hors périmètre (P2-R3-E).
+ *
+ * Ordre imposé — chaque étape est un gate fail-closed franchi AVANT la suivante :
+ *   1. résoudre l'`entityKey` canonique (`gamme:<alias>`, forme namespacée attendue par la RPC) ;
+ *   2. master flag `SEO_PROJECTION_READ_V1` ;
+ *   3. allowlist EXACTE `<ROLE>@<entity_id>` (rôle + entité, jamais l'entité seule) ;
+ *   4. seulement alors, appeler le reader ;
+ *   5. mapper avec les sections requises du pack `standard` ;
+ *   6. servir la projection UNIQUEMENT si `ready` ;
+ *   7. sinon fallback legacy observable.
+ *
+ * **Invariant** : master flag OFF **ou** paire non allowlistée ⇒ **0 appel RPC**. Les deux flags
+ * étant OFF/vides par défaut, l'état mergé de cette PR est : 100 % legacy, 0 RPC, 0 lecture.
+ *
+ * **Atomicité BODY** : le verdict porte sur la page entière. Jamais « S1 projection + S2 legacy » —
+ * une projection incomplète ou invalide fait basculer le BODY ENTIER sur le legacy.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { PACK_DEFINITIONS } from '@config/conseil-pack.constants';
+import { FeatureFlagsService } from '@config/feature-flags.service';
+import {
+  mapR3Projection,
+  R3_MAPPER_ROLE,
+  type R3Slot,
+} from '@modules/seo-projection/projection-r3.mapper';
+import { SeoProjectionReaderService } from '@modules/seo-projection/seo-projection-reader.service';
+
+/** Rôle de projection servant les pages conseil R3. */
+export const R3_PROJECTION_ROLE = R3_MAPPER_ROLE;
+
+/** Pack de complétude du pilote R3 (résolu SERVEUR — jamais depuis la requête publique). */
+const R3_PACK = PACK_DEFINITIONS.standard;
+
+export type R3BodySource = 'projection' | 'legacy';
+
+/** Causes de repli — toutes observables, aucune muette. */
+export type R3FallbackReason =
+  | 'MASTER_OFF'
+  | 'NOT_ALLOWLISTED'
+  | 'RPC_ERROR'
+  | 'RPC_EXCEPTION'
+  | 'PROJECTION_ABSENT'
+  | 'MAPPER_INVALID'
+  | 'MAPPER_INCOMPLETE';
+
+export interface R3ProjectionDecision {
+  entityKey: string;
+  projectionRole: typeof R3_PROJECTION_ROLE;
+  bodySource: R3BodySource;
+  /** `null` seulement si `bodySource === 'projection'`. */
+  fallbackReason: R3FallbackReason | null;
+  mappedCount: number;
+  invalidCount: number;
+  /**
+   * Slots projetés — présents UNIQUEMENT si `bodySource === 'projection'`. Transportés verbatim
+   * depuis le mapper (aucune reformulation intermédiaire). `null` sur tout repli legacy, pour
+   * qu'aucune projection partielle ne puisse fuiter dans un BODY legacy.
+   */
+  slots: Record<string, R3Slot> | null;
+}
+
+/** `entity_id` canonique namespacé — même forme que la clé d'écriture et le `p_entity_id` de la RPC. */
+function toEntityKey(pgAlias: string): string {
+  return `gamme:${pgAlias}`;
+}
+
+/** Jeton d'allowlist : la PAIRE rôle+entité, jamais l'entité seule. */
+function toCanaryToken(entityKey: string): string {
+  return `${R3_PROJECTION_ROLE}@${entityKey}`;
+}
+
+@Injectable()
+export class R3ProjectionDecisionService {
+  private readonly logger = new Logger(R3ProjectionDecisionService.name);
+
+  constructor(
+    private readonly reader: SeoProjectionReaderService,
+    private readonly flags: FeatureFlagsService,
+  ) {}
+
+  /**
+   * La paire (R3_CONSEILS, gamme:<alias>) est-elle ciblée par la canary ? **Synchrone, 0 RPC** :
+   * appelable avant toute lecture de cache pour décider du bypass sans coût réseau.
+   */
+  isTargeted(pgAlias: string): boolean {
+    return this.isTargetedKey(toEntityKey(pgAlias));
+  }
+
+  private isTargetedKey(entityKey: string): boolean {
+    if (!this.flags.seoProjectionReadV1) return false;
+    return this.flags.seoProjectionReadCanary.includes(
+      toCanaryToken(entityKey),
+    );
+  }
+
+  async decide(pgAlias: string): Promise<R3ProjectionDecision> {
+    // 1. Identité canonique.
+    const entityKey = toEntityKey(pgAlias);
+
+    // 2. Master flag — prime sur l'allowlist (une paire allowlistée reste inerte si le master est OFF).
+    if (!this.flags.seoProjectionReadV1) {
+      return this.fallback(entityKey, 'MASTER_OFF');
+    }
+
+    // 3. Allowlist exacte rôle + entité.
+    if (!this.isTargetedKey(entityKey)) {
+      return this.fallback(entityKey, 'NOT_ALLOWLISTED');
+    }
+
+    // 4. Lecture (le SEUL chemin atteignant la RPC).
+    const { envelope, degradeReason } = await this.reader.readActiveProjection(
+      entityKey,
+      R3_PROJECTION_ROLE,
+    );
+    if (envelope === null) {
+      return this.fallback(entityKey, this.toReaderFallback(degradeReason));
+    }
+
+    // 5. Mapping + complétude jugée sur le pack résolu côté serveur.
+    const result = mapR3Projection(envelope, {
+      requiredSections: R3_PACK.requiredSections,
+    });
+
+    // 6/7. Atomicité : ready ⇒ BODY projection ; sinon BODY legacy ENTIER.
+    if (!result.ready) {
+      const structurallyInvalid = result.invalid.some(
+        (entry) =>
+          entry.kind === 'block_contract_invalid' ||
+          entry.kind === 'slot_collision',
+      );
+      return this.fallback(
+        entityKey,
+        structurallyInvalid ? 'MAPPER_INVALID' : 'MAPPER_INCOMPLETE',
+        result.mapped.length,
+        result.invalid.length,
+      );
+    }
+
+    return this.emit({
+      entityKey,
+      projectionRole: R3_PROJECTION_ROLE,
+      bodySource: 'projection',
+      fallbackReason: null,
+      mappedCount: result.mapped.length,
+      invalidCount: result.invalid.length,
+      slots: result.slots,
+    });
+  }
+
+  /**
+   * Traduit la dégradation du reader (contrat C0 : `RPC error: …` · `RPC exception` ·
+   * `projection absente`) en cause typée. Une chaîne inattendue n'est jamais absorbée en
+   * silence : elle est journalisée en warn puis classée `RPC_ERROR` (repli conservateur).
+   */
+  private toReaderFallback(degradeReason: string | null): R3FallbackReason {
+    if (degradeReason === 'projection absente') return 'PROJECTION_ABSENT';
+    if (degradeReason?.startsWith('RPC exception')) return 'RPC_EXCEPTION';
+    if (!degradeReason?.startsWith('RPC error')) {
+      this.logger.warn({
+        msg: 'dégradation reader hors contrat connu — classée RPC_ERROR',
+        degrade_reason: degradeReason,
+      });
+    }
+    return 'RPC_ERROR';
+  }
+
+  private fallback(
+    entityKey: string,
+    fallbackReason: R3FallbackReason,
+    mappedCount = 0,
+    invalidCount = 0,
+  ): R3ProjectionDecision {
+    return this.emit({
+      entityKey,
+      projectionRole: R3_PROJECTION_ROLE,
+      bodySource: 'legacy',
+      fallbackReason,
+      mappedCount,
+      invalidCount,
+      slots: null,
+    });
+  }
+
+  /** Point d'émission unique du journal structuré de décision. */
+  private emit(decision: R3ProjectionDecision): R3ProjectionDecision {
+    this.logger.log({
+      entity_key: decision.entityKey,
+      projection_role: decision.projectionRole,
+      decision: decision.bodySource,
+      fallback_reason: decision.fallbackReason,
+      mapped_count: decision.mappedCount,
+      invalid_count: decision.invalidCount,
+    });
+    return decision;
+  }
+}

--- a/backend/src/modules/blog/services/r3-projection-decision.service.ts
+++ b/backend/src/modules/blog/services/r3-projection-decision.service.ts
@@ -1,8 +1,15 @@
 /**
  * R3ProjectionDecisionService — chaîne de décision DARK du consumer R3 (P2-R3-D, ADR-059).
  *
- * Décide, pour une gamme, si le BODY servi doit venir de la **projection** (RAW → WIKI → exports
- * → projection) ou rester **legacy**. Ne rend RIEN : le rendu md→HTML est hors périmètre (P2-R3-E).
+ * Évalue, pour une gamme, si la projection (RAW → WIKI → exports → projection) est **prête à être
+ * rendue**. Ne rend RIEN et ne sert RIEN : le rendu md→HTML gouverné est le périmètre de P2-R3-E.
+ *
+ * **Deux notions distinctes, jamais confondues** (le mapper émet du Markdown, la surface servie
+ * attend du HTML, et aucun renderer gouverné n'existe encore) :
+ *   - `projectionStatus` — état de PRÉPARATION : `READY_FOR_RENDER` | `FALLBACK` ;
+ *   - `servedBodySource` — source RÉELLEMENT rendue. En D, littéralement `'legacy'`, TOUJOURS.
+ * `READY_FOR_RENDER` signifie « le mapper a produit un DTO complet » — jamais « c'est servi ».
+ * Seule P2-R3-E, après renderer + sanitization, pourra élargir `servedBodySource` à `'projection'`.
  *
  * Ordre imposé — chaque étape est un gate fail-closed franchi AVANT la suivante :
  *   1. résoudre l'`entityKey` canonique (`gamme:<alias>`, forme namespacée attendue par la RPC) ;
@@ -10,14 +17,14 @@
  *   3. allowlist EXACTE `<ROLE>@<entity_id>` (rôle + entité, jamais l'entité seule) ;
  *   4. seulement alors, appeler le reader ;
  *   5. mapper avec les sections requises du pack `standard` ;
- *   6. servir la projection UNIQUEMENT si `ready` ;
- *   7. sinon fallback legacy observable.
+ *   6. `READY_FOR_RENDER` UNIQUEMENT si le mapper est `ready` ;
+ *   7. sinon `FALLBACK` avec cause observable.
  *
  * **Invariant** : master flag OFF **ou** paire non allowlistée ⇒ **0 appel RPC**. Les deux flags
  * étant OFF/vides par défaut, l'état mergé de cette PR est : 100 % legacy, 0 RPC, 0 lecture.
  *
  * **Atomicité BODY** : le verdict porte sur la page entière. Jamais « S1 projection + S2 legacy » —
- * une projection incomplète ou invalide fait basculer le BODY ENTIER sur le legacy.
+ * une projection incomplète ou invalide disqualifie la projection ENTIÈRE.
  */
 import { Injectable, Logger } from '@nestjs/common';
 import { PACK_DEFINITIONS } from '@config/conseil-pack.constants';
@@ -25,6 +32,7 @@ import { FeatureFlagsService } from '@config/feature-flags.service';
 import {
   mapR3Projection,
   R3_MAPPER_ROLE,
+  type R3InvalidEntry,
   type R3Slot,
 } from '@modules/seo-projection/projection-r3.mapper';
 import { SeoProjectionReaderService } from '@modules/seo-projection/seo-projection-reader.service';
@@ -35,7 +43,18 @@ export const R3_PROJECTION_ROLE = R3_MAPPER_ROLE;
 /** Pack de complétude du pilote R3 (résolu SERVEUR — jamais depuis la requête publique). */
 const R3_PACK = PACK_DEFINITIONS.standard;
 
-export type R3BodySource = 'projection' | 'legacy';
+/**
+ * État de PRÉPARATION de la projection — **pas** la source servie.
+ * `READY_FOR_RENDER` = le mapper a produit un DTO complet et conforme, rendable par P2-R3-E.
+ */
+export type R3ProjectionStatus = 'READY_FOR_RENDER' | 'FALLBACK';
+
+/**
+ * Source RÉELLEMENT rendue. Volontairement figée au littéral `'legacy'` en P2-R3-D : aucun
+ * renderer md→HTML gouverné n'existe, donc aucune valeur `'projection'` ne peut être honnête ici.
+ * L'élargissement de ce type est le livrable central de P2-R3-E.
+ */
+export type R3ServedBodySource = 'legacy';
 
 /** Causes de repli — toutes observables, aucune muette. */
 export type R3FallbackReason =
@@ -50,15 +69,18 @@ export type R3FallbackReason =
 export interface R3ProjectionDecision {
   entityKey: string;
   projectionRole: typeof R3_PROJECTION_ROLE;
-  bodySource: R3BodySource;
-  /** `null` seulement si `bodySource === 'projection'`. */
+  /** Préparation seulement. `READY_FOR_RENDER` ≠ « servi ». */
+  projectionStatus: R3ProjectionStatus;
+  /** Toujours `'legacy'` en D — le BODY servi ne dépend pas encore de `projectionStatus`. */
+  servedBodySource: R3ServedBodySource;
+  /** `null` seulement si `projectionStatus === 'READY_FOR_RENDER'`. */
   fallbackReason: R3FallbackReason | null;
   mappedCount: number;
   invalidCount: number;
   /**
-   * Slots projetés — présents UNIQUEMENT si `bodySource === 'projection'`. Transportés verbatim
-   * depuis le mapper (aucune reformulation intermédiaire). `null` sur tout repli legacy, pour
-   * qu'aucune projection partielle ne puisse fuiter dans un BODY legacy.
+   * Slots projetés — présents UNIQUEMENT si `projectionStatus === 'READY_FOR_RENDER'`. Transportés
+   * verbatim depuis le mapper (aucune reformulation intermédiaire). `null` sur tout `FALLBACK`,
+   * pour qu'aucune projection partielle ne puisse fuiter.
    */
   slots: Record<string, R3Slot> | null;
 }
@@ -71,6 +93,29 @@ function toEntityKey(pgAlias: string): string {
 /** Jeton d'allowlist : la PAIRE rôle+entité, jamais l'entité seule. */
 function toCanaryToken(entityKey: string): string {
   return `${R3_PROJECTION_ROLE}@${entityKey}`;
+}
+
+/**
+ * Classe un verdict `ready: false` du mapper — **fail-closed par construction**.
+ *
+ * Seul un manque de CONTENU (`required_slot_missing` exclusivement) est une projection
+ * « incomplète ». Tout le reste est un contrat INVALIDE :
+ *   - `block_contract_invalid` / `slot_collision` — données hors contrat ;
+ *   - `required_section_unknown` — **faute de configuration** (ex. `S2_DIAGNOSTIC` au lieu de
+ *     `S2_DIAG`) : la présenter comme « contenu manquant » masquerait un bug de config derrière
+ *     un état d'attente légitime, et on attendrait indéfiniment un contenu impossible ;
+ *   - toute invalidité FUTURE ajoutée au mapper — inconnue ⇒ INVALID, jamais absorbée en silence.
+ *
+ * Pure et exportée : testable sans monter le service ni contourner le typage `PlannableSection[]`
+ * de `requiredSections` (qui rend `required_section_unknown` inatteignable via le pack canonique).
+ */
+export function classifyMapperFallback(
+  invalid: readonly R3InvalidEntry[],
+): R3FallbackReason {
+  const incompleteOnly =
+    invalid.length > 0 &&
+    invalid.every((entry) => entry.kind === 'required_slot_missing');
+  return incompleteOnly ? 'MAPPER_INCOMPLETE' : 'MAPPER_INVALID';
 }
 
 @Injectable()
@@ -125,16 +170,11 @@ export class R3ProjectionDecisionService {
       requiredSections: R3_PACK.requiredSections,
     });
 
-    // 6/7. Atomicité : ready ⇒ BODY projection ; sinon BODY legacy ENTIER.
+    // 6/7. Atomicité : ready ⇒ DTO rendable ; sinon FALLBACK (la projection ENTIÈRE est écartée).
     if (!result.ready) {
-      const structurallyInvalid = result.invalid.some(
-        (entry) =>
-          entry.kind === 'block_contract_invalid' ||
-          entry.kind === 'slot_collision',
-      );
       return this.fallback(
         entityKey,
-        structurallyInvalid ? 'MAPPER_INVALID' : 'MAPPER_INCOMPLETE',
+        classifyMapperFallback(result.invalid),
         result.mapped.length,
         result.invalid.length,
       );
@@ -143,7 +183,9 @@ export class R3ProjectionDecisionService {
     return this.emit({
       entityKey,
       projectionRole: R3_PROJECTION_ROLE,
-      bodySource: 'projection',
+      projectionStatus: 'READY_FOR_RENDER',
+      // Prête, mais PAS servie : D n'a pas de renderer. Cf. P2-R3-E.
+      servedBodySource: 'legacy',
       fallbackReason: null,
       mappedCount: result.mapped.length,
       invalidCount: result.invalid.length,
@@ -177,7 +219,8 @@ export class R3ProjectionDecisionService {
     return this.emit({
       entityKey,
       projectionRole: R3_PROJECTION_ROLE,
-      bodySource: 'legacy',
+      projectionStatus: 'FALLBACK',
+      servedBodySource: 'legacy',
       fallbackReason,
       mappedCount,
       invalidCount,
@@ -190,7 +233,8 @@ export class R3ProjectionDecisionService {
     this.logger.log({
       entity_key: decision.entityKey,
       projection_role: decision.projectionRole,
-      decision: decision.bodySource,
+      projection_status: decision.projectionStatus,
+      served_body_source: decision.servedBodySource,
       fallback_reason: decision.fallbackReason,
       mapped_count: decision.mappedCount,
       invalid_count: decision.invalidCount,

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -234,12 +234,26 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       }
     })();
 
+    // Canary projection R3 (P2-R3-D) : `projectionMeta` n'est présent que si la paire
+    // R3_CONSEILS@gamme:<alias> est allowlistée côté backend — sa présence EST le signal de
+    // ciblage. Une réponse ciblée ne doit JAMAIS être mise en cache partagé : le contenu
+    // dépend d'un flag runtime, donc un CDN/navigateur pourrait resservir la variante ciblée
+    // à tout le monde (ou l'inverse) après un flip. Hors canary : politique publique inchangée.
+    // `buildCacheHeaders` honore déjà les `loaderHeaders` — pas de réécriture de `headers()`.
+    const isCanaryTargeted = guide.projectionMeta !== undefined;
+
     return data(
       { guide, pg_alias, r4Reference: r4ReferencePromise },
       {
-        headers: {
-          "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
-        },
+        headers: isCanaryTargeted
+          ? {
+              "Cache-Control": "private, no-store",
+              "X-R3-Canary": "1",
+            }
+          : {
+              "Cache-Control":
+                "public, max-age=300, stale-while-revalidate=3600",
+            },
       },
     );
   } catch (error) {

--- a/frontend/app/types/r3-guide.types.ts
+++ b/frontend/app/types/r3-guide.types.ts
@@ -53,9 +53,14 @@ type AnyArticle = any;
  * décision projection (P2-R3-D). **Présent uniquement si la paire R3_CONSEILS@gamme:<alias> est
  * ciblée par la canary** : sa présence EST le signal de ciblage (le loader impose alors
  * `private, no-store`). Absent hors canary — donc absent partout tant que les flags sont OFF.
+ *
+ * `projectionStatus` = PRÉPARATION (`READY_FOR_RENDER` = DTO complet côté mapper).
+ * `servedBodySource` = source RÉELLEMENT rendue — littéralement `"legacy"` tant que le renderer
+ * md→HTML gouverné n'existe pas (P2-R3-E). `READY_FOR_RENDER` ne veut PAS dire « projection servie ».
  */
 export interface R3ProjectionMeta {
-  decision: "projection" | "legacy";
+  projectionStatus: "READY_FOR_RENDER" | "FALLBACK";
+  servedBodySource: "legacy";
   fallbackReason: string | null;
   mappedCount: number;
   invalidCount: number;

--- a/frontend/app/types/r3-guide.types.ts
+++ b/frontend/app/types/r3-guide.types.ts
@@ -48,6 +48,19 @@ export interface R3GuideSection {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyArticle = any;
 
+/**
+ * Miroir de `R3ProjectionMeta` (backend `r3-guide.interfaces.ts`) — verdict de la chaîne de
+ * décision projection (P2-R3-D). **Présent uniquement si la paire R3_CONSEILS@gamme:<alias> est
+ * ciblée par la canary** : sa présence EST le signal de ciblage (le loader impose alors
+ * `private, no-store`). Absent hors canary — donc absent partout tant que les flags sont OFF.
+ */
+export interface R3ProjectionMeta {
+  decision: "projection" | "legacy";
+  fallbackReason: string | null;
+  mappedCount: number;
+  invalidCount: number;
+}
+
 export interface R3GuidePayload {
   page: R3GuidePage;
   s1Sections: R3GuideSection[];
@@ -62,4 +75,6 @@ export interface R3GuidePayload {
     previous: AnyArticle | null;
     next: AnyArticle | null;
   };
+  /** Voir {@link R3ProjectionMeta} — absent hors canary. */
+  projectionMeta?: R3ProjectionMeta;
 }


### PR DESCRIPTION
## P2-R3-D — chaîne de décision R3, DARK

Suite de #1286 (P2-R3-C, mapper pur). Câble la **chaîne de décision** du consumer R3.
**Merge owner-gated.** Aucune activation demandée.

### Périmètre : décider et observer, PAS rendre

**Blocage rencontré et arbitré par l'owner** : `mapR3Projection` émet du **Markdown**
(`content_md`), or `R3GuideSection.html` attend du **HTML**, et **aucun renderer md→HTML
gouverné n'existe** dans le repo (vérifié : 0 dépendance backend/root/frontend ; le legacy
`sgc_content` est déjà du HTML). Plutôt qu'improviser un renderer + une surface XSS dans
cette PR, l'owner a acté la **scission** :

- **D (cette PR)** = chaîne de décision + observabilité + cache/headers. **0 nouvelle dépendance, 0 surface XSS.**
- **E (suivante)** = renderer md→HTML gouverné + sanitization + fidélité S4/S5 + caractérisation HTML.

Conséquence assumée et explicite dans le code : `decision: 'projection'` signifie **« la projection
est complète et servable »**, PAS « le BODY ci-joint vient de la projection ». **Le BODY servi reste
legacy dans TOUS les cas** en D.

### État mergé = 100 % legacy

`SEO_PROJECTION_READ_V1=false` · `SEO_PROJECTION_READ_CANARY=""` · **aucun token ajouté aux
configurations PREPROD ou PROD**. L'activation de `R3_CONSEILS@gamme:filtre-a-huile` reste une
décision distincte.

### Ordre de décision (chaque étape = gate fail-closed franchi AVANT la suivante)

| # | Étape | Preuve |
|---|-------|--------|
| 1 | entityKey canonique `gamme:<alias>` | test identité + rôle passés au reader |
| 2 | master flag `SEO_PROJECTION_READ_V1` | 2 tests, dont « allowlistée mais master OFF » |
| 3 | allowlist EXACTE `<ROLE>@<entity_id>` | 4 tests (vide · autre entité · autre rôle · entité seule) |
| 4 | appel du reader (seul chemin vers la RPC) | — |
| 5 | mapper avec `requiredSections` du pack `standard` (résolu **serveur**) | 2 tests |
| 6 | projection servable **uniquement si** `ready` | — |
| 7 | sinon repli legacy observable | 7 causes typées |

**Invariant prouvé — 0 appel RPC** quand master OFF ou paire non allowlistée (`expect(reader.readActiveProjection).not.toHaveBeenCalled()` ×5).

**Role-scoped prouvé** : un GO **R4** sur la **même** gamme n'active **jamais** R3. R3/R4/R6 partagent
l'entité `gamme:` — une allowlist par entité seule les activerait ensemble.

### Atomicité BODY

Le verdict porte sur la page entière : projection incomplète/invalide ⇒ **BODY legacy ENTIER**.
Jamais « S1 projection + S2 legacy ». `slots` est `null` sur tout repli (aucune fuite partielle).
Caractérisé : hors `projectionMeta`, le payload ciblé est **`toEqual`** le payload hors-canary.

### Repli observable — 7 causes, aucune muette

`MASTER_OFF` · `NOT_ALLOWLISTED` · `RPC_ERROR` · `RPC_EXCEPTION` · `PROJECTION_ABSENT` ·
`MAPPER_INVALID` · `MAPPER_INCOMPLETE`.
Journal structuré : `entity_key`, `projection_role`, `decision`, `fallback_reason`, `mapped_count`,
`invalid_count`. Une dégradation reader **hors contrat connu** est journalisée en `warn` puis classée
`RPC_ERROR` — jamais absorbée en silence.

### Cache — empoisonnement croisé évité

`r3-guide:v2:<alias>` est une clé **partagée sans variante de flag** : elle pourrait retenir
alternativement un payload ciblé et un payload hors-canary selon qui la peuple en premier.
→ **canary ciblée = bypass TOTAL** (ni `get`, ni `set`, ni single-flight partagé) ;
**hors canary = chemin legacy strictement inchangé** (prouvé : les 10 tests pré-existants passent).
Loader : `private, no-store` + `X-R3-Canary` sur les réponses ciblées. `buildCacheHeaders` **honore
déjà `loaderHeaders`** → `headers()` n'est **pas** réécrit.

### HEAD inchangé

title · meta description · canonical · robots · H1 · URL · `sourceType` (le gate JSON-LD frontend en
dépend). Aucune modification de `meta()`, des tables, des grants/RLS.

### Dépendances

`BlogModule` importe **`SeoProjectionReadModule` seul** — jamais `SeoProjectionModule` (writer + gate
`service_role` + queues) ni `AdminModule` : le runtime public ne tire aucune capacité d'écriture.
**Ratchet write-sink inchangé** (64 clés / 269 occurrences) — D n'ajoute **aucun** sink et ne réécrit
jamais `__seo_gamme_conseil`.

### Durcissement type-only (demandé par l'owner)

`PackDefinition.requiredSections/optionalSections` : `string[]` → **`PlannableSection[]`** (SoT
`PLANNABLE_SECTIONS`, miroir de l'enum `page-contract-r3.json`). Empêche **à la compilation** un
`S2_DIAGNOSTIC` au lieu de `S2_DIAG` que le mapper traiterait comme indéfiniment manquant.
**0 valeur changée** (les 12 sections des 3 packs sont déjà canoniques).

A révélé **un vrai site d'appel** — `conseil-quality-scorer.service.ts:206` — où une chaîne DB
(`sgc_section_type`) est testée pour appartenance : le **récepteur** est élargi, le type du pack
n'est **pas** affaibli.

### Tests

**283 verts / 0 échec** (19 suites : blog + seo-projection + config), dont :
- **20 nouveaux** sur la chaîne de décision (ordre · 0-RPC ×5 · role-scoped · 3 dégradations reader ·
  invalid/incomplete/vide · pack standard · caractérisation `content_md` **byte-for-byte** ·
  `isTargeted` sans RPC · journal) ;
- **7 nouveaux** sur le cache (`get`/`set` jamais appelés en ciblé · recompute · `projectionMeta` ·
  BODY legacy identique au hors-canary · 404 préservé).

Backend `tsc` : **0 erreur**. `check-role-purity` sur les 9 fichiers touchés : **0 contamination**.

### Ce que cette PR ne fait PAS

❌ activer la lecture · ❌ remplir l'allowlist · ❌ servir une projection (PREPROD ou PROD) ·
❌ rendre du HTML projeté · ❌ modifier le contenu indexé · ❌ toucher grants/RLS/tables/queues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
