### PR TITLE
fix(seo): guard link-tracking beacons against malformed/undefined body

### DIFF
--- a/backend/src/modules/seo/seo-link-tracking.controller.test.ts
+++ b/backend/src/modules/seo/seo-link-tracking.controller.test.ts
@@ -1,0 +1,119 @@
+import { SeoLinkTrackingController } from './seo-link-tracking.controller';
+import type { SeoLinkTrackingService } from './infrastructure/seo-link-tracking.service';
+
+/**
+ * Regression tests for the PUBLIC, unauthenticated SEO beacon endpoints.
+ *
+ * Sentry PROD (2026-07-17) : `TypeError: Cannot read properties of undefined
+ * (reading 'linkType')` on `POST /api/seo/track-impression`. Root cause: the
+ * custom body-parser in `main.ts` (`body-parser.json()`, default
+ * `type: 'application/json'`) only populates `req.body` when the request
+ * Content-Type is `application/json`. Empty-body / wrong-content-type / bot /
+ * aborted POSTs to this public endpoint leave `req.body === undefined`, and the
+ * handler dereferenced `dto.linkType` without a guard → 500.
+ *
+ * Contract: a malformed/absent body is a no-op `{ success: false }` (never a
+ * throw), mirroring the governed sibling beacon `LandingAttributionController`.
+ */
+describe('SeoLinkTrackingController — malformed body resilience', () => {
+  let service: jest.Mocked<
+    Pick<SeoLinkTrackingService, 'trackImpression' | 'trackClick'>
+  >;
+
+  // Boundary view of the controller: these endpoints receive arbitrary request
+  // bodies (the framework binds `@Body()` to whatever the body-parser produced,
+  // including `undefined`). Typing the calls as `unknown` reflects that reality
+  // and stays valid across the handler-signature change.
+  let call: {
+    trackImpression(body: unknown): Promise<{ success: boolean }>;
+    trackClick(
+      body: unknown,
+      ua?: string,
+      referer?: string,
+    ): Promise<{ success: boolean }>;
+  };
+
+  beforeEach(() => {
+    service = {
+      trackImpression: jest.fn().mockResolvedValue(true),
+      trackClick: jest.fn().mockResolvedValue(true),
+    };
+    const controller = new SeoLinkTrackingController(
+      service as unknown as SeoLinkTrackingService,
+    );
+    call = controller as unknown as typeof call;
+  });
+
+  describe('trackImpression', () => {
+    it('returns { success: false } and skips the service when body is undefined', async () => {
+      await expect(call.trackImpression(undefined)).resolves.toEqual({
+        success: false,
+      });
+      expect(service.trackImpression).not.toHaveBeenCalled();
+    });
+
+    it('returns { success: false } when body is not an object', async () => {
+      await expect(call.trackImpression('not-json')).resolves.toEqual({
+        success: false,
+      });
+      expect(service.trackImpression).not.toHaveBeenCalled();
+    });
+
+    it('returns { success: false } when linkType is missing', async () => {
+      await expect(
+        call.trackImpression({ pageUrl: '/x', linkCount: 2 }),
+      ).resolves.toEqual({ success: false });
+      expect(service.trackImpression).not.toHaveBeenCalled();
+    });
+
+    it('forwards a well-formed impression to the service', async () => {
+      await expect(
+        call.trackImpression({
+          linkType: 'CrossSelling',
+          pageUrl: '/pieces/x.html',
+          linkCount: 4,
+          sessionId: 'sess-1',
+        }),
+      ).resolves.toEqual({ success: true });
+      expect(service.trackImpression).toHaveBeenCalledWith(
+        expect.objectContaining({
+          linkType: 'CrossSelling',
+          pageUrl: '/pieces/x.html',
+          linkCount: 4,
+          sessionId: 'sess-1',
+        }),
+      );
+    });
+  });
+
+  describe('trackClick', () => {
+    it('returns { success: false } and skips the service when body is undefined', async () => {
+      await expect(
+        call.trackClick(undefined, undefined, undefined),
+      ).resolves.toEqual({ success: false });
+      expect(service.trackClick).not.toHaveBeenCalled();
+    });
+
+    it('forwards a well-formed click to the service (device inferred from UA)', async () => {
+      await expect(
+        call.trackClick(
+          {
+            linkType: 'LinkGammeCar',
+            sourceUrl: '/a.html',
+            destinationUrl: '/b.html',
+          },
+          'Mozilla/5.0 (iPhone) Mobile',
+          '/a.html',
+        ),
+      ).resolves.toEqual({ success: true });
+      expect(service.trackClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          linkType: 'LinkGammeCar',
+          sourceUrl: '/a.html',
+          destinationUrl: '/b.html',
+          deviceType: 'mobile',
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/seo/seo-link-tracking.controller.ts
+++ b/backend/src/modules/seo/seo-link-tracking.controller.ts
@@ -34,46 +34,56 @@ import {
   LinkMetrics,
   LinkPerformanceReport,
 } from './infrastructure/seo-link-tracking.service';
+import { z } from 'zod';
 
-// DTO pour les requêtes
-class TrackClickDto {
-  linkType:
-    | 'LinkGammeCar'
-    | 'LinkGammeCar_ID'
-    | 'LinkGamme'
-    | 'CompSwitch'
-    | 'CrossSelling'
-    | 'VoirAussi'
-    | 'Footer'
-    | 'RelatedArticles'
-    | string;
-  sourceUrl: string;
-  destinationUrl: string;
-  anchorText?: string;
-  linkPosition?:
-    | 'header'
-    | 'content'
-    | 'sidebar'
-    | 'footer'
-    | 'crossselling'
-    | 'voiraussi';
-  sessionId?: string;
-  deviceType?: 'mobile' | 'desktop' | 'tablet';
-  userAgent?: string;
-  referer?: string;
+// ── Body schemas (public, unauthenticated beacon endpoints) ────────────────
+// These POST endpoints are hit fire-and-forget via `navigator.sendBeacon`
+// (frontend/app/utils/beacon.ts). Being public, they ALSO receive empty-body,
+// wrong-content-type, bot and aborted requests — for those the custom
+// body-parser in `main.ts` (`body-parser.json()`, default
+// `type: 'application/json'`) never populates `req.body`, so `@Body()` binds to
+// `undefined`. Validating with `safeParse` (and treating a malformed body as a
+// silent no-op) mirrors the governed sibling beacon `LandingAttributionController`
+// and prevents the 500 previously reported to Sentry
+// (`TypeError: reading 'linkType'`). Unknown extra keys are stripped, never a
+// hard reject, so a slightly richer client payload can't drop legit telemetry.
+
+const DEVICE_TYPES = ['mobile', 'desktop', 'tablet'] as const;
+const LINK_POSITIONS = [
+  'header',
+  'content',
+  'sidebar',
+  'footer',
+  'crossselling',
+  'voiraussi',
+  'blog',
+] as const;
+
+const TrackClickSchema = z.object({
+  linkType: z.string().min(1),
+  sourceUrl: z.string().min(1),
+  destinationUrl: z.string().min(1),
+  anchorText: z.string().optional(),
+  // Constrained optionals use `.catch(undefined)` so an out-of-range value drops
+  // that single field instead of failing (and dropping) the whole beacon.
+  linkPosition: z.enum(LINK_POSITIONS).optional().catch(undefined),
+  sessionId: z.string().optional(),
+  deviceType: z.enum(DEVICE_TYPES).optional().catch(undefined),
+  userAgent: z.string().optional(),
+  referer: z.string().optional(),
   // A/B Testing fields
-  switchVerbId?: number;
-  switchNounId?: number;
-  switchFormula?: string;
-  targetGammeId?: number;
-}
+  switchVerbId: z.number().optional().catch(undefined),
+  switchNounId: z.number().optional().catch(undefined),
+  switchFormula: z.string().optional(),
+  targetGammeId: z.number().optional().catch(undefined),
+});
 
-class TrackImpressionDto {
-  linkType: string;
-  pageUrl: string;
-  linkCount: number;
-  sessionId?: string;
-}
+const TrackImpressionSchema = z.object({
+  linkType: z.string().min(1),
+  pageUrl: z.string().min(1),
+  linkCount: z.number(),
+  sessionId: z.string().optional(),
+});
 
 @ApiTags('SEO Link Tracking')
 @Controller('api/seo')
@@ -89,10 +99,21 @@ export class SeoLinkTrackingController {
   @ApiOperation({ summary: 'Track un clic sur lien interne' })
   @ApiResponse({ status: 201, description: 'Clic enregistré' })
   async trackClick(
-    @Body() dto: TrackClickDto,
+    @Body() body: unknown,
     @Headers('user-agent') userAgent?: string,
     @Headers('referer') referer?: string,
   ): Promise<{ success: boolean }> {
+    const parsed = TrackClickSchema.safeParse(body);
+    if (!parsed.success) {
+      // Empty/malformed/bot request to a public beacon endpoint → observable
+      // no-op, never a 500 (cf. Sentry TypeError on undefined body).
+      this.logger.debug(
+        `track-click: body absent/malformed — no-op (${parsed.error.message})`,
+      );
+      return { success: false };
+    }
+    const dto = parsed.data;
+
     // Détecter le type de device (utiliser celui du DTO si fourni)
     const deviceType = dto.deviceType || this.detectDeviceType(userAgent);
 
@@ -128,15 +149,18 @@ export class SeoLinkTrackingController {
   @Post('track-impression')
   @ApiOperation({ summary: 'Track une impression de liens' })
   @ApiResponse({ status: 201, description: 'Impression enregistrée' })
-  async trackImpression(
-    @Body() dto: TrackImpressionDto,
-  ): Promise<{ success: boolean }> {
-    const event: LinkImpressionEvent = {
-      linkType: dto.linkType,
-      pageUrl: dto.pageUrl,
-      linkCount: dto.linkCount,
-      sessionId: dto.sessionId,
-    };
+  async trackImpression(@Body() body: unknown): Promise<{ success: boolean }> {
+    const parsed = TrackImpressionSchema.safeParse(body);
+    if (!parsed.success) {
+      // Empty/malformed/bot request to a public beacon endpoint → observable
+      // no-op, never a 500 (cf. Sentry TypeError on undefined body).
+      this.logger.debug(
+        `track-impression: body absent/malformed — no-op (${parsed.error.message})`,
+      );
+      return { success: false };
+    }
+
+    const event: LinkImpressionEvent = parsed.data;
 
     const success = await this.trackingService.trackImpression(event);
     return { success };


### PR DESCRIPTION
## Symptom (Sentry PROD)

`TypeError: Cannot read properties of undefined (reading 'linkType')` on
`POST /api/seo/track-impression` → HTTP 500 (issue `3c7c8f1d…`, 2026-07-17 16:02 UTC,
`auto.function.nestjs.exception_captured`).

## Root cause (server-side, definitive)

- `backend/src/main.ts` disables Nest's built-in body parser (`bodyParser: false`) and installs a custom `body-parser.json()` (default `type: 'application/json'`) for `/api/*`.
- `body-parser.json()` only populates `req.body` when the request `Content-Type` actually matches `application/json`. These are **public, unauthenticated** beacon endpoints, so they also receive empty-body / wrong-content-type / bot / scanner / aborted POSTs. For those, neither the json nor urlencoded parser claims the request → `req.body` stays `undefined`.
- NestJS binds `@Body() dto` to that `undefined`, and the handler dereferenced `dto.linkType` (impression) / `dto.deviceType` (click) **with no guard** → 500.

The frontend beacon (`navigator.sendBeacon` + `Content-Type: application/json`) is correct and is **not** the source; legit clients always send a well-formed object. `trackClick` carried the identical latent defect.

## Fix

Extend the **governed sibling-beacon pattern** (`LandingAttributionController`) instead of inventing a local guard:

- `@Body() body: unknown` + Zod `safeParse`.
- Malformed/absent body → **observable no-op** (`{ success: false }` + `logger.debug`), never a throw / 500.
- Constrained optional fields (`linkPosition`, `deviceType`, A/B numeric ids) use `.catch(undefined)` so one out-of-range field can't drop a whole legit beacon; unknown keys are stripped (never a hard reject).
- **Response contract + status codes unchanged.** Well-formed beacons behave exactly as before (verified: legit frontend payloads always send non-empty `linkType`/`sourceUrl`/`pathname`/`destinationUrl`, so `.min(1)` never drops real telemetry).

Covers both `trackImpression` and `trackClick`.

## Tests (TDD, red-first)

`seo-link-tracking.controller.test.ts` — the red test reproduced the **exact** Sentry `TypeError` on `undefined` body before the fix; green after. 6/6 pass.

## Verification

- `jest` (new suite): 6/6 ✅
- `tsc --noEmit -p backend/tsconfig.json`: exit 0 ✅
- `eslint --max-warnings=0` on changed files: exit 0 ✅
- PROD currently healthy (`/health` 200) — alert #2 (homepage 10s uptime timeout, same day) was a transient monitor blip, unrelated to this endpoint; no code change.

## Deploy note

Merge to `main` deploys **PREPROD container CI only**; PROD promotion is a separate owner-gated `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)