### PR TITLE
fix(catch-all): 410 on corrupted-encoding URLs (U+FFFD) instead of 5xx

### DIFF
--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -4,8 +4,9 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
   data,
+  useRouteError,
+  isRouteErrorResponse,
 } from "react-router";
-import { useRouteError, isRouteErrorResponse } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { buildCacheHeaders } from "~/utils/cache-control";
 import { logger } from "~/utils/logger";
@@ -288,6 +289,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
  * Retourne true pour court-circuiter AVANT tout appel API (économie de 3 fetch/requête).
  */
 function isGarbageUrl(pathname: string): boolean {
+  // Caractère de remplacement Unicode U+FFFD (`�`, encodé `%EF%BF%BD`) = input
+  // corrompu (mojibake d'un lien cassé / scraper). decodeURIComponent réussit
+  // (UTF-8 valide) mais le caractère SURVIT à la normalisation d'accents de
+  // `resolveKnownPattern` et empoisonne le header `Location` d'un redirect 301
+  // (octet > 0xFF → ByteString/ERR_INVALID_CHAR → 500). Traité comme garbage → 410.
+  try {
+    if (decodeURIComponent(pathname).includes("�")) return true;
+  } catch {
+    // %-encoding invalide (ex. `%ZZ`) : laissé aux gardes suivantes (404).
+  }
+
   // Base64-encoded strings: /wl8k5m6HsSkVW3cXi61ZQ==
   if (/^\/[A-Za-z0-9+/]{8,}={1,2}$/.test(pathname)) return true;
 
@@ -333,7 +345,14 @@ function resolveKnownPattern(pathname: string): string | null {
   try {
     const decoded = decodeURIComponent(pathname);
     const normalized = decoded.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-    if (normalized !== decoded) {
+    // Défense en profondeur : ne JAMAIS renvoyer une cible de redirect
+    // contenant un caractère non-latin1 (> 0xFF, ex. U+FFFD survivant à la
+    // normalisation), sinon `redirect(target, 301)` construit un header
+    // `Location` invalide → ByteString/ERR_INVALID_CHAR → 500. `isGarbageUrl`
+    // intercepte déjà le cas U+FFFD en amont (410) ; ce garde couvre tout
+    // autre caractère exotique → on retombe proprement sur le 404.
+    const headerSafe = ![...normalized].some((ch) => ch.charCodeAt(0) > 0xff);
+    if (normalized !== decoded && headerSafe) {
       return normalized;
     }
   } catch {

--- a/frontend/tests/unit/catch-all-corrupted-encoding-410.test.ts
+++ b/frontend/tests/unit/catch-all-corrupted-encoding-410.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { loader } from "~/routes/$";
+
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+/**
+ * Régression — 5xx sur URL au %-encoding corrompu (caractère de remplacement
+ * Unicode U+FFFD `�`, encodé `%EF%BF%BD`).
+ *
+ * Cause : `resolveKnownPattern` décode le pathname, strippe les accents
+ * (`normalize("NFD").replace(/[̀-ͯ]/g,"")`) et renvoie la version
+ * normalisée comme cible de redirect 301. Le `%EF%BF%BD` décode en U+FFFD
+ * (UTF-8 valide → pas de throw au décodage) mais N'EST PAS un diacritique
+ * combinant, donc il SURVIT à la normalisation. `redirect(target, 301)`
+ * construit alors `new Response(null,{headers:{Location: "...�..."}})`
+ * dont la valeur de header contient un octet > 0xFF → `TypeError`
+ * (« Cannot convert argument to a ByteString ») / Node `ERR_INVALID_CHAR`.
+ * L'appel est HORS du try/catch du loader → l'erreur remonte → 500.
+ *
+ * Empirique (2026-07-18, DEV:3000 = PROD, même DB) :
+ *   /r%C3%A9f%EF%BF%BD%C3%A9rence-auto/bras-de-suspension500 → 500 (PROD live)
+ *   Signalé comme « Erreur serveur (5xx) » par Google Search Console
+ *   (validation ÉCHOUÉE 2026-07-11, exemple « Manual » en tête du rapport).
+ *
+ * Attendu après fix : input corrompu (U+FFFD) = garbage → 410 propre
+ * (jamais de 5xx sur un lien mort — cf. « not-found = 404/410, pas 5xx »).
+ */
+describe("catch-all $.tsx — URL au %-encoding corrompu (U+FFFD) → 410, jamais 500", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response(JSON.stringify({ found: false }))),
+      ),
+    );
+  });
+
+  const call = (path: string) =>
+    loader({
+      request: new Request(`https://www.automecanik.com${path}`),
+      params: {},
+      context: {},
+    } as never);
+
+  // `isGarbageUrl` court-circuite via `throw data(...)` → DataWithResponseInit
+  // (même forme que les 410 garbage existants, cf. catch-all-404-noindex.test).
+  type ThrownData = { init?: { status?: number; headers?: HeadersInit } };
+
+  it("URL corrompue (%EF%BF%BD) → 410 contrôlé (PAS un TypeError → 500)", async () => {
+    let thrown: ThrownData | undefined;
+    try {
+      await call("/r%C3%A9f%EF%BF%BD%C3%A9rence-auto/bras-de-suspension500");
+    } catch (e) {
+      thrown = e as ThrownData;
+    }
+    // AVANT le fix : thrown = TypeError (« Cannot convert argument to a
+    // ByteString ») → remonte → 500. APRÈS : 410 propre + noindex.
+    expect(thrown?.init?.status).toBe(410);
+    expect(new Headers(thrown?.init?.headers).get("X-Robots-Tag")).toBe(
+      "noindex, follow",
+    );
+  });
+
+  it("caractère de remplacement seul dans un segment → 410", async () => {
+    let thrown: ThrownData | undefined;
+    try {
+      await call("/pi%C3%A8ces-%EF%BF%BD-auto");
+    } catch (e) {
+      thrown = e as ThrownData;
+    }
+    expect(thrown?.init?.status).toBe(410);
+  });
+
+  it("NON-régression : accent PROPRE (référence-auto) redirige toujours 301", async () => {
+    const res = (await call(
+      "/r%C3%A9f%C3%A9rence-auto/bras-de-suspension500",
+    )) as Response;
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(301);
+    // accent-strip → cible ASCII propre, header Location valide
+    expect(res.headers.get("Location")).toBe(
+      "/reference-auto/bras-de-suspension500",
+    );
+  });
+});


### PR DESCRIPTION
## Contexte

Google Search Console signale « **Erreur serveur (5xx)** » sur ~1,18 k pages (validation **ÉCHOUÉE le 2026-07-11**). L'exemple **« Manual »** en tête du rapport GSC est :

```
https://www.automecanik.com/réf�érence-auto/bras-de-suspension500   (%EF%BF%BD = U+FFFD)
```

Diagnostic complet : **la quasi-totalité des URLs du rapport sont déjà servies correctement** aujourd'hui (PROD : 200 / 301 / 410 / 404 — 0 5xx sur ~15 classes sondées). Le gros du volume = erreurs **transitoires figées 24 h au bord Cloudflare/Caddy** (incident 2026-06-25, durci par #1140 → #1222 → #1272 ; remédiation = purge CF + re-validation, owner-gated). **Cette PR ferme la SEULE 5xx reproductible en live** : les URLs au `%`-encoding corrompu.

## Cause racine (reproduite + testée)

`resolveKnownPattern` ([frontend/app/routes/$.tsx](../blob/main/frontend/app/routes/$.tsx)) décode le pathname, strippe les accents (`normalize("NFD").replace(/[̀-ͯ]/g,"")`) et renvoie la version normalisée comme cible de **redirect 301**. Le caractère de remplacement Unicode **U+FFFD** (`%EF%BF%BD`) :

- décode sans erreur (UTF-8 valide) — donc pas capté par le `catch` du décodage ;
- n'est **pas** un diacritique combinant → **survit** à la normalisation ;
- se retrouve dans la valeur du header `Location` (octet `0xFFFD` > `0xFF`) → **`TypeError: Cannot convert argument to a ByteString` / Node `ERR_INVALID_CHAR`**.

`redirect(quickRedirect, 301)` est appelé **hors** du `try/catch` du loader → l'erreur remonte à l'error boundary → **500**.

Isolation empirique (DEV:3000 = même DB que PROD) :

| URL | avant |
|---|---|
| `/réf�érence-auto/…` (U+FFFD) | **500** |
| `/référence-auto/…` (accent propre) | 301 |
| `/pieces/�/…` (U+FFFD sans accent à stripper) | 404 |

→ la 500 exige **accent (déclenche le redirect) + caractère invalide (empoisonne le header)**.

Vérifié au runtime Node : `new Response(null,{headers:{Location:"…�…"}})` **throw** `ByteString … value 65533 > 255`.

## Fix (2 gardes complémentaires, blast radius minimal)

1. **`isGarbageUrl`** — un chemin décodé contenant `U+FFFD` = input corrompu → court-circuit **410** propre (canon : *not-found = 404/410, jamais 5xx*). Sémantiquement correct : ces URLs n'ont jamais existé (mojibake de lien cassé / scraper).
2. **`resolveKnownPattern`** (défense en profondeur) — ne **jamais** renvoyer une cible de redirect portant un caractère non-latin1 (`> 0xFF`) → retombe proprement sur le **404** au lieu du 500.

Aucune URL réelle n'est modifiée : les accents propres redirigent toujours (301), les vraies pages restent 200.

## Tests / vérif

- Nouveau `catch-all-corrupted-encoding-410.test.ts` : corrompu → **410 + noindex,follow** ; **non-régression** accent propre → **301** inchangé. (Échouait avant sur `TypeError`, passe après.)
- `catch-all-404-noindex`, `catch-all-data-suffix-redirect`, `constructeurs-model-410` : **14/14 verts**.
- `tsc --noEmit` exit 0 · eslint 0 warning · prod bundle non impacté (loader-only).

## Suites owner (hors code, pour clore le rapport GSC)

1. **Cloudflare Purge Everything** une fois (vider les 5xx transitoires déjà cachés au bord).
2. Confirmer que **#1272** (`:preprod` → tag `v*`) et le **Caddyfile** (volume-monté, reload manuel) sont bien déployés sur PROD.
3. Dans GSC : **VALIDER LE CORRECTIF** à nouveau une fois cette PR taguée `v*` + purge faite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)