### PR TITLE
ci(ast-grep): promote payments-no-raw-equality warning → error (PR-C)

### DIFF
--- a/.ast-grep/rules/payments-no-raw-equality.yml
+++ b/.ast-grep/rules/payments-no-raw-equality.yml
@@ -1,6 +1,10 @@
 id: payments-no-raw-equality
 language: typescript
-severity: warning
+# Promoted warning -> error (PR-C, 2026-07-19): payments/** corpus verified CLEAN
+# (0 findings via `npx ast-grep scan --config sgconfig.yml --rule <this> backend/src`),
+# per sgconfig policy "promote to error once the codebase is clean". Payments HMAC is an
+# owner-STOP zone (.claude/rules/payments.md: timingSafeEqual obligatoire, JAMAIS ===).
+severity: error
 message: |
   Signature/HMAC comparison in payments/* must use crypto.timingSafeEqual,
   not === or !==. Plain string equality is vulnerable to timing attacks.


### PR DESCRIPTION
## What

Promote the `payments-no-raw-equality` ast-grep rule from `severity: warning` to `severity: error`. One file, +5/−1 (severity line + evidence comment).

## Why

Signature/HMAC comparison in `payments/**` must use `crypto.timingSafeEqual`, never `===`/`!==` (timing attack — owner-STOP zone, `.claude/rules/payments.md`). As a warning it couldn't fail CI. The `payments/**` corpus is **verified clean** (0 findings), so per `sgconfig.yml`'s own policy — *"promote to error once the codebase is clean"* — the guard now blocks: any future raw-equality in `payments/**` fails `audit:ast` + pre-commit instead of only warning.

## Verification

```
npx ast-grep scan --config sgconfig.yml --rule .ast-grep/rules/payments-no-raw-equality.yml backend/src
→ exit 0, 0 violations
```
No behavior change to any payments code; the guard cannot red-CI because there is nothing to flag today.

## Context

Closes one AUTOMATE gap from the agent-instruction audit (`audit/agent-instructions-audit-2026-07-18.md` §6). The other severity flips are **deferred by design** — they would break the build on known/grandfathered debt until their cleanup PRs land:
- `seo-no-rag-as-content-source` warn→error — the rule self-documents: flip only after the RAG→content writers close (25 known findings).
- `validate-agents-md.sh --all` sweep — would catch the grandfathered DEV key + VPS IPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)