### PR TITLE
fix(seo-projection): self-heal feeder OFF path — deregister residual repeatable at boot

### DIFF
--- a/backend/src/modules/seo-projection/seo-projection-feeder.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-feeder.service.ts
@@ -65,6 +65,15 @@ export class SeoProjectionFeederService implements OnModuleInit {
       this.logger.log(
         'SEO_PROJECTION_R1_FEED_ENABLED!=true — feeder R1 non planifié (flag OFF, rollout owner-gated).',
       );
+      // Réconciliation fail-safe OFF : « désactivé » DOIT signifier « aucun
+      // repeatable ne peut se déclencher », pas seulement « n'enregistre rien de
+      // neuf ». Un flag basculé ON→OFF laissait vivre le repeatable nocturne
+      // (le nettoyage ne tournait que sur le chemin d'activation) → le writer
+      // continuait de tirer malgré OFF. On dérégistre tout résidu ici, à chaque
+      // boot, de façon observable. Fire-and-forget (`void`) : `onModuleInit`
+      // reste non-bloquant (backend.md) ; Bull = Redis local (local-fast OK,
+      // pas d'I/O distante Supabase).
+      void this.deregisterResidualRepeatable();
       return;
     }
     this.logger.log(
@@ -309,12 +318,35 @@ export class SeoProjectionFeederService implements OnModuleInit {
     }
   }
 
-  private async removeStaleRepeatableJob(): Promise<void> {
+  /**
+   * Réconciliation OFF observable : prouve, à chaque boot d'un feeder désactivé,
+   * qu'AUCUN repeatable n'est vivant — et le dit dans les logs. Transforme le
+   * « SSH en PROD + inspection Redis d'un repeatable résiduel » (vérif manuelle)
+   * en invariant de code appliqué au démarrage. Pas de repli silencieux : on
+   * journalise le résultat dans les deux cas (résidu supprimé vs rien à faire).
+   */
+  private async deregisterResidualRepeatable(): Promise<void> {
+    const removed = await this.removeStaleRepeatableJob();
+    if (removed > 0) {
+      this.logger.warn(
+        `🧹 Feeder R1 OFF — ${removed} repeatable résiduel supprimé (activation passée non nettoyée) : le writer nocturne ne se déclenchera plus.`,
+      );
+    } else {
+      this.logger.log(
+        '✅ Feeder R1 OFF — aucun repeatable résiduel (rien à nettoyer).',
+      );
+    }
+  }
+
+  /** Supprime les repeatables feeder obsolètes ; retourne le nombre supprimé (0 = aucun). */
+  private async removeStaleRepeatableJob(): Promise<number> {
+    let removed = 0;
     try {
       const jobs = await this.feedQueue.getRepeatableJobs();
       for (const job of jobs) {
         if (job.name === PROJECTION_FEED_JOB) {
           await this.feedQueue.removeRepeatableByKey(job.key);
+          removed += 1;
           this.logger.log(
             `🗑️ Repeatable feeder R1 obsolète supprimé: ${job.key}`,
           );
@@ -325,6 +357,7 @@ export class SeoProjectionFeederService implements OnModuleInit {
         `Énumération des repeatables feeder impossible: ${getErrorMessage(err)}`,
       );
     }
+    return removed;
   }
 
   /** 02:00 UTC = avant la régénération sitemap (03:00) → projection fraîche avant le sitemap. */

--- a/backend/src/modules/seo-projection/seo-projection-feeder.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-feeder.test.ts
@@ -6,6 +6,7 @@ import type { ConfigService } from '@nestjs/config';
 import type { Queue } from 'bull';
 import { promises as fs } from 'node:fs';
 import { SeoProjectionFeederService } from './seo-projection-feeder.service';
+import { PROJECTION_FEED_JOB } from './seo-projection.types';
 import { getAppConfig } from '../../config/app.config';
 import type { FeatureFlagsService } from '../../config/feature-flags.service';
 
@@ -25,15 +26,23 @@ const mockGetAppConfig = getAppConfig as jest.Mock;
 
 const EXPORTS_ROOT = '/abs/seo';
 
-function makeService(opts: { exportsDir?: string } = {}) {
+function makeService(
+  opts: {
+    exportsDir?: string;
+    enabled?: boolean;
+    repeatables?: Array<{ name: string; key: string }>;
+  } = {},
+) {
   const feedQueue = {
     add: jest.fn().mockResolvedValue({ id: 'feed-1' }),
-    getRepeatableJobs: jest.fn().mockResolvedValue([]),
-    removeRepeatableByKey: jest.fn(),
+    getRepeatableJobs: jest.fn().mockResolvedValue(opts.repeatables ?? []),
+    removeRepeatableByKey: jest.fn().mockResolvedValue(undefined),
   };
   const writeQueue = { add: jest.fn().mockResolvedValue({ id: 'write-1' }) };
   const config = {
     get: jest.fn((key: string, def?: string) => {
+      if (key === 'SEO_PROJECTION_R1_FEED_ENABLED')
+        return opts.enabled ? 'true' : def;
       if (key === 'SEO_PROJECTION_R1_EXPORTS_DIR')
         return opts.exportsDir ?? '/abs/exports';
       if (key === 'SEO_PROJECTION_EXPORTS_ROOT') return EXPORTS_ROOT;
@@ -200,5 +209,75 @@ describe('SeoProjectionFeederService.triggerEntity — single-entity role-scoped
     const { svc, writeQueue } = makeService();
     await expect(svc.triggerEntity(input)).rejects.toThrow(/roles_allowed/);
     expect(writeQueue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('SeoProjectionFeederService.onModuleInit — réconciliation fail-safe OFF', () => {
+  // `onModuleInit` lance ses effets en fire-and-forget (`void`, non-bloquant,
+  // backend.md). `flush()` draine microtasks + macrotasks (toutes les queues
+  // sont mockées → résolues) pour observer l'état APRÈS la réconciliation.
+  const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+  const STALE = {
+    name: PROJECTION_FEED_JOB,
+    key: `repeat:${PROJECTION_FEED_JOB}:0 2 * * *`,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ supabase: { readOnly: false } });
+  });
+
+  it('OFF + repeatable résiduel (activation passée) → dérégistré au boot, jamais réenregistré', async () => {
+    const { svc, feedQueue } = makeService({
+      enabled: false,
+      repeatables: [STALE],
+    });
+    svc.onModuleInit();
+    await flush();
+    expect(feedQueue.getRepeatableJobs).toHaveBeenCalledTimes(1);
+    expect(feedQueue.removeRepeatableByKey).toHaveBeenCalledWith(STALE.key);
+    // OFF ne doit JAMAIS (ré)enregistrer un repeatable.
+    expect(feedQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('OFF + aucun repeatable → no-op (rien supprimé, rien enregistré)', async () => {
+    const { svc, feedQueue } = makeService({
+      enabled: false,
+      repeatables: [],
+    });
+    svc.onModuleInit();
+    await flush();
+    expect(feedQueue.getRepeatableJobs).toHaveBeenCalledTimes(1);
+    expect(feedQueue.removeRepeatableByKey).not.toHaveBeenCalled();
+    expect(feedQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('OFF ne touche PAS un repeatable d’un autre job (filtre par nom)', async () => {
+    const { svc, feedQueue } = makeService({
+      enabled: false,
+      repeatables: [{ name: 'un-autre-job', key: 'repeat:un-autre-job:x' }],
+    });
+    svc.onModuleInit();
+    await flush();
+    expect(feedQueue.removeRepeatableByKey).not.toHaveBeenCalled();
+    expect(feedQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('ON → purge des obsolètes PUIS enregistre le repeatable (cron + jobId stable)', async () => {
+    const { svc, feedQueue } = makeService({
+      enabled: true,
+      repeatables: [STALE],
+    });
+    svc.onModuleInit();
+    await flush();
+    // La purge tourne d'abord (idempotence au redeploy)…
+    expect(feedQueue.removeRepeatableByKey).toHaveBeenCalledWith(STALE.key);
+    // …puis un unique repeatable est (ré)enregistré.
+    expect(feedQueue.add).toHaveBeenCalledTimes(1);
+    const [jobName, , addOpts] = feedQueue.add.mock.calls[0];
+    expect(jobName).toBe(PROJECTION_FEED_JOB);
+    expect(addOpts.jobId).toBe('seo-projection-r1-nightly-feed');
+    expect(addOpts.repeat).toMatchObject({ cron: '0 2 * * *', tz: 'UTC' });
   });
 });


### PR DESCRIPTION
## Problème (structurel, pas de bricolage)

`SeoProjectionFeederService.onModuleInit` — chemin **OFF** (flag `SEO_PROJECTION_R1_FEED_ENABLED != true`, défaut) — se contentait de logguer puis `return`, **sans toucher la queue**. Le nettoyage du repeatable obsolète (`removeStaleRepeatableJob`) ne tournait **que sur le chemin d'activation** (`configureRepeatableJob`).

Conséquence : un flag basculé **ON→OFF** laissait vivre le repeatable nocturne dans Redis. Le write-job continuait de se déclencher **malgré la désactivation**. « OFF » ne signifiait donc pas « aucun repeatable ne peut tirer », seulement « n'enregistre rien de neuf ».

C'est exactement le risque que l'audit `2026-07-16-prod-bundle` demandait de vérifier **à la main** (SSH PROD + inspection Bull/Redis). Cette PR remplace la vérif manuelle par un **invariant de code réconcilié à chaque boot**.

## Solution

- Chemin OFF appelle désormais `void this.deregisterResidualRepeatable()` (réconciliation fail-safe).
- `deregisterResidualRepeatable()` énumère la feed-queue et supprime tout repeatable `PROJECTION_FEED_JOB`, **de façon observable** : `WARN` quand N>0 sont supprimés, `LOG` quand il n'y a rien à nettoyer. **Aucun repli silencieux** (CLAUDE.md).
- `removeStaleRepeatableJob()` retourne maintenant le **nombre supprimé** pour que le réconciliateur puisse le journaliser.

## Invariants préservés

- **Non-bloquant** : réconciliation en `void` fire-and-forget, `onModuleInit` reste synchrone (`.claude/rules/backend.md`).
- **Pas d'I/O distante en `onModuleInit`** : Bull = Redis **local** (local-fast OK). La règle ast-grep `backend-no-remote-io-in-onmoduleinit` reste **verte** (0 match).
- **Chemin ON inchangé** : purge-puis-enregistre, toujours idempotent au redeploy.
- **Aucune activation de feature.** Aucun changement de comportement quand le flag est ON.

## Tests (`seo-projection-feeder.test.ts`, 4 nouveaux cas)

| Cas | Attendu |
|-----|---------|
| OFF + repeatable résiduel | supprimé + **jamais** réenregistré |
| OFF + aucun repeatable | no-op (rien supprimé, rien enregistré) |
| OFF + repeatable d'un **autre** job | intact (filtre par nom) |
| ON | purge **puis** enregistre (cron + `jobId` stable) |

`15 passed / 15 total`. tsc backend clean · eslint `--max-warnings=0` clean · ast-grep onModuleInit clean.

## Déploiement

`merge main` ⇒ **container PREPROD uniquement** (`.claude/rules/deployment.md`). **Aucun tag `v*`, PROD inchangé.** Aucune action infra requise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)