### PR TITLE
chore(seo-batch): neutralize r7-brand-rag-generator (RAG→content writer, slice 1)

### DIFF
--- a/workspaces/seo-batch/.claude/agents/r7-brand-rag-generator.md
+++ b/workspaces/seo-batch/.claude/agents/r7-brand-rag-generator.md
@@ -1,208 +1,38 @@
 ---
 name: r7-brand-rag-generator
-description: >-
-  [DEPRECATED 2026-06-12 — successeur wiki-proposal-writer, ADR-031/046] Generation
-  artefacts RAG constructeur (brand.md + role_map.json). 1 marque par
-  invocation. Lit DB + gammes RAG, ecrit dans
-  /opt/automecanik/rag/knowledge/constructeurs/.
-model: sonnet
+disable-model-invocation: true
+description: "[NEUTRALISÉ 2026-07-19 → wiki-proposal-writer, ADR-031/046] Corps opératoire retiré. Cet agent lisait la DB + le RAG (/opt/automecanik/rag/knowledge/gammes) puis ÉCRIVAIT des artefacts constructeur (brand.md + role_map.json) dans /opt/automecanik/rag/knowledge/constructeurs/ — direction RAG→source-de-contenu abandonnée. La vérité contenu vient du WIKI (RAW→WIKI→projection). Successeur : wiki-proposal-writer (entity_type=constructeur, ADR-033)."
 tools:
-  - mcp__supabase__execute_sql
   - Read
-  - Write
-  - Glob
-  - Grep
 role: R7_BRAND
 ---
 
-# Agent R7 Brand RAG Generator V1
+# Agent R7 Brand RAG Generator — NEUTRALISÉ (2026-07-19)
 
-> 🚨 **DEPRECATED 2026-06-12** — écrit dans `/opt/automecanik/rag/knowledge/constructeurs/`
-> = chemin RAG-source-de-contenu abandonné (ADR-031/046). Aucune heuristique marque unique
-> à porter : le schema vit dans `.spec/00-canon/brand-md-schema.md` (SoT conservée), les
-> termes interdits + gates dans `backend/src/config/r7-keyword-plan.constants.ts` (SoT code),
-> les top gammes/modèles sont des agrégations DB déjà couvertes côté backend. La référence
-> `backend/src/config/brand-role-map.schema.ts` (`buildDefaultBrandRoleMap`) n'existe plus
-> dans le repo (chemin mort — l'agent ne peut plus exécuter son Step 4 tel quel).
-> **Successeur** : `wiki-proposal-writer` (entity_type=constructeur, ADR-033) +
-> `automecanik-wiki/exports`. Suppression après 2 cycles.
+> 🚫 **NEUTRALISÉ** — cet agent est **inerte**. Son corps opératoire (fetch DB + lecture du
+> corpus RAG gammes, génération `brand.md` / `role_map.json`, écriture dans
+> `/opt/automecanik/rag/knowledge/constructeurs/`) a été **retiré**. C'était la direction
+> **RAG→source-de-contenu abandonnée** (ADR-031 / ADR-046, vault) : le RAG est un retrieval
+> **chatbot uniquement**, jamais une source de contenu / SEO. Déjà `[DEPRECATED 2026-06-12]` ;
+> son Step 4 était déjà mort (`backend/src/config/brand-role-map.schema.ts` absent du repo).
 
-Tu es un agent specialise dans la generation de documents RAG pour les pages **R7_BRAND** (constructeur) d'AutoMecanik.
+## Écriture désactivée (défense en profondeur)
 
-**Projet Supabase** : `cxpojprgwgubzjyqzmoq`
+Les outils d'écriture (`mcp__supabase__execute_sql`, `Write`, `Glob`, `Grep`) ont été **retirés**
+de `tools` : seul `Read` demeure, et `disable-model-invocation: true` empêche l'auto-invocation.
+Même recopié, cet agent **ne peut plus écrire** ni en base ni dans le corpus RAG.
 
-**Axiome R7** : intent = brand_selection (awareness funnel). Le contenu est **R7_ROUTER safe** : uniquement page constructeur, pas de diagnostic, pas de howto, pas de tutoriel.
+## Remplacement (méthode canon)
 
-**Source de verite** :
-- Schema : `.spec/00-canon/brand-md-schema.md`
-- Zod : `backend/src/config/brand-role-map.schema.ts`
-- Constants R7 : `backend/src/config/r7-keyword-plan.constants.ts`
+- **Successeur** : `wiki-proposal-writer` (`entity_type=constructeur`, ADR-033) + `automecanik-wiki/exports`.
+  La vérité contenu vient du **WIKI** (sourcée, lintée, validée humainement), **jamais** du RAG.
+- **Schéma constructeur** (SoT conservée) : `.spec/00-canon/brand-md-schema.md`.
+- **Constants R7** (SoT code) : `backend/src/config/r7-keyword-plan.constants.ts`.
 
----
-
-## Input
-
-```
-brand_alias: string  (ex: "renault", "bmw", "peugeot")
-```
-
-1 marque par invocation. Pas de batch multi-marques.
-
----
-
-## Output (2 fichiers)
-
-```
-/opt/automecanik/rag/knowledge/constructeurs/{alias}.md
-/opt/automecanik/rag/knowledge/constructeurs/{alias}.role_map.json
-```
-
----
-
-## Pipeline
-
-### Step 1 — Fetch donnees DB
-
-```sql
--- 1. Info marque
-SELECT marque_id, marque_name, marque_alias, marque_logo
-FROM auto_marque WHERE marque_alias = '{alias}';
-
--- 2. SEO marque
-SELECT sm_title, sm_descrip, sm_h1, sm_content
-FROM __seo_marque WHERE sm_marque_id = '{marque_id}';
-
--- 3. Top 10 gammes
-SELECT pg.pg_alias, pg.pg_name, COUNT(*) as nb_refs
-FROM __cross_gamme_car_new cgc
-JOIN pieces_gamme pg ON pg.pg_id::text = cgc.cgc_pg_id
-WHERE cgc.cgc_marque_id = '{marque_id}'
-  AND pg.pg_display = '1'
-GROUP BY pg.pg_alias, pg.pg_name
-ORDER BY nb_refs DESC LIMIT 10;
-
--- 4. Top 10 modeles
-SELECT mo.modele_name, mo.modele_alias, mo.modele_id,
-       COUNT(DISTINCT t.type_id) as nb_types
-FROM auto_modele mo
-JOIN auto_type t ON t.type_modele_id = mo.modele_id::text
-WHERE mo.modele_marque_id = {marque_id}
-  AND mo.modele_display = '1'
-GROUP BY mo.modele_name, mo.modele_alias, mo.modele_id
-ORDER BY nb_types DESC LIMIT 10;
-```
-
-### Step 2 — Fetch RAG gammes (Read)
-
-Pour les top 5 gammes, lire le fichier RAG :
-```
-/opt/automecanik/rag/knowledge/gammes/{pg_alias}.md
-```
-Extraire `domain.role` du frontmatter YAML. Si fichier absent → skip gracieux.
-
-### Step 3 — Generer le .md
-
-Appliquer le template defini dans `.spec/00-canon/brand-md-schema.md` :
-
-**Frontmatter YAML** : remplir tous les champs Meta + domain depuis les donnees DB.
-
-**Sections markdown** :
-
-| Section | Source | Contraintes |
-|---------|--------|-------------|
-| S2_MICRO_SEO_ROUTER | `sm_content` + gammes RAG domain.role | 150-220 mots, factuel, safe |
-| S3_SHORTCUTS_INTERNAL_LINKS | top gammes + top modeles | Liens markdown, pas de prose |
-| S7_COMPATIBILITY_QUICK_GUIDE | Template generique + brand name | 3 etapes + 3 erreurs, safe |
-| S8_SAFE_TABLE | Template generique | 6 lignes, pas de km |
-| S9_FAQ_ROUTER | `sm_content` + gammes RAG | 4-6 Q/R, safe |
-| S10_ABOUT_BRAND | `sm_content` (nettoyage HTML) | Max 800 chars, neutre |
-
-### Step 4 — Generer le .role_map.json
-
-Utiliser `buildDefaultBrandRoleMap(alias, brandId)` de `brand-role-map.schema.ts` comme source.
-Ecrire le JSON formate (indent 2).
-
-### Step 5 — Quality check
-
-Avant d'ecrire, verifier :
-1. **Word count** : S2 entre 150-220 mots, S7 >= 80 mots, S9 >= 120 mots
-2. **Termes interdits** : aucun de `R7_FORBIDDEN_FROM_R3` + `R7_FORBIDDEN_FROM_R5` dans le contenu
-3. **S10 truncation** : <= 800 chars
-4. **domain.role** : >= 80 chars
-
-Si violation → corriger avant ecriture. Ne PAS ecrire un fichier non conforme.
-
----
-
-## Termes interdits (29 termes — source r7-keyword-plan.constants.ts)
-
-```
-etape, pas-a-pas, tuto, tutoriel, montage, demonter, visser, devisser,
-couple de serrage, symptome, diagnostic, panne, voyant, comparatif,
-versus, vs, definition, glossaire, encyclopedie, etymologie,
-historique technique, comment reparer, comment changer, comment remplacer,
-bruit au, fuite de, voyant allume, panne de, symptomes de
-```
-
----
-
-## Exemple de sortie attendue
-
-### renault.md (extrait)
-
-```yaml
----
-category: constructeur
-slug: renault
-brand_id: 140
-brand_name: RENAULT
-doc_family: catalog
-source_type: constructeur
-truth_level: L2
-updated_at: "2026-03-11"
-verification_status: draft
-pays: france
-groupe: renault-nissan-mitsubishi
-intent_targets: [brand_selection, navigational, commercial_investigation]
-business_priority: high
-lifecycle:
-  stage: v1_generated
-  last_enriched_by: r7-brand-rag-generator
-  last_enriched_at: "2026-03-11"
-domain:
-  role: "Hub de navigation pour pieces detachees Renault : selection par modele (Clio, Megane, Scenic, Kangoo), annee de mise en circulation et motorisation, avec filtrage par gamme de pieces"
-  must_be_true:
-    - Renault est un constructeur automobile francais
-    - Pieces detachees compatibles disponibles par vehicule
-  must_not_contain:
-    - diagnostic
-    - symptome
-    - tutoriel
-    - montage
-    - reparation
-    - comment reparer
-    - comment changer
----
-```
-
-### renault.role_map.json
-
-```json
-{
-  "doc_type": "CONSTRUCTEUR",
-  "doc_id": "renault-140",
-  "sections": [...]
-}
-```
-
-## Contrat de sortie obligatoire
-
-> REGLE NON-NEGOCIABLE — s'applique a ce run.
-
-- Tu ne corriges JAMAIS automatiquement. Tu scannes, analyses, et rapportes.
-- Tu ne peux pas affirmer "tout scanne/verifie/corrige" sans coverage manifest.
-- Tu dois separer : scan | analysis | correction (proposee) | validation | verdict.
-- Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
-- Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
-- Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.
+> Le fichier est **conservé** (non supprimé) pour ne pas casser les références des registres
+> `.spec/00-canon/**` (`prompt-registry`, `artefact-registry`, `role-implementation-map`,
+> `canon-registry`) ni les chaînes d'agents (`r7-brand-execution`, `agentic-planner`) : elles
+> pointent désormais vers un agent inerte qui **STOP + redirige**.
+>
+> Réf : `audit/agent-instructions-audit-2026-07-18.md` (writers RAG→SEO indexé),
+> `audit/rag-legacy-inventory-2026-07-02.md`. Rollback = `git revert`.


### PR DESCRIPTION
## What

Neutralize the deprecated `r7-brand-rag-generator` agent (owner-GO'd slice 1 of the RAG→SEO writer removal). `+25 / −195`, one file.

## Why

The agent — though `[DEPRECATED 2026-06-12]` — still shipped **write tools** (`mcp__supabase__execute_sql`, `Write`) and a full pipeline body that generated `brand.md` / `role_map.json` from RAG + DB and wrote them into `/opt/automecanik/rag/knowledge/constructeurs/`. That's the **abandoned RAG-as-content-source** direction (ADR-031/046) — RAG is chatbot-retrieval only, never a content/SEO source.

## How (content-gen neutralization pattern)

- `tools:` reduced to **`Read` only** (all write tools removed) + `disable-model-invocation: true` → cannot write even if invoked.
- Body gutted → hard **STOP + redirect** to the successor `wiki-proposal-writer` (`entity_type=constructeur`, ADR-033). Content truth = **WIKI**.
- **File kept (not deleted)** so the ~14 references in `.spec/00-canon` registries (`prompt-registry`, `artefact-registry`, `role-implementation-map`, `canon-registry`) and agent chains (`r7-brand-execution`, `agentic-planner`) stay valid — they now hit an inert STOP agent.

## Safety

- **No `.spec` edits** (owner-gated closure untouched), **no DB / URL / indexed-SEO** mutation.
- Drift gate `spec-canon-prompt-registry-drift` is warn-only *and* its path filter doesn't match `workspaces/` — plus the path stays "alive" (file kept).
- Remaining writers **#1 `seo-gamme-audit --fix`, #2 `r*-content-batch`, #3 `/kp RAG_ONLY`** stay **per-slice owner-gated** (see `audit/agent-instructions-audit-2026-07-18.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)