### PR TITLE
fix(deploy): ssr probe must not write a temp file (read-only prod rootfs)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -75,6 +75,15 @@ jobs:
         # (the regression that made the previous rollback a no-op).
         run: npm run test:prod-rollback
 
+      - name: 🖥️ PROD SSR gate — behavioural proof vs stubbed docker (BLOCKING)
+        # The SSR gate runs ONLY in deploy-prod.yml (never PREPROD/CI), so it shipped
+        # untested and false-failed in PROD on 2026-07-19: it wrote the body to a temp
+        # file inside a read-only-rootfs container, capturing an empty body and rejecting
+        # even the known-good image on rollback. This executes prod-ssr-probe.sh against a
+        # stubbed docker (pass/fail per homepage state) and statically forbids the
+        # container temp-file write from ever coming back.
+        run: npm run test:prod-ssr-probe
+
       - name: 🗂️ EDITORIAL_AUTHORITY_SINKS registry invariants (BLOCKING)
         # Pins the exact P0 sink set (audit §6): 2 served-tracked + 15 ratchet-blind,
         # each evidence-linked, no rN wildcard. The blind rows justify the registry.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "audit:served-write-ratchet:test": "tsx --test scripts/audit/check-served-content-write-sinks-ratchet.test.ts",
     "audit:editorial-sinks:test": "tsx --test scripts/audit/editorial-authority-sinks.test.ts",
     "test:prod-rollback": "node --test scripts/ci/prod-rollback.test.mjs",
+    "test:prod-ssr-probe": "node --test scripts/ci/prod-ssr-probe.test.mjs",
     "audit:rag-authority-rule:test": "ast-grep test --test-dir scripts/audit/__fixtures__/rag-authority --skip-snapshot-tests",
     "audit:rag-authority-read-ratchet": "tsx scripts/audit/check-rag-authority-read-ratchet.ts",
     "audit:rag-authority-read-ratchet:json": "tsx scripts/audit/check-rag-authority-read-ratchet.ts --json",

--- a/scripts/ci/prod-rollback.test.mjs
+++ b/scripts/ci/prod-rollback.test.mjs
@@ -57,13 +57,17 @@ case "$1" in
   push) [ "\${STUB_PUSH_FAIL:-0}" = "1" ] && exit 1 || exit 0 ;;
   exec)
     shift 2
+    # SSR probe headers: wget --server-response -O /dev/null (body discarded)
     if printf '%s' "$*" | grep -q -- '--server-response'; then
       printf '%s\\n' "$STUB_SSR_HEADERS" >&2
       exit 0
+    # health: wget -qO- .../health
     elif printf '%s' "$*" | grep -q -- '/health'; then
       printf '%s\\n' "$STUB_HEALTH"
       exit 0
-    elif printf '%s' "$*" | grep -q -- 'cat'; then
+    # SSR probe body: wget -qO- .../ (no temp file — was 'cat /tmp/...' before
+    # the read-only-rootfs fix, 2026-07-19)
+    elif printf '%s' "$*" | grep -q -- 'wget'; then
       printf '%s\\n' "$STUB_SSR_BODY"
       exit 0
     fi

--- a/scripts/ci/prod-ssr-probe.sh
+++ b/scripts/ci/prod-ssr-probe.sh
@@ -37,8 +37,17 @@ CONTAINER="${PROD_CONTAINER:-nestjs-remix-monorepo-prod}"
 URL="${SSR_URL:-http://localhost:3000/}"
 MARKER="${SSR_MARKER:-__reactRouterContext}"
 
-hdrs=$(docker exec "$CONTAINER" wget -q --server-response -O /tmp/ssr-probe.html "$URL" 2>&1 || true)
-body=$(docker exec "$CONTAINER" cat /tmp/ssr-probe.html 2>/dev/null || echo "")
+# Capture WITHOUT writing a temp file inside the container. The PROD container's
+# rootfs is not writable by this process, so `wget -O /tmp/ssr-probe.html` failed
+# with "Read-only file system" — yet `--server-response` still printed the 200 to
+# stderr, so status/Content-Type parsed fine while the body file stayed EMPTY →
+# the marker check false-failed and rejected even the known-good image on rollback
+# (PROD deploy incident 2026-07-19, tag v2026.07.19-deploy-safety-sentry-beacon).
+# Headers go to stderr with the body discarded to /dev/null (writable even on a
+# read-only rootfs); the body streams to stdout via `wget -qO-` — the exact
+# pattern the /health probe in prod-rollback.sh already relies on.
+hdrs=$(docker exec "$CONTAINER" wget -q --server-response -O /dev/null "$URL" 2>&1 || true)
+body=$(docker exec "$CONTAINER" wget -qO- "$URL" 2>/dev/null || echo "")
 
 status=$(echo "$hdrs" | grep -m1 'HTTP/' | awk '{print $2}')
 ctype=$(echo "$hdrs" | grep -i -m1 'Content-Type:' | tr -d '\r')

--- a/scripts/ci/prod-ssr-probe.test.mjs
+++ b/scripts/ci/prod-ssr-probe.test.mjs
@@ -1,0 +1,158 @@
+/**
+ * Behavioural proof of the PROD SSR gate (prod-ssr-probe.sh).
+ *
+ * This gate had NO test and ran for the first time ever during a real PROD
+ * deploy — where it false-failed: it wrote the body to `-O /tmp/ssr-probe.html`
+ * inside a container whose rootfs is not writable, so the body file was empty
+ * and the marker check rejected even the known-good image on rollback (incident
+ * 2026-07-19, tag v2026.07.19-deploy-safety-sentry-beacon).
+ *
+ * These tests:
+ *   1. EXECUTE prod-ssr-probe.sh against a stubbed `docker` and assert the
+ *      pass/fail decision for each observable homepage state;
+ *   2. statically assert the probe never writes a temp file inside the
+ *      container (the exact regression), i.e. it captures via /dev/null + stdout.
+ *
+ * Run: npm run test:prod-ssr-probe
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PROBE_SH = join(SCRIPT_DIR, "prod-ssr-probe.sh");
+
+const HEALTHY_HEADERS = [
+  "  HTTP/1.1 200 OK",
+  "  Content-Type: text/html; charset=utf-8",
+  "  Cache-Control: public, max-age=300",
+].join("\n");
+
+// The degraded homepage fallback answers 200 + noindex (frontend/app/routes/_index.tsx).
+const DEGRADED_HEADERS = [
+  "  HTTP/1.1 200 OK",
+  "  Content-Type: text/html; charset=utf-8",
+  "  X-Robots-Tag: noindex, follow",
+].join("\n");
+
+const ERROR_HEADERS = ["  HTTP/1.1 503 Service Unavailable", "  Content-Type: text/html"].join("\n");
+const JSON_HEADERS = ["  HTTP/1.1 200 OK", "  Content-Type: application/json"].join("\n");
+
+const SSR_BODY = '<!DOCTYPE html><html lang="fr"><body>x<script>window.__reactRouterContext={};</script></body></html>';
+const NO_MARKER_BODY = "<!DOCTYPE html><html><body>no hydration payload here</body></html>";
+
+/**
+ * A stub `docker` mirroring the two calls the probe makes:
+ *   - `wget --server-response -O /dev/null URL`  → headers to STDERR
+ *   - `wget -qO- URL`                            → body to STDOUT
+ */
+const DOCKER_STUB = `#!/usr/bin/env bash
+echo "$@" >> "$DOCKER_LOG"
+case "$1" in
+  exec)
+    shift 2
+    if printf '%s' "$*" | grep -q -- '--server-response'; then
+      printf '%s\\n' "$STUB_SSR_HEADERS" >&2
+      exit 0
+    elif printf '%s' "$*" | grep -q -- 'wget'; then
+      printf '%s\\n' "$STUB_SSR_BODY"
+      exit 0
+    fi
+    exit 0 ;;
+esac
+exit 0
+`;
+
+function runProbe(env = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "prod-ssr-probe-"));
+  const stub = join(dir, "docker");
+  const log = join(dir, "docker.log");
+  writeFileSync(stub, DOCKER_STUB);
+  chmodSync(stub, 0o755);
+  writeFileSync(log, "");
+
+  let code = 0;
+  let stdout = "";
+  try {
+    stdout = execFileSync("bash", [PROBE_SH, "test"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        DOCKER_LOG: log,
+        PROD_CONTAINER: "nestjs-remix-monorepo-prod",
+        STUB_SSR_HEADERS: HEALTHY_HEADERS,
+        STUB_SSR_BODY: SSR_BODY,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (e) {
+    code = e.status ?? 1;
+    stdout = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  return { code, stdout };
+}
+
+describe("prod-ssr-probe.sh — behavioural proof of the SSR gate", () => {
+  test("PASSES on a healthy, indexable, server-rendered homepage", () => {
+    const { code, stdout } = runProbe();
+    assert.equal(code, 0, `expected pass, got ${code}\n${stdout}`);
+    assert.match(stdout, /✅.*SSR marker present, indexable/);
+  });
+
+  test("FAILS when the body lacks the SSR marker (not server-rendered)", () => {
+    const { code, stdout } = runProbe({ STUB_SSR_BODY: NO_MARKER_BODY });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /lacks the stable SSR marker/);
+  });
+
+  test("FAILS on the degraded 200 + noindex homepage fallback", () => {
+    const { code, stdout } = runProbe({ STUB_SSR_HEADERS: DEGRADED_HEADERS });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /noindex|DEGRADED FALLBACK/);
+  });
+
+  test("FAILS when GET / is not 200", () => {
+    const { code, stdout } = runProbe({ STUB_SSR_HEADERS: ERROR_HEADERS });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /expected 200/);
+  });
+
+  test("FAILS when Content-Type is not text/html", () => {
+    const { code, stdout } = runProbe({ STUB_SSR_HEADERS: JSON_HEADERS });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /not text\/html/);
+  });
+});
+
+describe("prod-ssr-probe.sh — must not write a temp file in the container (2026-07-19 regression)", () => {
+  const src = readFileSync(PROBE_SH, "utf8");
+  // Strip full-line comments — the header comment intentionally *quotes* the bad
+  // `-O /tmp/...` pattern to document the incident; only real code should be checked.
+  const code = src
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("#"))
+    .join("\n");
+
+  test("does not write the response body to a container path", () => {
+    // The read-only-rootfs bug: `wget -O /tmp/ssr-probe.html`. Any `-O <path>`
+    // other than `-` (stdout) or `/dev/null` risks the same failure.
+    const badWrites = code.match(/-O\s+(?!-|\/dev\/null)\S+/g) || [];
+    assert.deepEqual(
+      badWrites,
+      [],
+      `probe must not '-O' to a container file (read-only rootfs). Found: ${badWrites.join(", ")}`,
+    );
+    assert.doesNotMatch(code, /\bcat\s+\/tmp/, "probe must not cat a container temp file");
+  });
+
+  test("captures body via stdout (wget -qO-) and headers via /dev/null", () => {
+    assert.match(code, /wget\s+-qO-/, "body must stream to stdout");
+    assert.match(code, /-O\s+\/dev\/null/, "headers must discard body to /dev/null");
+  });
+});


### PR DESCRIPTION
## Incident (2026-07-19)

The first-ever PROD deploy to use the new SSR gate (#1288) — tag `v2026.07.19-deploy-safety-sentry-beacon` (`e3de45fa9`) — **failed at the SSR gate, and it false-failed.** All pre-tag gates (fresh bundle audit, E2E Smoke, Lighthouse, `test:prod-rollback`) were green.

**What happened:** `prod-ssr-probe.sh` fetched the homepage with `wget --server-response -O /tmp/ssr-probe.html` then `cat`-ed the file back. The PROD container's rootfs is **not writable** by that process, so the `-O /tmp/...` write failed (`Read-only file system`) — but `--server-response` still printed the `200` to stderr, so **status + Content-Type parsed fine while the body temp file stayed empty** → the marker check reported "not server-rendered". This rejected even the **known-good** image during rollback (`Rollback SSR gate FAILED`).

**PROD impact: none ongoing.** The rollback restored the previous image (verified image-ID + `/health` OK + `GET / → 200`); there were ~seconds of edge `521` during the container stop/rm/up churn, now resolved. The release never went live — PROD is on the previous version.

**Why it shipped:** the SSR gate runs **only** in `deploy-prod.yml` (never PREPROD/CI) and had **no test**, so it was unexercised against a real container.

## Fix

Mirror the `/health` probe in `prod-rollback.sh`, which already reads via **stdout** and worked in the same deploy:
- **headers** → `wget --server-response -O /dev/null` (`/dev/null` is writable even on a read-only rootfs)
- **body** → `wget -qO-` (stdout)
- No container temp file. Decision logic (`200` / `text/html` / marker present / no `noindex`) **unchanged**.

## Tests + guardrails

- **New `scripts/ci/prod-ssr-probe.test.mjs`** — 5 behavioural cases via a stubbed `docker` (healthy → pass; missing marker / `noindex` / non-200 / non-html → fail) + a **static guard** that forbids any `-O <container-path>` write from ever returning.
- **`test:prod-ssr-probe`** wired as a **BLOCKING** `audit.yml` job, like `test:prod-rollback`.
- Updated `prod-rollback.test.mjs` docker stub (probe body now via `wget`, not `cat`).

## Verification

- `npm run test:prod-ssr-probe` ✅ · `npm run test:prod-rollback` ✅
- **E2E against a real `--read-only` Alpine container** (mock SSR homepage): the actual script **PASSES** (`200 | text/html | marker present | exit 0`) — reproducing the exact failure environment — and a **negative control** (JSON `/health`) is correctly **rejected**.
- Root cause independently reproduced: `wget -O /tmp/file` → `Read-only file system` in `docker run --read-only node:24-alpine`, while `-O /dev/null` + `-qO-` succeed.

## Deploy note

Merge → PREPROD only. **PROD re-tag is owner-gated** and separate. Once merged, a new `v*` tag on a head that includes this fix will deploy with a working SSR gate + the real rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)