### PR TITLE
fix(deploy): prod-ssr-probe SIGPIPE false-negative on large SSR pages (stacks on #1301)

### DIFF
--- a/scripts/ci/prod-ssr-probe.sh
+++ b/scripts/ci/prod-ssr-probe.sh
@@ -63,7 +63,14 @@ if ! echo "$ctype" | grep -qi 'text/html'; then
   echo "  ❌ [$LABEL] GET / Content-Type is not text/html"
   exit 1
 fi
-if ! printf '%s' "$body" | grep -qF "$MARKER"; then
+# Pure-bash substring test — deliberately NOT `printf '%s' "$body" | grep -qF`.
+# With `set -o pipefail`, `grep -q` exits on the FIRST match and closes the pipe;
+# on a large (>64 KB) SSR page printf is still streaming and takes SIGPIPE, so the
+# pipeline returns FAILURE even though the marker IS present — a false negative that
+# sank the first real deploy to reach this gate (run 29701454004, tag
+# v2026.07.19-catch-all-410-prod-rollback-ssr-gate) and its rollback. No subprocess/
+# pipe = flavour-independent (GNU grep triggered it; the dev box's ugrep hid it).
+if [[ "$body" != *"$MARKER"* ]]; then
   echo "  ❌ [$LABEL] GET / lacks the stable SSR marker $MARKER — document was not server-rendered"
   exit 1
 fi

--- a/scripts/ci/prod-ssr-probe.test.mjs
+++ b/scripts/ci/prod-ssr-probe.test.mjs
@@ -45,6 +45,17 @@ const JSON_HEADERS = ["  HTTP/1.1 200 OK", "  Content-Type: application/json"].j
 const SSR_BODY = '<!DOCTYPE html><html lang="fr"><body>x<script>window.__reactRouterContext={};</script></body></html>';
 const NO_MARKER_BODY = "<!DOCTYPE html><html><body>no hydration payload here</body></html>";
 
+// A healthy homepage larger than the 64 KB OS pipe buffer, marker near the top.
+// This is the shape that made the old `printf '%s' "$body" | grep -qF` marker check
+// a SIGPIPE false-negative on the 275 KB PROD homepage (run 29701454004): grep -q
+// matched early and closed the pipe, printf took SIGPIPE, and `set -o pipefail`
+// turned a PRESENT marker into "not server-rendered". ~100 KB stays under
+// MAX_ARG_STRLEN (128 KB) so it can ride an env var into the docker stub.
+const LARGE_SSR_BODY =
+  '<!DOCTYPE html><html lang="fr"><body><script>window.__reactRouterContext={};</script>' +
+  "x".repeat(100 * 1024) +
+  "</body></html>";
+
 /**
  * A stub `docker` mirroring the two calls the probe makes:
  *   - `wget --server-response -O /dev/null URL`  → headers to STDERR
@@ -105,6 +116,16 @@ describe("prod-ssr-probe.sh — behavioural proof of the SSR gate", () => {
     assert.match(stdout, /✅.*SSR marker present, indexable/);
   });
 
+  test("PASSES on a LARGE (>64 KB) healthy homepage (SIGPIPE-under-pipefail regression)", () => {
+    // The marker check must not choke on a real homepage. The old
+    // `printf '%s' "$body" | grep -qF` form false-failed here: grep -q closed the
+    // pipe on first match, printf took SIGPIPE, and pipefail turned the PRESENT
+    // marker into a "not server-rendered" failure (run 29701454004).
+    const { code, stdout } = runProbe({ STUB_SSR_BODY: LARGE_SSR_BODY });
+    assert.equal(code, 0, `large healthy SSR page must pass, got ${code}\n${stdout.slice(0, 800)}`);
+    assert.match(stdout, /✅.*SSR marker present, indexable/);
+  });
+
   test("FAILS when the body lacks the SSR marker (not server-rendered)", () => {
     const { code, stdout } = runProbe({ STUB_SSR_BODY: NO_MARKER_BODY });
     assert.notEqual(code, 0);
@@ -154,5 +175,14 @@ describe("prod-ssr-probe.sh — must not write a temp file in the container (202
   test("captures body via stdout (wget -qO-) and headers via /dev/null", () => {
     assert.match(code, /wget\s+-qO-/, "body must stream to stdout");
     assert.match(code, /-O\s+\/dev\/null/, "headers must discard body to /dev/null");
+  });
+
+  test("marker check is a pure-bash test, not a pipe into grep (SIGPIPE-under-pipefail)", () => {
+    // `printf '%s' "$body" | grep -qF` SIGPIPEs on a large page under `set -o
+    // pipefail` (grep -q closes the pipe, printf fails) → false negative. The marker
+    // check must be a pure-bash substring test with no subprocess. (Header/ctype/
+    // robots greps stay fine — those pipe tiny values, not the body.)
+    assert.doesNotMatch(code, /"\$body"\s*\|/, "must not pipe the response body into another process");
+    assert.match(code, /\[\[.*\$body.*\$MARKER.*\]\]/, "marker check must be a pure-bash [[ ]] substring test");
   });
 });


### PR DESCRIPTION
## What

The PROD SSR deploy gate (`scripts/ci/prod-ssr-probe.sh`) throws a **false negative on any real, large homepage**, blocking healthy deploys **and** their rollback.

The marker check was:
```bash
if ! printf '%s' "$body" | grep -qF "$MARKER"; then   # "not server-rendered"
```
Under `set -o pipefail`, `grep -q` exits on the first match and closes the pipe. On a real 275 KB homepage `printf` is still streaming and takes **SIGPIPE**, so the pipeline returns **failure even though the marker IS present** → `if !` reports "document was not server-rendered".

## Relationship to #1301

This **stacks on #1301** (already merged). #1301 fixed a *different* defect in the same probe — the read-only-rootfs temp-file write (`-O /tmp/...` → empty body), which sank the `deploy-safety-sentry-beacon` deploy. **#1301 did not touch the marker check**, so the SIGPIPE false-negative remained. Two distinct bugs, same probe; this PR closes the second.

## Impact (observed)

Run **`29701454004`** (tag `v2026.07.19-catch-all-410-prod-rollback-ssr-gate`):
- `🚀 Deploy to PROD`: rejected a **healthy** new image on all 3 attempts — `prod-ssr-probe.sh: printf: write error: Broken pipe` at the marker line.
- `⏪ Rollback PROD`: restored the known-good image (registry + `/health` OK) but its **own** post-probe hit the same bug → run left **red / "MANUAL INTERVENTION REQUIRED"**.
- Live PROD is **healthy** on the restored image. No outage; but #1294's 410 fix never shipped.

Why it shipped green: invisible on the dev box (its `grep` is **ugrep**, which drains stdin) and with the tests' small bodies (fit the 64 KB pipe buffer).

## Fix

Pure-bash substring test — no subprocess, no pipe, no SIGPIPE, grep-flavour independent:
```bash
if [[ "$body" != *"$MARKER"* ]]; then
```

## Tests (`scripts/ci/prod-ssr-probe.test.mjs`, the suite #1301 introduced)

- **Behavioural**: a ~100 KB healthy homepage **PASSES** the gate.
- **Source-level** (deterministic, environment-independent — same style as #1301's temp-file guard): the marker check must be a pure-bash `[[ ]]` test and must **not** pipe the body into grep. Verified to fail on the buggy line, pass on the fix.

Suites: probe 9/9, rollback 6/6 green.

## Scope / safety

Touches only `scripts/ci/prod-ssr-probe.sh` (1 line + comment) and its test. No runtime code, no payments, no migrations, no workflow YAML. Unblocks the governed release so #1294 (+ bundle) can reach PROD once this merges and `:preprod` rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
