### PR TITLE
fix(jobs): stop timestamp-only churn commits in diag-canon export + RAG sync

### DIFF
--- a/.github/workflows/diag-canon-slugs-export.yml
+++ b/.github/workflows/diag-canon-slugs-export.yml
@@ -122,20 +122,33 @@ jobs:
           token: ${{ secrets.WIKI_REPO_TOKEN }}
           ref: main
 
-      - name: Diff vs current wiki exports/ (3 files)
+      - name: Diff vs current wiki exports/ (3 files, ignoring volatile generated_at)
         id: diff
+        shell: bash
         run: |
           mkdir -p automecanik-wiki/exports
+          # `generated_at` is a provenance timestamp that export-diag-canon-slugs.py
+          # stamps with wall-clock time on EVERY run (it is required by the Zod schema
+          # in backend/src/config/diag-canon.schema.ts, but no consumer treats it as a
+          # freshness signal). Comparing it byte-for-byte defeated this idempotency
+          # guard and re-committed diag-canon.json nightly with NO content change.
+          # We compare CONTENT only — strip generated_at (objects only) before diffing —
+          # so a no-op run makes no commit. Export liveness is measured separately by
+          # scripts/wiki/wiki-readiness-check.py C3 via THIS workflow's CI run-history,
+          # not by commit recency. (diag-canon-slugs.json is an array and
+          # diag-canon.schema.json has no generated_at — the normalization is a no-op
+          # for those.)
+          norm() { jq -S 'if type=="object" then del(.generated_at) else . end' "$1"; }
           changed=0
           for f in diag-canon-slugs.json diag-canon.json diag-canon.schema.json; do
             if [ ! -f "automecanik-wiki/exports/$f" ]; then
               echo "[diff] $f: missing in wiki — will create"
               changed=1
-            elif diff -q "/tmp/canon/$f" "automecanik-wiki/exports/$f" > /dev/null; then
-              echo "[diff] $f: identical (idempotent)"
+            elif diff -q <(norm "/tmp/canon/$f") <(norm "automecanik-wiki/exports/$f") > /dev/null; then
+              echo "[diff] $f: content identical (ignoring generated_at) — idempotent"
             else
               echo "[diff] $f: content changed — will update"
-              diff -u "automecanik-wiki/exports/$f" "/tmp/canon/$f" | head -20 || true
+              diff -u <(norm "automecanik-wiki/exports/$f") <(norm "/tmp/canon/$f") | head -20 || true
               changed=1
             fi
           done

--- a/.github/workflows/wiki-readiness-check.yml
+++ b/.github/workflows/wiki-readiness-check.yml
@@ -34,6 +34,7 @@ on:
 
 permissions:
   contents: read
+  actions: read  # C3 liveness queries diag-canon-slugs-export.yml run-history via GITHUB_TOKEN
 
 jobs:
   readiness-check:
@@ -50,7 +51,7 @@ jobs:
         with:
           repository: ak125/automecanik-wiki
           path: automecanik-wiki
-          fetch-depth: 0  # need git log for C3 freshness check
+          fetch-depth: 0  # full history kept for wiki-side checks (C5 quality-gates)
 
       - name: Checkout automecanik-rag
         uses: actions/checkout@v4
@@ -73,6 +74,8 @@ jobs:
           AUTOMECANIK_WIKI_PATH: ${{ github.workspace }}/automecanik-wiki
           AUTOMECANIK_RAG_PATH: ${{ github.workspace }}/automecanik-rag
           AUTOMECANIK_MONOREPO_PATH: ${{ github.workspace }}/monorepo
+          # C3 liveness reads diag-canon-slugs-export.yml run-history (needs actions:read).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Don't fail the workflow if NOT_READY — this is informational on schedule.
           # On PR triggers, fail to surface regression.

--- a/scripts/cron/sync-rag-from-wiki.sh
+++ b/scripts/cron/sync-rag-from-wiki.sh
@@ -78,6 +78,14 @@ if [ "$RAG_BRANCH" != "main" ]; then
   log "ERROR: rag not on main (branch=$RAG_BRANCH), aborting (manual cleanup needed)"
   exit 3
 fi
+# Transition safety: Step 4 intentionally never commits knowledge/.last-sync.json,
+# so the sync script's per-run rewrite leaves it a dirty TRACKED file until the
+# companion rag-repo untrack lands. A dirty tracked file blocks `git pull --ff-only`
+# the moment an incoming commit touches it (notably the untrack commit's deletion),
+# which would wedge this cron every hour under `set -euo pipefail`. Discard our
+# local manifest churn first — it is regenerated from scratch in Step 3, so this is
+# always safe. No-op once the manifest is untracked/ignored (post-untrack).
+git checkout -- knowledge/.last-sync.json 2>/dev/null || true
 git pull --ff-only origin main 2>&1 | tee -a "$LOG_FILE"
 
 # --- Step 3: Run sync (D20 enforce + sha256 idempotent) ---
@@ -87,16 +95,32 @@ python3 "$SYNC_SCRIPT" \
   --rag-repo "$RAG_PATH" \
   --apply 2>&1 | tee -a "$LOG_FILE"
 
-# --- Step 4: Commit + push if changes ---
+# --- Step 4: Commit + push only if real CONTENT changed ---
+# knowledge/.last-sync.json is a per-run runtime freshness manifest: the sync
+# script rewrites it every run with a fresh `synced_at` (+ stats), and it is
+# read *from disk* by RagMirrorFreshnessService for the 36h mirror-freshness
+# SLO. It is runtime observability state, NOT git-tracked source content —
+# committing it turned every hourly no-op sync into a `synced-from-wiki:` churn
+# commit (defeating the idempotency intent of this step). We exclude it from
+# both the change-detection guard and staging so a run that copies 0 new files
+# produces NO commit. The rag repo also untracks it (.gitignore, companion PR)
+# for a clean working tree; this exclude keeps the job correct during that
+# transition and if the ignore is ever reverted.
 cd "$RAG_PATH"
-if git diff --quiet -- knowledge/ && git diff --cached --quiet -- knowledge/; then
-  log "[4/4] No changes under knowledge/ — nothing to commit (idempotent)"
+MANIFEST_EXCLUDE=':(exclude)knowledge/.last-sync.json'
+# Stage first (excluding the manifest), THEN inspect the index. A plain `git diff`
+# guard is blind to UNTRACKED files and would silently drop a pure-addition sync
+# (a brand-new knowledge file) — the mirror's primary payload. Staging surfaces
+# additions, modifications and deletions in one shot; the exclude keeps the
+# runtime manifest churn out of the commit.
+git add -- knowledge/ "$MANIFEST_EXCLUDE"
+if git diff --cached --quiet -- knowledge/ "$MANIFEST_EXCLUDE"; then
+  log "[4/4] No content changes under knowledge/ (runtime manifest churn ignored) — nothing to commit (idempotent)"
   log "=== sync-rag-from-wiki done (no-op) ==="
   exit 0
 fi
 
-log "[4/4] Committing + pushing changes"
-git add knowledge/
+log "[4/4] Committing + pushing content changes"
 
 # D22 marker : marker `synced-from-wiki: <sha>` requis par .githooks/commit-msg
 # et .github/workflows/d22-protected-paths.yml côté rag.

--- a/scripts/wiki/test_wiki_readiness_check.py
+++ b/scripts/wiki/test_wiki_readiness_check.py
@@ -1,0 +1,186 @@
+"""pytest suite for wiki-readiness-check.py — focused on C3 liveness re-point.
+
+Single-file convention canon: load the hyphenated script via
+importlib.util.spec_from_file_location (no package, no sys.path mutation).
+
+Scope: the C3 change that decouples "export cron liveness" from content-commit
+recency (the export is now idempotent on `generated_at`, so commit age is no
+longer a liveness signal). Liveness now comes from the export workflow's GitHub
+Actions run-history; local mode (no token) reports it UNVERIFIED, never a silent
+pass.
+"""
+import datetime
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parent / "wiki-readiness-check.py"
+_spec = importlib.util.spec_from_file_location("wiki_readiness_check", SCRIPT_PATH)
+wr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wr)
+
+UTC = datetime.timezone.utc
+
+
+def _make_wiki(tmp_path: Path, n_slugs: int = 6) -> Path:
+    """Build a minimal valid wiki checkout: exports/ with the 2 files C3 reads."""
+    exports = tmp_path / "exports"
+    exports.mkdir(parents=True)
+    slugs = [{"symptom_slug": f"symptom_{i}", "system_slug": "freinage"} for i in range(n_slugs)]
+    (exports / "diag-canon-slugs.json").write_text(json.dumps(slugs), encoding="utf-8")
+    (exports / "diag-canon.json").write_text(
+        json.dumps({"generated_at": "2026-01-01T00:00:00Z", "symptoms": {}, "systems": {}, "version": "1"}),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ── module smoke ──────────────────────────────────────────────────────────────
+
+
+def test_module_exposes_new_liveness_api():
+    assert hasattr(wr, "export_workflow_liveness")
+    assert hasattr(wr, "c3_export_diag_canon_slugs_fresh")
+    assert wr.EXPORT_FRESHNESS_DAYS == 7
+    assert wr.EXPORT_WORKFLOW_FILE == "diag-canon-slugs-export.yml"
+
+
+# ── export_workflow_liveness tri-state ────────────────────────────────────────
+
+
+def test_liveness_none_when_no_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    status, detail = wr.export_workflow_liveness()
+    assert status is None
+    assert "no GITHUB_TOKEN" in detail
+
+
+def _fake_urlopen(payload: dict):
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _open(req, timeout=0):
+        return _Resp(json.dumps(payload).encode("utf-8"))
+
+    return _open
+
+
+def test_liveness_alive_recent_run(monkeypatch):
+    now = datetime.datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+    payload = {"workflow_runs": [{"created_at": "2026-07-19T03:00:00Z"}]}  # ~9h ago
+    monkeypatch.setattr(wr.urllib.request, "urlopen", _fake_urlopen(payload))
+    status, detail = wr.export_workflow_liveness(repo="x/y", token="t", now=now)
+    assert status is True
+    assert "0.4d ago" in detail or "ago" in detail
+
+
+def test_liveness_dead_when_run_too_old(monkeypatch):
+    now = datetime.datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+    payload = {"workflow_runs": [{"created_at": "2026-07-01T03:00:00Z"}]}  # ~18d ago
+    monkeypatch.setattr(wr.urllib.request, "urlopen", _fake_urlopen(payload))
+    status, detail = wr.export_workflow_liveness(repo="x/y", token="t", now=now)
+    assert status is False
+    assert "cron may be dead" in detail
+
+
+def test_liveness_dead_when_no_scheduled_runs(monkeypatch):
+    payload = {"workflow_runs": []}
+    monkeypatch.setattr(wr.urllib.request, "urlopen", _fake_urlopen(payload))
+    status, detail = wr.export_workflow_liveness(repo="x/y", token="t")
+    assert status is False
+    assert "no successful scheduled run" in detail
+
+
+def test_liveness_failclosed_after_retries(monkeypatch):
+    monkeypatch.setattr(wr.time, "sleep", lambda *a, **k: None)  # no real backoff
+    calls = {"n": 0}
+
+    def _boom(req, timeout=0):
+        calls["n"] += 1
+        raise wr.urllib.error.URLError("network down")
+
+    monkeypatch.setattr(wr.urllib.request, "urlopen", _boom)
+    status, detail = wr.export_workflow_liveness(repo="x/y", token="t", attempts=3)
+    assert status is False  # fail-closed, never mask a dead cron
+    assert "fail-closed" in detail
+    assert calls["n"] == 3  # bounded retry before giving up
+
+
+def test_liveness_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(wr.time, "sleep", lambda *a, **k: None)
+    now = datetime.datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+    payload = {"workflow_runs": [{"created_at": "2026-07-19T03:00:00Z"}]}
+    state = {"n": 0}
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _flaky(req, timeout=0):
+        state["n"] += 1
+        if state["n"] < 3:
+            raise wr.urllib.error.URLError("transient")
+        return _Resp(json.dumps(payload).encode("utf-8"))
+
+    monkeypatch.setattr(wr.urllib.request, "urlopen", _flaky)
+    status, detail = wr.export_workflow_liveness(repo="x/y", token="t", now=now, attempts=3)
+    assert status is True  # recovered on the 3rd attempt
+    assert state["n"] == 3
+
+
+# ── C3 decision logic (liveness injected) ─────────────────────────────────────
+
+
+def test_c3_local_mode_passes_validity_only(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    ok, evidence = wr.c3_export_diag_canon_slugs_fresh(wiki, liveness_fn=lambda: (None, "no token"))
+    assert ok is True
+    assert "UNVERIFIED" in evidence
+
+
+def test_c3_alive_passes(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    ok, evidence = wr.c3_export_diag_canon_slugs_fresh(
+        wiki, liveness_fn=lambda: (True, "last successful export run 0.4d ago")
+    )
+    assert ok is True
+    assert "export workflow" in evidence
+
+
+def test_c3_dead_fails(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    ok, evidence = wr.c3_export_diag_canon_slugs_fresh(
+        wiki, liveness_fn=lambda: (False, "last successful export run 18d ago — cron may be dead")
+    )
+    assert ok is False
+    assert "liveness" in evidence
+
+
+def test_c3_insufficient_slugs_fails_before_liveness(tmp_path):
+    wiki = _make_wiki(tmp_path, n_slugs=3)
+    # liveness would pass, but validity must fail first (and never call liveness).
+    called = {"n": 0}
+
+    def _liveness():
+        called["n"] += 1
+        return (True, "alive")
+
+    ok, evidence = wr.c3_export_diag_canon_slugs_fresh(wiki, liveness_fn=_liveness)
+    assert ok is False
+    assert "distinct slugs" in evidence
+    assert called["n"] == 0  # validity short-circuits before the network call
+
+
+def test_c3_missing_files_fail(tmp_path):
+    ok, evidence = wr.c3_export_diag_canon_slugs_fresh(tmp_path, liveness_fn=lambda: (True, "alive"))
+    assert ok is False
+    assert "missing" in evidence

--- a/scripts/wiki/wiki-readiness-check.py
+++ b/scripts/wiki/wiki-readiness-check.py
@@ -21,9 +21,13 @@ Criteria (each is independent, returns PASS/FAIL with evidence) :
   C3 — diag-canon export à jour :
        - automecanik-wiki/exports/diag-canon-slugs.json + diag-canon.json exist
        - ≥ 5 distinct slugs (validity, read from diag-canon-slugs.json)
-       - last commit on diag-canon.json < 7 days old (liveness — this file
-         carries `generated_at` so it is re-committed every run; the slugs
-         array is content-stable and not a reliable freshness signal)
+       - export cron is ALIVE : the diag-canon-slugs-export.yml workflow had a
+         successful run < 7 days ago. Liveness is measured from THIS repo's
+         GitHub Actions run-history, NOT from commit recency: the export now only
+         commits when the symptom→system map actually changes (no more nightly
+         `generated_at`-only churn), so commit age is no longer a liveness signal.
+         Local mode (no GITHUB_TOKEN) reports liveness as UNVERIFIED and asserts
+         validity only — the authoritative liveness check runs in CI.
 
   C4 — fiches gamme migrées :
        - 0 hits for `entity_data.symptoms:` or `^symptoms:` in
@@ -68,6 +72,9 @@ import os
 import re
 import subprocess
 import sys
+import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 
@@ -77,7 +84,12 @@ DEFAULT_WIKI_PATH = Path(os.environ.get("AUTOMECANIK_WIKI_PATH", "/opt/automecan
 DEFAULT_RAG_PATH = Path(os.environ.get("AUTOMECANIK_RAG_PATH", "/opt/automecanik/rag"))
 DEFAULT_MONOREPO_PATH = Path(os.environ.get("AUTOMECANIK_MONOREPO_PATH", "/opt/automecanik/app"))
 
-EXPORT_FRESHNESS_DAYS = 7  # C3 : commit < 7 days = "alive"
+EXPORT_FRESHNESS_DAYS = 7  # C3 : last SUCCESSFUL export run < 7 days = "alive"
+# C3 liveness is measured from this workflow's GitHub Actions run-history (the
+# authoritative "did the scheduled export run" signal), decoupled from content
+# commit recency (the export is now idempotent on `generated_at`).
+EXPORT_WORKFLOW_FILE = "diag-canon-slugs-export.yml"
+DEFAULT_GITHUB_REPO = "ak125/nestjs-remix-monorepo"
 
 
 # ── Criteria ─────────────────────────────────────────────────────────────────
@@ -123,16 +135,101 @@ def c2_validator_ci_active(monorepo_path: Path) -> tuple[bool, str]:
     return True, f"{workflow.relative_to(monorepo_path)} present and blocking ✓"
 
 
-def c3_export_diag_canon_slugs_fresh(wiki_path: Path) -> tuple[bool, str]:
-    """C3 — diag-canon export is alive: ≥ 5 slugs present AND it ran < 7 days ago.
+def export_workflow_liveness(
+    repo: str | None = None,
+    token: str | None = None,
+    now: datetime.datetime | None = None,
+    attempts: int = 3,
+) -> tuple[bool | None, str]:
+    """Liveness of the nightly diag-canon export, read from THIS repo's GitHub
+    Actions run-history — the authoritative "did the SCHEDULED job run" signal,
+    decoupled from content-commit recency.
+
+    Only `event=schedule` runs count: a manual `workflow_dispatch` must not mask a
+    dead nightly cron (a one-off manual run would otherwise read as "alive" for up
+    to EXPORT_FRESHNESS_DAYS). Transient API errors are retried (bounded, with
+    backoff) before we fail-closed, so a single blip does not spuriously red a PR.
+
+    Returns (status, detail):
+      (True,  detail) — a successful SCHEDULED run happened < EXPORT_FRESHNESS_DAYS ago.
+      (False, detail) — no recent successful scheduled run, OR the API query kept
+                        failing (after retries) while a token WAS present
+                        (fail-closed: never mask a dead cron).
+      (None,  detail) — no token (local mode). Caller MUST treat liveness as
+                        UNVERIFIED and say so explicitly (authoritative = CI).
+    """
+    token = token or os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        return None, (
+            "no GITHUB_TOKEN/GH_TOKEN — CI run-history not queryable "
+            "(run in CI for the authoritative liveness check)"
+        )
+    repo = repo or os.environ.get("GITHUB_REPOSITORY") or DEFAULT_GITHUB_REPO
+    now = now or datetime.datetime.now(tz=datetime.timezone.utc)
+    url = (
+        f"https://api.github.com/repos/{repo}/actions/workflows/"
+        f"{EXPORT_WORKFLOW_FILE}/runs?status=success&event=schedule&per_page=1"
+    )
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "wiki-readiness-check",
+        },
+    )
+    n = max(1, attempts)
+    last_err = ""
+    payload = None
+    for attempt in range(1, n + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            break
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+            last_err = f"{type(e).__name__}: {e}"
+            if attempt < n:
+                time.sleep(min(2 ** (attempt - 1), 4))  # 1s, 2s, 4s … capped
+    if payload is None:
+        # Token present but the API kept erroring: fail-closed rather than
+        # silently pass a liveness gate (CLAUDE.md — no silent fallback).
+        return False, f"GitHub API query failed after {n} attempts ({last_err}) — fail-closed"
+
+    runs = payload.get("workflow_runs") or []
+    if not runs:
+        return False, (
+            f"no successful scheduled run of {EXPORT_WORKFLOW_FILE} found via API "
+            "(nightly cron may be dead/disabled)"
+        )
+    created = runs[0].get("created_at") or runs[0].get("run_started_at")
+    try:
+        started = datetime.datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return False, f"API run record has unparseable timestamp: {created!r}"
+    age_days = (now - started).total_seconds() / 86_400.0
+    if age_days >= EXPORT_FRESHNESS_DAYS:
+        return False, (
+            f"last successful scheduled export run was {age_days:.1f}d ago "
+            f"(expected < {EXPORT_FRESHNESS_DAYS}d) — cron may be dead"
+        )
+    return True, f"last successful scheduled export run {age_days:.1f}d ago"
+
+
+def c3_export_diag_canon_slugs_fresh(
+    wiki_path: Path, liveness_fn=export_workflow_liveness
+) -> tuple[bool, str]:
+    """C3 — diag-canon export is alive: ≥ 5 slugs present AND the export cron ran
+    successfully < EXPORT_FRESHNESS_DAYS ago.
 
     Content validity (≥ 5 distinct slugs) is read from the legacy array
-    `diag-canon-slugs.json`. Freshness (liveness) is measured on
-    `diag-canon.json` instead: the flat-map artifact carries a `generated_at`
-    field, so it is re-committed on EVERY nightly run. The legacy array is only
-    re-committed when the slug set itself changes — so its commit age is NOT a
-    reliable "export ran recently" signal (a healthy nightly emitting identical
-    slugs would never re-commit it, ageing out C3 while the export is fine).
+    `diag-canon-slugs.json`. Liveness is measured from the export workflow's
+    GitHub Actions run-history (see `export_workflow_liveness`), NOT from commit
+    recency: the export is now idempotent on `generated_at` (it only commits when
+    the symptom→system map changes), so commit age no longer proves the cron ran.
+    In local mode (no GITHUB_TOKEN) liveness cannot be queried, so C3 asserts
+    validity only and labels liveness UNVERIFIED — a documented, observable skip
+    (CLAUDE.md no-silent-fallback exception); the authoritative check runs in CI.
     """
     slugs_file = wiki_path / "exports" / "diag-canon-slugs.json"
     fresh_file = wiki_path / "exports" / "diag-canon.json"
@@ -151,21 +248,19 @@ def c3_export_diag_canon_slugs_fresh(wiki_path: Path) -> tuple[bool, str]:
     if len(slugs) < 5:
         return False, f"FAIL: only {len(slugs)} distinct slugs (expected ≥ 5)"
 
-    # Freshness measured on diag-canon.json (re-committed every run via
-    # `generated_at`), NOT the content-stable legacy array.
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(wiki_path), "log", "-1", "--format=%ct", "--", "exports/diag-canon.json"],
-            capture_output=True, text=True, check=True
+    # Liveness via CI run-history (decoupled from content commits).
+    live_ok, detail = liveness_fn()
+    if live_ok is None:
+        # Local mode: cannot verify the CI cron. Assert validity only and label
+        # liveness explicitly (observable, not a silent pass).
+        sys.stderr.write(f"[C3] liveness UNVERIFIED: {detail}\n")
+        return True, (
+            f"{len(slugs)} slugs ✓ | liveness UNVERIFIED locally ({detail}) — "
+            f"authoritative check = CI run-history"
         )
-        ts = int(result.stdout.strip())
-        last_commit = datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
-        age = datetime.datetime.now(tz=datetime.timezone.utc) - last_commit
-        if age.days >= EXPORT_FRESHNESS_DAYS:
-            return False, f"FAIL: last export commit was {age.days}d ago (expected < {EXPORT_FRESHNESS_DAYS}d)"
-        return True, f"{len(slugs)} slugs; diag-canon.json last commit {age.days}d ago ✓"
-    except (subprocess.CalledProcessError, ValueError) as e:
-        return False, f"FAIL: cannot read git log: {e}"
+    if not live_ok:
+        return False, f"FAIL: export liveness — {detail}"
+    return True, f"{len(slugs)} slugs; export workflow {detail} ✓"
 
 
 def c4_fiches_migrated(wiki_path: Path) -> tuple[bool, str]:


### PR DESCRIPTION
## Problem

Two scheduled jobs re-committed nightly/hourly with **no business change** — only a timestamp field flipping — polluting the wiki/rag histories (report 2026-07-19):
- **WIKI** `chore(diag-canon): nightly export` — only `exports/diag-canon.json`'s `generated_at` changed.
- **RAG** `synced-from-wiki:` — only `knowledge/.last-sync.json`'s `synced_at` changed (8+ consecutive no-ops).

## Fix

### WIKI export — `.github/workflows/diag-canon-slugs-export.yml`
`export-diag-canon-slugs.py` stamps `generated_at` with wall-clock time every run; the byte-diff idempotency guard compared it too, so `diag-canon.json` was re-committed nightly with no content change. The diff step now compares **content only** (`jq -S 'if type=="object" then del(.generated_at) else . end'`, applied to both sides) → a no-op run makes no commit. `generated_at` stays (required by the Zod schema) and only advances when the symptom→system map actually changes.

### WIKI readiness C3 — `scripts/wiki/wiki-readiness-check.py` (coupled — read this)
C3 **deliberately** used `diag-canon.json`'s commit age as an export-**liveness heartbeat** — which only worked *because of the churn above*. Removing the churn alone would false-fail C3 after 7 stable days. So C3 liveness is re-pointed to the authoritative signal — the export workflow's **GitHub Actions run-history**:
- Query filtered to `event=schedule&status=success` within `EXPORT_FRESHNESS_DAYS` (a manual `workflow_dispatch` must not mask a dead nightly).
- CI (`GITHUB_TOKEN` + new `actions: read`): exact. Transient API errors are **retried** (bounded, backoff) then **fail-closed**.
- Local mode (no token): liveness reported **UNVERIFIED** — an observable, labelled skip (no silent pass); validity (≥5 slugs) still checked.
- Unit tests added (`test_wiki_readiness_check.py`, 12 cases).

### RAG sync cron — `scripts/cron/sync-rag-from-wiki.sh`
`sync-wiki-exports-to-rag.py` rewrites `knowledge/.last-sync.json` (fresh `synced_at`) every run; under `knowledge/` it defeated the no-op guard.
- **Step 4** now **stages first** (excluding the manifest via `:(exclude)knowledge/.last-sync.json`) then inspects the index — so **brand-new untracked files (the mirror's primary payload) are still committed**, while a manifest-only run commits nothing.
- **Step 2** discards the manifest's local churn before `git pull --ff-only`, so the dirty tracked file can't wedge the hourly cron during the transition window.
- The manifest keeps updating **on disk** → `RagMirrorFreshnessService` 36 h SLO unchanged.

## Companion PR
`ak125/automecanik-rag#19` gitignores + untracks `knowledge/.last-sync.json` for a permanently clean tree. The cron fix above is transition-safe **in either merge order**.

## Verification
- `jq` semantic-diff on the **real** 3 export files: generated_at-only → no commit; new symptom → commit.
- Stage-first guard on a scratch repo: manifest-only → skip; modified → commit; **pure-addition → commit**.
- Transition pull (dirty manifest + incoming untrack): **aborts** without the Step-2 fix, **succeeds** with it.
- **12/12** unit tests pass.
- Hardened against a 5-way adversarial review that caught: the pure-addition regression, the transition wedge, dispatch-masks-a-dead-cron, and the transient-API fail-closed edge.

## Deploy notes
Merge to `main` = PREPROD tag only; no PROD tag. No Docker restart needed. The DEV cron picks up the new script via the ~10 min `sync-dev-runtime.sh`.

## Definition of Done — auto-évaluation

- [x] DoD1 — Tests verts: #1304 CI = 29 SUCCESS / 0 fail (authoritative `gh` rollup, incl. 🚦 Wiki readiness ✅); 12/12 unit tests (`test_wiki_readiness_check.py`); no `.only`/`.skip`/`xfail` added; jq semantic-diff, stage-first guard and transition-pull proven on scratch repos + the real export files.
- [x] DoD2 — Ownership: owner = @Fafa (automecanik.seo@gmail.com); ≥1 human approval REQUIRED before merge — **pending** (this PR is not self-merged).
- [x] DoD3 — Rollback: `git revert` the merge — reversibility = **instant**; config-only (2 workflow YAML + 1 shell cron + 1 py + 1 test), no DB/data migration; DEV cron reverts within one `sync-dev-runtime.sh` cycle (~10 min).
- [x] DoD4 — Observabilité: existing logs retained (`sync-rag-from-wiki.log`; export workflow run-logs + `upload-artifact`); C3 liveness now emits an observable signal from GitHub Actions run-history (no new blind path); `[C3] liveness UNVERIFIED` is written to stderr in local mode.
- [x] DoD5 — Drift zéro: no DB migration, no schema/registry change; registry-fresh unaffected; 5 files only (2 YAML, 1 shell, 2 py).
- [x] DoD6 — Docs: behaviour documented inline in every changed file (rationale comments) + this PR body; no external doc needs updating (internal cron/CI jobs).
- [x] DoD7 — Monitoring: watcher = @Fafa; window = T+~1h (first hourly RAG cron post-merge) + next nightly WIKI export; abort = revert PR if a no-op run still commits, if the cron wedges, or if `.last-sync.json` stops refreshing on disk. Post-merge checks: `.last-sync.json` present on disk + `synced_at` advances + RAG worktree clean + a `written: 0` run creates no commit.
- [x] DoD8 — No TODO unresolved: 0 TODO/FIXME/HACK added (grep-verified on the diff).
- [x] DoD9 — No silent skip: the WIKI no-op skip is explicit + logged; C3 local-mode UNVERIFIED is labelled + stderr (not a silent pass); GitHub API error = fail-closed (never masks a dead cron). No test/feature/migration silently gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
