### PR TITLE
fix(deploy-prod): keep Caddy up + readiness poll — cut the deploy outage (step 1 toward zero-downtime)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -84,6 +84,14 @@ jobs:
         # container temp-file write from ever coming back.
         run: npm run test:prod-ssr-probe
 
+      - name: 🔄 PROD app-recreate path — behavioural proof vs stubbed docker (BLOCKING)
+        # Also runs ONLY in deploy-prod.yml. Its whole reason for existing is a
+        # behaviour static YAML review cannot prove: Caddy (the public TLS listener)
+        # is NEVER stopped, the readiness poll succeeds early / fails fast, and Caddy
+        # is restarted ONLY when the Caddyfile changed. This executes
+        # prod-app-recreate.sh against a stubbed docker and asserts exactly that.
+        run: npm run test:prod-app-recreate
+
       - name: 🗂️ EDITORIAL_AUTHORITY_SINKS registry invariants (BLOCKING)
         # Pins the exact P0 sink set (audit §6): 2 served-tracked + 15 ratchet-blind,
         # each evidence-linked, no rN wildcard. The blind rows justify the registry.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -304,27 +304,37 @@ jobs:
           # what made the old rollback restore the broken build.
           echo "🔒 Rollback point pinned: ${ROLLBACK_IMAGE_ID:-<none — auto-rollback disabled>}"
 
-          # POINT OF NO RETURN. Past this line the running container is destroyed,
-          # so ANY later failure — including in "Validate PROD" — must roll back.
-          # The dedicated `if: failure()` rollback step keys off this flag, which
-          # is why it is set BEFORE the stop/rm rather than after a successful up.
+          # POINT OF NO RETURN. Past this line the running app container is
+          # recreated (destroyed + replaced), so ANY later failure — including in
+          # "Validate PROD" — must roll back. The dedicated `if: failure()`
+          # rollback step keys off this flag, set BEFORE the recreate.
+          #
+          # NOTE: Caddy (the public 80/443 TLS listener) is deliberately NOT torn
+          # down anymore. The old deploy did `docker stop nestjs-remix-caddy …`,
+          # which dropped the public listener for the whole window → total outage,
+          # not just a 502. prod-app-recreate.sh keeps Caddy up and recreates ONLY
+          # the app container; a changed Caddyfile is applied by a targeted Caddy
+          # restart AFTER the app is healthy (admin is off ⇒ restart is the apply
+          # path). See scripts/ci/prod-app-recreate.sh + its behavioural test.
           echo "DEPLOY_STARTED=1" >> "$GITHUB_ENV"
-
-          docker stop nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
-          docker rm nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
 
           # 🚨 Sentry secrets injection via SOPS exec-env wrapper (parity with
           # ci.yml preprod deploy step). docker-compose.prod.yml declares
           # `environment: - SENTRY_DSN` etc. which inherit from this shell's env.
-          # If sops/age unavailable on this runner, fall back to plain
-          # `docker compose up` — Sentry SDK no-ops, deploy still succeeds.
-          # Source ~/production/.env first so bare `environment: - VAR` refs
-          # for SUPABASE_*, INTERNAL_API_KEY, etc. inherit from the shell
-          # (not just env_file, which is overridden by `environment: -` listings).
+          # If sops/age unavailable on this runner, fall back to a plain run —
+          # Sentry SDK no-ops, deploy still succeeds. Source ~/production/.env
+          # first so bare `environment: - VAR` refs for SUPABASE_*,
+          # INTERNAL_API_KEY, etc. inherit from the shell (not just env_file,
+          # which is overridden by `environment: -` listings).
           set -a
           # shellcheck disable=SC1091
           . "$PROD_DIR/.env"
           set +a
+
+          # The app recreate (Caddy-preserving, readiness-polled, SSR-gated) lives
+          # in a tested script so the deploy path is provable — see
+          # scripts/ci/prod-app-recreate.test.mjs (npm run test:prod-app-recreate).
+          RECREATE="bash $GITHUB_WORKSPACE/scripts/ci/prod-app-recreate.sh"
 
           SOPS_FILE="$GITHUB_WORKSPACE/secrets/sentry.prod.sops.env"
           AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
@@ -333,81 +343,20 @@ jobs:
              && [ -r "$AGE_KEY_FILE" ]; then
             echo "✅ Injecting Sentry secrets via sops exec-env"
             export SOPS_AGE_KEY_FILE="$AGE_KEY_FILE"
-            sops exec-env "$SOPS_FILE" \
-              'docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d --no-deps monorepo_prod caddy redis_prod'
+            sops exec-env "$SOPS_FILE" "$RECREATE"
           else
             echo "::warning::sops binary, secrets file, or age key missing on runner — Sentry SDK will start in no-op mode for PROD"
             echo "  sops:        $(command -v sops || echo 'NOT FOUND')"
             echo "  SOPS_FILE:   $SOPS_FILE ($([ -f "$SOPS_FILE" ] && echo present || echo absent))"
             echo "  age key:     $AGE_KEY_FILE ($([ -r "$AGE_KEY_FILE" ] && echo readable || echo unreadable))"
-            docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d --no-deps monorepo_prod caddy redis_prod
+            $RECREATE
           fi
+          # imgproxy is a separate stateless, Cloudflare-cached service; recreate it
+          # after the app is healthy. (Its own zero-downtime treatment is out of
+          # scope for this PR — tracked in the design note.)
           docker compose -f docker-compose.imgproxy.yml up -d --force-recreate
 
-          echo "Waiting for containers to start (60s)..."
-          sleep 60
-
-          if ! docker ps | grep -q nestjs-remix-monorepo-prod; then
-            echo "Container not running - checking logs..."
-            docker logs nestjs-remix-monorepo-prod --tail 50
-            exit 1
-          fi
-
-          # Image assertion: verify container runs the correct image
-          EXPECTED_IMAGE="massdoc/nestjs-remix-monorepo:production"
-          ACTUAL_IMAGE=$(docker inspect nestjs-remix-monorepo-prod --format='{{.Config.Image}}')
-          if [ "$ACTUAL_IMAGE" != "$EXPECTED_IMAGE" ]; then
-            echo "FATAL: Container running $ACTUAL_IMAGE instead of $EXPECTED_IMAGE"
-            exit 1
-          fi
-          echo "Image verified: $ACTUAL_IMAGE"
-
-          # Health check with retry
-          echo "Running health check (inside container)..."
-          RETRIES=5
-          HEALTH=""
-          for i in $(seq 1 $RETRIES); do
-            HEALTH=$(docker exec nestjs-remix-monorepo-prod wget -qO- http://localhost:3000/health 2>/dev/null || echo "")
-            if echo "$HEALTH" | grep -q '"status":"ok"'; then
-              echo "/health -> OK (attempt $i/$RETRIES)"
-              break
-            fi
-            echo "Health check attempt $i/$RETRIES failed, waiting 10s..."
-            sleep 10
-          done
-
-          HEALTH_OK=0
-          if echo "$HEALTH" | grep -q '"status":"ok"'; then HEALTH_OK=1; fi
-
-          # SSR gate (BLOCKING). Only meaningful once the process answers /health.
-          # See scripts/ci/prod-ssr-probe.sh for why /health alone is not enough
-          # and why `noindex` is the signal that catches the degraded fallback.
-          SSR_OK=0
-          if [ "$HEALTH_OK" = "1" ]; then
-            echo "🖥️ Running SSR gate (GET /)..."
-            for i in $(seq 1 3); do
-              if bash "$GITHUB_WORKSPACE/scripts/ci/prod-ssr-probe.sh" "post-deploy $i/3"; then
-                SSR_OK=1
-                break
-              fi
-              echo "  SSR gate attempt $i/3 failed, waiting 10s..."
-              sleep 10
-            done
-          fi
-
-          if [ "$HEALTH_OK" != "1" ] || [ "$SSR_OK" != "1" ]; then
-            if [ "$HEALTH_OK" != "1" ]; then
-              echo "❌ Health check failed after $RETRIES attempts"
-            else
-              echo "❌ SSR gate failed — GET / is not a healthy, indexable, server-rendered document"
-            fi
-            docker logs nestjs-remix-monorepo-prod --tail 30
-            # Rollback is NOT done here: the dedicated `if: failure()` step owns it,
-            # so that a failure in "Validate PROD" rolls back through the SAME path.
-            exit 1
-          fi
-
-          echo "✅ PROD deployment successful — /health OK and GET / is a healthy indexable SSR document"
+          echo "✅ PROD deployment successful — Caddy stayed up, /health OK and GET / is a healthy indexable SSR document"
 
           docker image prune -f
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "audit:served-write-ratchet:test": "tsx --test scripts/audit/check-served-content-write-sinks-ratchet.test.ts",
     "audit:editorial-sinks:test": "tsx --test scripts/audit/editorial-authority-sinks.test.ts",
     "test:prod-rollback": "node --test scripts/ci/prod-rollback.test.mjs",
+    "test:prod-app-recreate": "node --test scripts/ci/prod-app-recreate.test.mjs",
     "test:prod-ssr-probe": "node --test scripts/ci/prod-ssr-probe.test.mjs",
     "audit:rag-authority-rule:test": "ast-grep test --test-dir scripts/audit/__fixtures__/rag-authority --skip-snapshot-tests",
     "audit:rag-authority-read-ratchet": "tsx scripts/audit/check-rag-authority-read-ratchet.ts",

--- a/scripts/ci/prod-app-recreate.sh
+++ b/scripts/ci/prod-app-recreate.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# PROD app recreate — replace the running app container WITHOUT tearing down the
+# public TLS listener, and WITHOUT the blind fixed sleep.
+#
+# WHY THIS EXISTS (deploy outage root cause, audit 2026-07-19)
+# -----------------------------------------------------------
+# The old deploy did, in order:
+#     docker stop  nestjs-remix-caddy nestjs-remix-monorepo-prod   # ← the 80/443 listener dies too
+#     docker rm    nestjs-remix-caddy nestjs-remix-monorepo-prod
+#     docker compose up -d monorepo_prod caddy redis_prod
+#     sleep 60                                                     # ← blind, before any health check
+# So for the whole window the PUBLIC TLS LISTENER (Caddy) was gone — every request
+# got connection-refused / TLS failure, not just a 502 — and a hard `sleep 60` ran
+# regardless of how fast the app actually booted. That is the 60–90 s outage.
+#
+# Two of those are simply wrong and are fixed here, WITHOUT changing any container
+# name, network alias, or Caddy upstream (all load-bearing: the fixed container
+# name `nestjs-remix-monorepo-prod` is an ops interface consumed by the watchdog,
+# cron health-checks, monitoring and smoke tests; the Caddy upstream is the DNS
+# name `monorepo_prod` in the Caddyfile). So:
+#
+#   1. Caddy is NEVER stopped. It keeps serving TLS the whole time. While the app
+#      is briefly down mid-recreate, Caddy answers via its own `handle_errors`
+#      (5xx + `Cache-Control: no-store`, so a transient error can't be cached by
+#      Cloudflare) and its fallback active health-check re-attaches the moment the
+#      app answers /health again. The residual is a short 502 window behind a LIVE
+#      listener that Cloudflare fronts — not a total outage.
+#   2. The blind `sleep 60` becomes an early readiness poll: it starts checking
+#      immediately and succeeds the instant /health is ok (often ~15–25 s), and
+#      fails fast (non-zero) if the app never becomes healthy — the caller's
+#      `if: failure()` step then owns the rollback, exactly as before.
+#   3. Caddy is restarted ONLY when the Caddyfile actually changed (admin is off,
+#      so `caddy reload` is unavailable; a restart is the only way to apply a new
+#      config). That ~1 s blip happens AFTER the app is healthy and only on the
+#      rare deploys that touch the Caddyfile — not on every app-only deploy.
+#
+# This does NOT achieve true zero-downtime (a two-slot blue/green would, but that
+# requires making the fixed ops name non-hardcoded first — see the PR design note).
+# It removes the listener-down window and the blind wait, which is the bulk of it.
+#
+# WHY A SCRIPT (not inline YAML): the deploy path must be testable. `bash -n` and
+# static step order prove nothing about "Caddy is never stopped" or "the poll
+# succeeds early / fails late". prod-app-recreate.test.mjs EXECUTES this against a
+# stubbed docker and asserts exactly that. Mirrors prod-rollback.sh (#1288).
+#
+# Required env: none (safe defaults below).
+# Optional env:
+#   PROD_CONTAINER            app container name     (default nestjs-remix-monorepo-prod)
+#   CADDY_CONTAINER           caddy container name   (default nestjs-remix-caddy)
+#   APP_SERVICE               compose service name   (default monorepo_prod)
+#   COMPOSE_FILES             compose -f flags       (default the prod + caddy files)
+#   EXPECTED_IMAGE            image the app must run (default massdoc/nestjs-remix-monorepo:production)
+#   CADDYFILE_PATH            path to the Caddyfile   (default config/caddy/Caddyfile, relative to CWD)
+#   READINESS_TIMEOUT_SECONDS max wait for /health   (default 120)
+#   READINESS_INTERVAL_SECONDS poll interval         (default 5 — tests set 0)
+set -uo pipefail
+
+PROD_CONTAINER="${PROD_CONTAINER:-nestjs-remix-monorepo-prod}"
+CADDY_CONTAINER="${CADDY_CONTAINER:-nestjs-remix-caddy}"
+APP_SERVICE="${APP_SERVICE:-monorepo_prod}"
+COMPOSE_FILES="${COMPOSE_FILES:--f docker-compose.prod.yml -f docker-compose.caddy.yml}"
+EXPECTED_IMAGE="${EXPECTED_IMAGE:-massdoc/nestjs-remix-monorepo:production}"
+CADDYFILE_PATH="${CADDYFILE_PATH:-config/caddy/Caddyfile}"
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-120}"
+READINESS_INTERVAL_SECONDS="${READINESS_INTERVAL_SECONDS:-5}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Step 0: decide whether the Caddyfile changed, BEFORE we touch anything ─────
+# A sidecar sha file records what config the running Caddy last loaded. The deploy
+# copies the fresh Caddyfile into place before calling this script, so comparing
+# its current hash against the recorded one tells us whether Caddy must reload.
+# No recorded hash (first deploy on this box) ⇒ treat as changed (ensures Caddy
+# loads the current config). `admin off` ⇒ a restart is the only apply mechanism.
+CADDY_CONFIG_CHANGED=0
+CADDY_SHA_FILE="${CADDYFILE_PATH}.deployed.sha"
+if [ -f "$CADDYFILE_PATH" ]; then
+  NEW_CADDY_SHA=$(sha256sum "$CADDYFILE_PATH" | awk '{print $1}')
+  OLD_CADDY_SHA=$(cat "$CADDY_SHA_FILE" 2>/dev/null || echo "")
+  if [ "$NEW_CADDY_SHA" != "$OLD_CADDY_SHA" ]; then
+    CADDY_CONFIG_CHANGED=1
+    echo "🧩 Caddyfile changed since last deploy (or first deploy) — Caddy will be restarted after the app is healthy."
+  else
+    echo "🧩 Caddyfile unchanged — Caddy stays up untouched (no reload needed)."
+  fi
+else
+  echo "::warning::Caddyfile not found at $CADDYFILE_PATH — skipping Caddy config-change detection."
+fi
+
+# ── Step 1: ensure the supporting containers are UP, without recreating them ──
+# `--no-deps` + no `--force-recreate`: idempotent. A running Caddy/redis is left
+# exactly as-is (this is the whole point — Caddy must NOT go down). On a first
+# deploy this creates them. Caddy is NEVER in a stop/rm here.
+echo "🔌 Ensuring Caddy + redis are up (no recreate — Caddy must keep serving TLS)..."
+# shellcheck disable=SC2086
+if ! docker compose $COMPOSE_FILES up -d --no-deps redis_prod caddy; then
+  echo "❌ FATAL: could not ensure Caddy + redis are up."
+  exit 1
+fi
+
+# ── Step 2: recreate ONLY the app container ───────────────────────────────────
+# POINT OF NO RETURN for the app: --force-recreate destroys the old app container.
+# Caddy is untouched (--no-deps). The image comes from compose's pinned
+# `image: …:production`, which the caller retagged to the new build.
+echo "🚀 Recreating app container ($APP_SERVICE) in place — Caddy stays up..."
+# shellcheck disable=SC2086
+if ! docker compose $COMPOSE_FILES up -d --no-deps --force-recreate "$APP_SERVICE"; then
+  echo "❌ FATAL: docker compose failed to recreate $APP_SERVICE."
+  exit 1
+fi
+
+# ── Step 3: assert the app runs the image we intended ─────────────────────────
+ACTUAL_IMAGE=$(docker inspect "$PROD_CONTAINER" --format='{{.Config.Image}}' 2>/dev/null || echo "")
+if [ "$ACTUAL_IMAGE" != "$EXPECTED_IMAGE" ]; then
+  echo "❌ FATAL: $PROD_CONTAINER runs '${ACTUAL_IMAGE:-<none>}', expected '$EXPECTED_IMAGE'."
+  exit 1
+fi
+echo "✅ Image verified: $ACTUAL_IMAGE"
+
+# ── Step 4: readiness poll (replaces the blind sleep 60) ──────────────────────
+# Start checking immediately; succeed the instant /health is ok; fail fast if the
+# deadline passes. All checks run INSIDE the container (host networking is
+# unreliable on the self-hosted runner — same reason prod-rollback.sh uses exec).
+echo "🩺 Readiness poll: /health (timeout ${READINESS_TIMEOUT_SECONDS}s, every ${READINESS_INTERVAL_SECONDS}s)..."
+HEALTH_OK=0
+elapsed=0
+while [ "$elapsed" -le "$READINESS_TIMEOUT_SECONDS" ]; do
+  HEALTH=$(docker exec "$PROD_CONTAINER" wget -qO- http://localhost:3000/health 2>/dev/null || echo "")
+  if echo "$HEALTH" | grep -q '"status":"ok"'; then
+    echo "✅ /health -> OK after ${elapsed}s"
+    HEALTH_OK=1
+    break
+  fi
+  sleep "$READINESS_INTERVAL_SECONDS"
+  elapsed=$((elapsed + READINESS_INTERVAL_SECONDS))
+  # Guard against an infinite loop when the interval is 0 (tests): one pass only.
+  if [ "$READINESS_INTERVAL_SECONDS" -eq 0 ]; then break; fi
+done
+
+if [ "$HEALTH_OK" != "1" ]; then
+  echo "❌ App did not become healthy within ${READINESS_TIMEOUT_SECONDS}s."
+  docker logs "$PROD_CONTAINER" --tail 40 2>/dev/null || true
+  exit 1
+fi
+
+# ── Step 5: SSR gate (BLOCKING) ───────────────────────────────────────────────
+# /health is a separate controller and never renders SSR; the degraded homepage
+# fallback answers 200 + noindex without throwing. prod-ssr-probe.sh is the only
+# gate that catches that. Retry a few times (SSR data path can warm slightly after
+# /health flips green).
+SSR_OK=0
+for i in 1 2 3; do
+  if bash "$SCRIPT_DIR/prod-ssr-probe.sh" "post-recreate $i/3"; then
+    SSR_OK=1
+    break
+  fi
+  echo "  SSR gate attempt $i/3 failed, retrying..."
+  sleep "$READINESS_INTERVAL_SECONDS"
+  if [ "$READINESS_INTERVAL_SECONDS" -eq 0 ]; then break; fi
+done
+
+if [ "$SSR_OK" != "1" ]; then
+  echo "❌ SSR gate failed — GET / is not a healthy, indexable, server-rendered document."
+  docker logs "$PROD_CONTAINER" --tail 30 2>/dev/null || true
+  exit 1
+fi
+
+# ── Step 6: apply a changed Caddyfile (only now, only if it changed) ──────────
+# Done AFTER the app is healthy so the ~1 s Caddy restart never overlaps an app
+# that isn't answering. Only on deploys that actually changed the Caddyfile.
+if [ "$CADDY_CONFIG_CHANGED" = "1" ]; then
+  echo "🧩 Restarting Caddy to load the changed Caddyfile (admin off ⇒ restart is the apply path)..."
+  if docker restart "$CADDY_CONTAINER"; then
+    echo "$NEW_CADDY_SHA" > "$CADDY_SHA_FILE"
+    echo "✅ Caddy restarted with the new config."
+  else
+    # Non-fatal: the app is healthy and the OLD Caddy config is still valid and
+    # serving. Surface loudly; do not fail the deploy over a config-reload blip.
+    echo "::warning::Could not restart Caddy to apply the new config — app is healthy, Caddy still serving the previous config."
+  fi
+fi
+
+echo "✅ App recreate complete — Caddy never went down, /health OK, GET / is a healthy indexable SSR document."

--- a/scripts/ci/prod-app-recreate.test.mjs
+++ b/scripts/ci/prod-app-recreate.test.mjs
@@ -1,0 +1,212 @@
+/**
+ * Behavioural proof of the PROD app-recreate path (deploy outage fix, 2026-07-19).
+ *
+ * The whole point of this deploy change is a behaviour that static YAML review
+ * cannot prove: **Caddy is never stopped**, the readiness poll **succeeds early
+ * and fails fast**, and Caddy is restarted **only when the Caddyfile changed**.
+ * These tests EXECUTE prod-app-recreate.sh against a stubbed `docker` and assert
+ * the observable calls. Mirrors prod-rollback.test.mjs.
+ *
+ *   1. happy path: app is force-recreated, Caddy is NEVER stop/rm'd, exit 0;
+ *   2. unchanged Caddyfile ⇒ Caddy is NOT restarted (no needless blip);
+ *   3. changed Caddyfile ⇒ Caddy IS restarted (only apply path under admin off);
+ *   4. app never healthy ⇒ FAILS (non-zero) so the caller's failure() rollback runs;
+ *   5. degraded 200+noindex homepage ⇒ FAILS (SSR gate catches it);
+ *   6. wrong image on the recreated container ⇒ FAILS before the health poll.
+ *
+ * Run: npm run test:prod-app-recreate
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const RECREATE_SH = join(SCRIPT_DIR, "prod-app-recreate.sh");
+
+const EXPECTED_IMAGE = "massdoc/nestjs-remix-monorepo:production";
+
+const HEALTHY_HEADERS = [
+  "  HTTP/1.1 200 OK",
+  "  Content-Type: text/html; charset=utf-8",
+  "  Cache-Control: public, max-age=120",
+].join("\n");
+
+// The degraded homepage fallback: HTTP 200 + noindex (frontend/app/routes/_index.tsx).
+const DEGRADED_HEADERS = [
+  "  HTTP/1.1 200 OK",
+  "  Content-Type: text/html; charset=utf-8",
+  "  X-Robots-Tag: noindex, follow",
+].join("\n");
+
+const SSR_BODY =
+  '<!DOCTYPE html><html lang="fr"><body>x<script>window.__reactRouterContext={};</script></body></html>';
+
+/**
+ * A stub `docker` that logs every invocation and answers per-scenario env.
+ * `inspect` returns the image the recreated app claims to run.
+ */
+const DOCKER_STUB = `#!/usr/bin/env bash
+echo "$@" >> "$DOCKER_LOG"
+case "$1" in
+  compose|restart|rm|stop|logs|tag|pull|push) exit 0 ;;
+  inspect) echo "$STUB_ACTUAL_IMAGE"; exit 0 ;;
+  exec)
+    shift 2
+    if printf '%s' "$*" | grep -q -- '--server-response'; then
+      printf '%s\\n' "$STUB_SSR_HEADERS" >&2
+      exit 0
+    elif printf '%s' "$*" | grep -q -- '/health'; then
+      printf '%s\\n' "$STUB_HEALTH"
+      exit 0
+    elif printf '%s' "$*" | grep -q -- 'wget'; then
+      printf '%s\\n' "$STUB_SSR_BODY"
+      exit 0
+    fi
+    exit 0 ;;
+esac
+exit 0
+`;
+
+/**
+ * Run prod-app-recreate.sh against the stub in an isolated CWD.
+ * `caddyfileSha` (or undefined) seeds the recorded Caddyfile hash so we can drive
+ * the changed / unchanged branches deterministically.
+ */
+function runRecreate(env = {}, { caddyfileContent = "caddy-config-v1\n", seededSha } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "prod-app-recreate-"));
+  const stub = join(dir, "docker");
+  const log = join(dir, "docker.log");
+  writeFileSync(stub, DOCKER_STUB);
+  chmodSync(stub, 0o755);
+  writeFileSync(log, "");
+
+  // The script reads CADDYFILE_PATH (relative to CWD) + a sidecar .deployed.sha.
+  const caddyfile = join(dir, "Caddyfile");
+  writeFileSync(caddyfile, caddyfileContent);
+  if (seededSha !== undefined) {
+    writeFileSync(`${caddyfile}.deployed.sha`, seededSha);
+  }
+
+  let code = 0;
+  let stdout = "";
+  try {
+    stdout = execFileSync("bash", [RECREATE_SH], {
+      cwd: dir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        DOCKER_LOG: log,
+        CADDYFILE_PATH: "Caddyfile",
+        READINESS_INTERVAL_SECONDS: "0", // one pass, no real waiting
+        READINESS_TIMEOUT_SECONDS: "0",
+        EXPECTED_IMAGE,
+        // healthy defaults — each test overrides what it is about
+        STUB_ACTUAL_IMAGE: EXPECTED_IMAGE,
+        STUB_HEALTH: '{"status":"ok"}',
+        STUB_SSR_HEADERS: HEALTHY_HEADERS,
+        STUB_SSR_BODY: SSR_BODY,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (e) {
+    code = e.status ?? 1;
+    stdout = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  const dockerCalls = existsSync(log)
+    ? readFileSync(log, "utf8").split("\n").filter(Boolean)
+    : [];
+  return { code, stdout, dockerCalls, dir };
+}
+
+/** Did the stub ever see Caddy in a stop/rm? That is the regression this fixes. */
+function caddyWasTornDown(dockerCalls) {
+  return dockerCalls.some(
+    (c) =>
+      (c.startsWith("stop ") || c.startsWith("rm ")) &&
+      c.includes("nestjs-remix-caddy"),
+  );
+}
+
+describe("prod-app-recreate.sh — behavioural proof (Caddy stays up, poll, conditional reload)", () => {
+  test("happy path: app force-recreated, Caddy NEVER torn down, exit 0", () => {
+    const { code, stdout, dockerCalls } = runRecreate();
+
+    assert.equal(code, 0, `expected success, got ${code}\n${stdout}`);
+
+    // The core invariant: Caddy is never stopped or removed.
+    assert.ok(
+      !caddyWasTornDown(dockerCalls),
+      `Caddy must NEVER be stopped/removed. Calls:\n${dockerCalls.join("\n")}`,
+    );
+
+    // The app IS recreated in place.
+    assert.ok(
+      dockerCalls.some(
+        (c) => c.includes("compose") && c.includes("--force-recreate") && c.includes("monorepo_prod"),
+      ),
+      `expected 'compose … --force-recreate monorepo_prod'. Calls:\n${dockerCalls.join("\n")}`,
+    );
+    assert.match(stdout, /Caddy never went down/);
+  });
+
+  test("unchanged Caddyfile ⇒ Caddy is NOT restarted", () => {
+    // Seed the recorded sha to the current file's sha so the script sees no change.
+    const content = "caddy-config-stable\n";
+    const sha = createHash("sha256").update(content).digest("hex");
+    const { code, dockerCalls } = runRecreate({}, { caddyfileContent: content, seededSha: sha });
+
+    assert.equal(code, 0);
+    assert.ok(
+      !dockerCalls.some((c) => c === "restart nestjs-remix-caddy"),
+      `Caddy must not be restarted when its config is unchanged. Calls:\n${dockerCalls.join("\n")}`,
+    );
+  });
+
+  test("changed Caddyfile ⇒ Caddy IS restarted (after the app is healthy)", () => {
+    // Seed a DIFFERENT recorded sha ⇒ the script detects a change.
+    const { code, dockerCalls } = runRecreate(
+      {},
+      { caddyfileContent: "caddy-config-v2\n", seededSha: "0000stalehash0000" },
+    );
+
+    assert.equal(code, 0);
+    assert.ok(
+      dockerCalls.some((c) => c === "restart nestjs-remix-caddy"),
+      `Caddy must be restarted when its config changed. Calls:\n${dockerCalls.join("\n")}`,
+    );
+    // Still never a stop/rm — a restart is graceful, not a teardown.
+    assert.ok(!caddyWasTornDown(dockerCalls));
+  });
+
+  test("app never becomes healthy ⇒ FAILS so the caller's rollback runs", () => {
+    const { code, stdout, dockerCalls } = runRecreate({ STUB_HEALTH: '{"status":"down"}' });
+
+    assert.notEqual(code, 0, "an app that never gets healthy must fail the deploy");
+    assert.match(stdout, /did not become healthy/);
+    // Even on failure, Caddy was never torn down.
+    assert.ok(!caddyWasTornDown(dockerCalls));
+  });
+
+  test("degraded 200+noindex homepage ⇒ FAILS (SSR gate catches it)", () => {
+    const { code, stdout } = runRecreate({ STUB_SSR_HEADERS: DEGRADED_HEADERS });
+
+    assert.notEqual(code, 0, "a degraded (noindex) homepage must fail the deploy");
+    assert.match(stdout, /DEGRADED FALLBACK|SSR gate failed/);
+  });
+
+  test("wrong image on the recreated container ⇒ FAILS before the health poll", () => {
+    const { code, stdout } = runRecreate({
+      STUB_ACTUAL_IMAGE: "massdoc/nestjs-remix-monorepo:some-other-tag",
+    });
+
+    assert.notEqual(code, 0);
+    assert.match(stdout, /runs '.*', expected/);
+  });
+});


### PR DESCRIPTION
## Problème (cause racine vérifiée dans `deploy-prod.yml`)

Le déploiement PROD provoquait une **coupure de 60–90 s** (pas un simple 502) :

```bash
docker stop  nestjs-remix-caddy nestjs-remix-monorepo-prod   # ← le listener TLS public meurt aussi
docker rm    nestjs-remix-caddy nestjs-remix-monorepo-prod
docker compose up -d monorepo_prod caddy redis_prod
sleep 60                                                      # ← aveugle, avant tout health-check
```

→ le listener **80/443 est absent** toute la fenêtre (connection-refused / TLS down, pas juste 502), et un `sleep 60` dur s'exécute quelle que soit la vitesse de boot.

## Ce qui change (sans toucher aux invariants)

Deux choses sont simplement fausses et corrigées **sans changer aucun nom de conteneur, alias réseau, ni upstream Caddy** — tous porteurs :
- le nom fixe `nestjs-remix-monorepo-prod` est une **interface ops** (watchdog, cron health-check, monitoring, smoke-tests) ;
- l'upstream Caddy est le nom DNS `monorepo_prod` (7 emplacements) ;
- Caddy tourne avec **`admin off`** → `caddy reload` indisponible.

1. **Caddy n'est JAMAIS arrêté** — il sert TLS en continu. Pendant le bref recreate de l'app, il répond via son `handle_errors` (5xx + `no-store`, donc Cloudflare ne peut pas cacher une erreur transitoire) et son active-health-check de fallback se ré-attache dès que l'app répond `/health`.
2. Le **`sleep 60` aveugle → poll de readiness** : commence immédiatement, réussit dès que `/health` est ok (~15–25 s typiques), échoue vite sinon → le step `if: failure()` de rollback existant s'exécute.
3. Caddy n'est **redémarré que si le Caddyfile a changé** (admin off ⇒ restart = seul chemin d'application), **après** que l'app soit saine — pas à chaque déploiement app-only.

La logique de déploiement passe dans `scripts/ci/prod-app-recreate.sh` pour être **prouvable** : `prod-app-recreate.test.mjs` l'exécute contre un `docker` stubé et vérifie que Caddy n'est jamais démonté, que le poll réussit-tôt/échoue-vite, et que Caddy redémarre **ssi** la config a changé (**6 tests**). Câblé **BLOCKING** dans `audit.yml`, comme `prod-rollback`.

### Preuve
`npm run test:prod-app-recreate` → 6/6 · `test:prod-rollback` + `test:prod-ssr-probe` toujours verts · YAML/JSON valides · `bash -n` clean.

---

## Pourquoi PAS le blue/green complet dans cette PR (honnêteté d'ingénierie)

Le **vrai zéro-downtime** = **blue/green à deux slots** (nouveau conteneur démarré à côté, health-gated, puis bascule de l'alias `monorepo_prod`, drain, arrêt de l'ancien ; rollback = re-bascule instantanée de l'alias). J'ai cartographié la topologie et il a **un prérequis bloquant** :

- Le nom `nestjs-remix-monorepo-prod` est **hardcodé dans ~10 fichiers ops** (`scripts/ops/prod-watchdog.sh`, `scripts/cron/health-check.sh`, `scripts/cron/deploy-watcher.sh`, `scripts/monitoring/*.sh`, `.github/workflows/prod-smoke-tests.yml`, `scripts/prod-restart.sh`, `docker-compose.ci-deploy.yml`). Deux slots `-blue`/`-green` **casseraient ce contrat** → watchdogs aveugles / fausses alertes « PROD down ».
- Docker Compose auto-attribue le nom de service comme **alias réseau** → deux slots du même service porteraient tous deux `monorepo_prod` → la bascule contrôlée exige un renommage de service **ou** une chirurgie réseau (create→détacher→gate→attacher-alias→détacher-ancien).
- La **box PROD n'est pas testable** avant le tag (pas de SSH). Livrer une bascule à l'aveugle qui casse le contrat de nom ops **n'est ni « safe » ni « sans bricolage »**.

**Séquence robuste décidée :**
1. **Cette PR** (safe, vérifiable, gros ROI) : Caddy reste up + poll → supprime la fenêtre listener-down et l'attente aveugle.
2. **Prérequis** (PR séparée, safe) : dé-hardcoder le nom → un resolver unique du conteneur servi, consommé par ops/monitoring/deploy.
3. **Blue/green deux slots** : bascule d'alias health-gated, Caddy jamais arrêté, rollback = flip instantané. Fail-safe par construction (l'ancien slot sert jusqu'à ce que le nouveau soit prouvé sain). Preuve comportementale (docker stubé) + validation réelle au 1er tag owner-gated.

Hors scope volontaire ici : `imgproxy` (`--force-recreate` à chaque deploy = blip images ; stateless + Cloudflare-caché, traité à l'étape 3).

## Déploiement
`merge main` ⇒ **container PREPROD uniquement** (`.claude/rules/deployment.md`). **Aucun tag `v*`, PROD inchangé.** Le chemin PROD ne change qu'au prochain tag, qui reste ton GO nominatif (invariant 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)