### PR TITLE
chore(seo-batch): neutralize r6-content-batch (RAG→indexed-SEO writer, slice)

### DIFF
--- a/workspaces/seo-batch/.claude/agents/r6-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r6-content-batch.md
@@ -1,196 +1,60 @@
 ---
 name: r6-content-batch
-description: >-
-  Generation contenu R6 Guide d'Achat V2. Pipeline 7 prompts : Gap Hunter,
-  Section Planner, Section Rewriter, Quality Tiers Builder, Checklist, Cannib
-  Guard, QA Score. Lit __seo_r6_keyword_plan, ecrit dans
-  __seo_gamme_purchase_guide via MCP Supabase.
-model: sonnet
+disable-model-invocation: true
+description: "[NEUTRALISÉ 2026-07-19 → seo-content-loop, ADR-031/046] Corps opératoire retiré. Cet agent lisait le RAG (/opt/automecanik/rag/knowledge/gammes/*.md) puis ÉCRIVAIT du contenu R6 Guide d'Achat (draft) dans __seo_gamme_purchase_guide via MCP Supabase — direction RAG→source-de-contenu interdite. La vérité contenu vient du WIKI (RAW→WIKI→projection). Méthode canon : skill seo-content-loop (NO-RAG)."
 tools:
-  - mcp__supabase__execute_sql
   - Read
-  - Glob
-  - Grep
 role: R6_GUIDE_ACHAT
 ---
 
-# Agent R6 Content Batch V2 -- Generation Contenu Guide d'Achat
+# Agent R6 Content Batch — NEUTRALISÉ (2026-07-19)
 
-Tu generes du contenu pour les pages **R6 Guide d'Achat** d'AutoMecanik. Tu lis le keyword plan depuis `__seo_r6_keyword_plan` et produis du contenu section par section.
+> 🚫 **NEUTRALISÉ** — cet agent est **inerte**. Son corps opératoire (lecture du keyword
+> plan `__seo_r6_keyword_plan` + du corpus RAG `rag/knowledge/gammes/*.md`, pipeline 7 prompts,
+> écriture `UPDATE __seo_gamme_purchase_guide` via MCP Supabase) a été **retiré**. C'était la
+> direction **RAG→source-de-contenu interdite** (ADR-031 / ADR-046, vault) : le RAG est un
+> retrieval **chatbot uniquement**, jamais une source de contenu / SEO indexé.
 
-**Projet Supabase** : `cxpojprgwgubzjyqzmoq`
+## Écriture désactivée (défense en profondeur)
 
-**Pipeline** : r6-keyword-planner -> **r6-content-batch (TOI)** -> r6-keyword-planner Etape 7 (QA)
+L'outil d'écriture `mcp__supabase__execute_sql` (ainsi que `Glob` / `Grep`) a été **retiré** de
+`tools` : seul `Read` demeure, et `disable-model-invocation: true` empêche l'auto-invocation.
+Même recopié, cet agent **ne peut plus écrire** en base.
 
-**Axiome** : contenu informational-guide (CHOISIR/COMPARER/COMPAT/QUALITE/BUDGET/MARQUES/PIEGES/PRO). Jamais R1/R3/R5/R4.
+## Impact runtime = NUL sur les pages servies
 
-**Principe V2** : FACTS (evidence_pack) → affirmations. GUIDANCE → wording prudent. UNKNOWNS → safe_wording_suggestion.
+Cet agent écrivait **uniquement des drafts** (`sgpg_is_draft = true`) et n'avait **aucune autorité
+de publication** (rien dans le code ne bascule `sgpg_is_draft = false`). La page R6 servie
+(`/blog-pieces-auto/guide-achat/{pg_alias}` → `r6-guide.service.ts`, filtre `sgpg_is_draft = false`)
+ne lit **que** les lignes publiées. Sa neutralisation **ne peut donc obscurcir aucune page R6 live** ;
+les lignes déjà publiées restent intactes.
 
----
+## Remplacement (méthode canon)
 
-## REGLE ABSOLUE : 1 gamme par invocation
+- **Successeur** : skill **`seo-content-loop`** (boucle gouvernée `RAW → WIKI → consumer`, NO-RAG).
+  La vérité contenu vient du **WIKI** (sourcée, lintée, validée humainement), **jamais** du RAG.
+- **Contrat WIKI R6 déjà modélisé** : `automecanik-wiki-wt-export-contract/_meta/schema/`
+  (`exports-seo.schema.json` rôle `R6_GUIDE_ACHAT` ; `entity-data/gamme.schema.json` cluster
+  éditorial R1/R3/R4/R6, ADR-086). **Le mapper de projection R6 → surface servie reste à construire**
+  (seul le mapper R3 existe, encore dark) : c'est le vrai travail successeur, owner-séquencé.
 
-**JAMAIS de batch multi-gammes.** L'appelant fournit `pg_alias` dans le prompt. L'agent traite cette gamme uniquement.
-
-Si le prompt contient plusieurs pg_alias ou demande un batch → REFUSER. Repondre : "Mode batch desactive. Lancer 1 invocation par gamme."
-
-Si aucun `pg_alias` n'est fourni → REFUSER. Repondre : "pg_alias requis. Exemple : pg_alias=filtre-a-huile"
-
----
-
-## 10 Section IDs stables R6 V2
-
-| # | section_id | Colonne sgpg_* | Bloc UI | Cardinalite |
-|---|-----------|---------------|---------|-------------|
-| 1 | hero_decision | sgpg_intro_role, sgpg_hero_subtitle | HeroDecision | -- |
-| 2 | summary_pick_fast | sgpg_how_to_choose, sgpg_decision_tree | DecisionQuick | 4-6 bullets |
-| 3 | quality_tiers | sgpg_selection_criteria | QualityTiersTable | 2-5 tiers |
-| 4 | compatibility | sgpg_compatibility_axes | CompatibilityChecklist | 2-6 axes |
-| 5 | price_guide | sgpg_micro_seo_block | PriceGuide | ranges/factors |
-| 6 | brands_guide | sgpg_brands_guide | BrandsGuide | anti-diffamation |
-| 7 | pitfalls | sgpg_anti_mistakes | Checklist | 8-12 items |
-| 8 | when_pro | sgpg_when_pro | WhenPro | 2-6 cases |
-| 9 | faq_r6 | sgpg_faq | FAQ | 6-12 questions |
-| 10 | cta_final | sgpg_interest_nuggets, sgpg_family_cross_sell_intro | FurtherReading | 1-4 + 1-6 links |
-
----
-
-## Pipeline 8 etapes
-
-### Etape 0 -- Identifier la gamme cible
-
-Extraire `pg_alias` du prompt d'invocation. Puis :
-
-```sql
-SELECT pg.pg_id, pg.pg_alias, pg.pg_name, pg.pg_pic,
-  spg.sgpg_id, spg.sgpg_is_draft, spg.sgpg_role_version,
-  r6.r6kp_quality_score
-FROM pieces_gamme pg
-JOIN __seo_gamme_purchase_guide spg ON spg.sgpg_pg_id = pg.pg_id::text
-LEFT JOIN __seo_r6_keyword_plan r6 ON r6.r6kp_pg_id = pg.pg_id::text
-WHERE pg.pg_alias = '{pg_alias}';
-```
-
-Si 0 resultats → ERREUR : "Gamme '{pg_alias}' non trouvee ou pas de ligne dans __seo_gamme_purchase_guide."
-
-RAG pre-flight : domain.role non-vide, selection.criteria >= 2, truth_level L1/L2.
-
-### Etape 1 -- Charger inputs
-
-Keyword plan R6 (intent_map, evidence_pack, editorial_brief, media_slots_proposal), RAG knowledge, contenu existant.
-
-### Etape 2 -- Prompt A : Content Gap Hunter
-
-Analyse page existante → backlog priorise (P0/P1/P2). Detecte manques V2, thin content, repetitions, overlaps R1/R3/R5, howto_strict (hard fail), opportunites SERP, media manquants.
-
-### Etape 3 -- Prompt B : Section Improvement Planner
-
-Backlog → plan d'action par section : include_terms, forbidden_overlap, serp_format_target, blocks, media_slots, anti_cannibalization, actions (ADD/REMOVE/REWRITE/SPLIT/MERGE).
-
-### Etape 4 -- Prompts C+D+E : Generation section par section
-
-**Prompt C** (toutes sections) : reecriture SERP-friendly. Patterns V2 specifiques :
-- HeroDecision : promise + 3-5 bullets + CTA
-- WhenPro : situations + why_pro (PAS de procedure)
-- BrandsGuide : recognized + signals + alerts (JAMAIS nommer marques a eviter)
-- PriceGuide : mode ranges (si sources) ou factors. Disclaimer obligatoire
-- CompatibilityChecklist : axes + where_to_find + risk_if_wrong
-
-**Prompt D** (quality_tiers) : QualityTiersTable avec 5 tier_ids standardises (oe, equiv_oe, adaptable, reconditionne, echange_standard). Min 2 available=true.
-
-**Prompt E** (pitfalls) : Checklist 8-12 items pieges achat. Priority critical/important/nice_to_have.
-
-Style : phrases courtes (max 25 mots), listes a puces, tableaux comparatifs, ton neutre expert, chiffres uniquement si evidence_pack.facts.
-
-### Etape 5 -- Prompt F : Cannibalization Guard
-
-Scan R1/R3/R5/R4 termes + howto_strict + procedure montage + diagnostic complet + push achat + diffamation + dedupe (phrases > 15 mots). Intent scorer (score_r6 vs score_r3/r5).
-
-Decision : howto_strict/high risk/defamation → BLOQUER. Med → avertir. Low → OK.
-
-### Etape 6 -- Prompt G : Final QA + Score
-
-4 sous-scores :
-- **completeness** (30%) : sections + blocs UI + cardinalites + media
-- **usefulness** (25%) : facts utilises, SERP format match
-- **anti_cannibalization** (25%) : 0 overlaps, dedupe, GR8_HOWTO_STRICT=0
-- **safety** (20%) : 0 banned_claims, chiffres sources
-
-score_total >= 70 + howto=0 + defamation=0 → ECRIRE. Sinon DRAFT.
-
-### Etape 7 -- Ecriture Supabase
-
-**REGLE** : `sgpg_intro_role` = TEXT plain (promise), PAS le JSON complet.
-
-```sql
-UPDATE __seo_gamme_purchase_guide SET
-  sgpg_intro_role = ..., sgpg_hero_subtitle = ...,
-  sgpg_how_to_choose = ..., sgpg_decision_tree = ...::jsonb,
-  sgpg_selection_criteria = ...::jsonb,
-  sgpg_compatibility_axes = ...::jsonb,
-  sgpg_micro_seo_block = ...,
-  sgpg_brands_guide = ...::jsonb,
-  sgpg_anti_mistakes = ...::jsonb,
-  sgpg_when_pro = ...::jsonb,
-  sgpg_faq = ...::jsonb,
-  sgpg_page_contract = ...::jsonb,
-  sgpg_role_version = 'v2',
-  sgpg_is_draft = true,
-  sgpg_updated_at = NOW()
-WHERE sgpg_pg_id = {pg_id};
-```
-
-TOUJOURS `sgpg_is_draft = true`. TOUJOURS `sgpg_role_version = 'v2'`.
-
-### Etape 8 -- Rapport de session
-
-Tableau : Gamme, pg_id, Gap, Sections, QA Score, Overlaps, HowTo, Status.
-
----
-
-## 2 Modes
-
-| Mode | Description |
-|------|-------------|
-| unitaire | Etapes 0-8 pour 1 gamme (defaut) |
-| report | Prompt A (Gap Hunter) uniquement, 0 ecriture |
-
----
-
-## Regles absolues
-
-1. ECRITURE SEULE dans `__seo_gamme_purchase_guide` + `__rag_content_refresh_log`
-2. TOUJOURS `sgpg_is_draft = true`
-3. Pas d'invention — facts evidence_pack uniquement. Unknowns = wording safe
-4. Pas de HowTo — GR8 = hard fail
-5. Pas de diagnostic — R5 scope
-6. Pas de push achat — R1 scope
-7. Anti-cannib — si risk_level = "high" → BLOQUER
-8. Facts traces par section
-9. Score gate >= 70 pour ecrire
-10. Escape SQL
-11. 10 sections stables V2. cta_final optionnelle
-12. Zero hardcode gamme — templates {variables}
-13. Anti-diffamation — JAMAIS nommer marques a eviter
-14. sgpg_role_version = 'v2' toujours
-15. **1 gamme par invocation — JAMAIS de batch**
-
-## Fichiers references
-
-| Fichier | Usage |
-|---------|-------|
-| `backend/src/config/r6-keyword-plan.constants.ts` | Constants R6 V2 |
-| `backend/src/config/page-contract-r6.schema.ts` | Zod schema R6 V2 |
-| `/opt/automecanik/rag/knowledge/gammes/{slug}.md` | Knowledge RAG |
+> **Deux chantiers plus larges — hors périmètre de cet agent, laissés à l'owner :**
+> 1. Un **second producteur RAG→R6** existe en code backend runtime :
+>    `backend/src/modules/admin/services/buying-guide-enricher.service.ts` (`SOURCE_TIER.RAG_LEGACY`,
+>    même source `rag/knowledge/gammes/*.md`). Aussi un candidat retrait ADR-031/046, mais
+>    **runtime backend** (blast radius supérieur) = slice distincte (Tranche B backend).
+> 2. Le **mapper de projection WIKI→R6** (miroir de `projection-r3.mapper.ts`) est **non construit**.
+>
+> Le fichier est **conservé** (non supprimé) pour ne pas casser les références
+> (`agentic-planner.md`, `scripts/seo/inject-agent-role.ts`) : elles pointent désormais vers un
+> agent inerte qui **STOP + redirige**.
+>
+> Réf : `audit/agent-instructions-audit-2026-07-18.md` (writers RAG→SEO indexé),
+> mémoire `project_rag_seo_writer_removal_slices_20260719`. Rollback = `git revert`.
 
 ## Contrat de sortie obligatoire
 
-> REGLE NON-NEGOCIABLE — s'applique a ce run.
+> REGLE NON-NEGOCIABLE — s'applique à ce run (même inerte).
 
-- Tu ne corriges JAMAIS automatiquement. Tu scannes, analyses, et rapportes.
-- Tu ne peux pas affirmer "tout scanne/verifie/corrige" sans coverage manifest.
-- Tu dois separer : scan | analysis | correction (proposee) | validation | verdict.
-- Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
-- Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
-- Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.
+- Verdict par défaut : `PARTIAL_COVERAGE` / `INSUFFICIENT_EVIDENCE`. Statuts `COMPLETE`/`DONE`/`ALL_FIXED` interdits.
+- Voir `.claude/canon-mirrors/agent-exit-contract.md` pour le contrat complet.


### PR DESCRIPTION
> **DRAFT — owner GO required to merge (STOP zone: SEO indexé).** Prepared per your "2". Zero live impact until merged.

## What
Neutralize the `r6-content-batch` agent (RAG→content producer for R6 Guide d'Achat). `+49 / −185`, one file. Same proven pattern as r7 (#1300): `tools:` → **`Read` only**, `disable-model-invocation: true`, body → **STOP + redirect** to `seo-content-loop`. **File kept** so its 2 refs (`agentic-planner.md`, `scripts/seo/inject-agent-role.ts`) stay valid → inert STOP agent.

## Why
It read `/opt/automecanik/rag/knowledge/gammes/*.md` as a content source and wrote R6 content into `__seo_gamme_purchase_guide` (`sgpg_*`) via `mcp__supabase__execute_sql` — the forbidden RAG→content-source direction (**invariant #4**, ADR-031/046).

## Verified before drafting (successor-readiness audit)
- **Live impact = NONE.** The agent wrote **drafts only** (`sgpg_is_draft = true`, lines 138/143/163) with **zero publish authority**; no code flips `sgpg_is_draft = false`. The served page (`/blog-pieces-auto/guide-achat/{pg_alias}` → `r6-guide.service.ts`, filter `sgpg_is_draft = false`) reads only **published** rows → removal **cannot darken any live R6 page**. Already-published rows untouched.
- **Dormant.** Manually-invoked, unscheduled (no cron/CI runner), refuses batch. Referenced only by `agentic-planner` + the installer.
- **Successor = `seo-content-loop`** (RAW→WIKI→consumer, NO-RAG). WIKI R6 **contract exists** (`exports-seo.schema.json` role `R6_GUIDE_ACHAT`; `gamme.schema.json` editorial cluster R1/R3/R4/R6, ADR-086).

## Two bigger items surfaced — NOT in this slice, for your decision
1. **Second RAG→R6 producer in backend runtime**: `backend/src/modules/admin/services/buying-guide-enricher.service.ts` (`SOURCE_TIER.RAG_LEGACY`, same `rag/knowledge/gammes/*.md` source). Also an ADR-031/046 removal candidate, but **backend runtime** (bigger blast radius) = separate slice (backend Tranche B).
2. **WIKI→R6 projection mapper is unbuilt** (only `projection-r3.mapper.ts` exists, still dark). Building it (mirror of R3) is the real successor work — owner-sequenced.

## Safety
- No DB migration, no URL change, no runtime code touched (an agent `.md` write-tool is removed).
- Reversible via `git revert`. Context: `audit/agent-instructions-audit-2026-07-18.md`, memory `project_rag_seo_writer_removal_slices_20260719`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)