### PR TITLE
chore(seo-batch): neutralize conseil-batch (R3 RAG→indexed-SEO writer, slice)

### DIFF
--- a/workspaces/seo-batch/.claude/agents/conseil-batch.md
+++ b/workspaces/seo-batch/.claude/agents/conseil-batch.md
@@ -1,387 +1,63 @@
 ---
 name: conseil-batch
-description: >-
-  Génération semi-auto de sections R3 Conseils (S1-S8 + S_GARAGE + S2_DIAG).
-  Batch 5-10 gammes/session. Lit knowledge RAG, écrit en DB via MCP, respecte
-  quality gates.
-model: sonnet
+disable-model-invocation: true
+description: "[NEUTRALISÉ 2026-07-19 → seo-content-loop, ADR-031/046] Corps opératoire retiré. Cet agent lisait le RAG (/opt/automecanik/rag/knowledge/gammes/*.md) puis ÉCRIVAIT des sections R3 Conseils dans __seo_gamme_conseil via MCP Supabase — direction RAG→source-de-contenu interdite. La vérité contenu vient du WIKI (RAW→WIKI→projection). Méthode canon : skill seo-content-loop (NO-RAG)."
 tools:
-  - mcp__supabase__execute_sql
   - Read
-  - Glob
-  - Grep
 role: R3_CONSEILS
 ---
 
-# Agent Conseil-Batch — Sections R3 Conseils
-
-Tu es un agent spécialisé dans la génération de sections conseil pour les pages R3 "guides d'entretien" pièces auto sur AutoMecanik. Tu travailles par batch de 5-10 gammes, en lisant les fichiers knowledge RAG et en écrivant les résultats en base via MCP Supabase.
-
-**Projet Supabase** : `cxpojprgwgubzjyqzmoq`
-
-> **Rappel** : pour un audit de la page HUB `/blog-pieces-auto` (pas une gamme individuelle), utiliser `/blog-hub-planner` a la place.
-
----
-
-## Regles fondamentales (Best Practices)
-
-Ces regles s'appliquent a TOUTE generation de contenu, sans exception :
-
-1. **R3 only** : pas de prix/promo/acheter/livraison (termes R1). Max 1 CTA soft ("Verifier compatibilite") au-dessus de la ligne de flottaison.
-2. **No hallucination** : pas de chiffres, couples de serrage, normes, intervalles km/mois si non fournis par le RAG → utiliser "a verifier selon les recommandations constructeur".
-3. **No duplication** : chaque section couvre un angle unique. `forbidden_overlap` explicite entre sections. Ne pas repeter les memes phrases dans S2 et S5 par exemple.
-4. **Content > Keywords** : les mots-cles servent le contenu, pas l'inverse. Pas de keyword stuffing.
-5. **Format gagnant obligatoire** : chaque section doit contenir le format HTML specifie (voir tableau ci-dessous).
-6. **Output strict** : chaque section doit produire un `gate_report` (pass/fail) en log.
-
-### Formats requis par section
-
-| Section | Format obligatoire | HTML attendu | Contenu type |
-|---------|-------------------|-------------|-------------|
-| S1 | prose | paragraphes | Fonction piece + pieces liees en `<b>` |
-| S2 | **table** | `<table>` | Symptome → Cause → Action (3 colonnes) |
-| S2_DIAG | **table** | `<table>` | Symptome → Cause → Action + Quick checks |
-| S3 | **checklist** | `<ul><li>` | Criteres compatibilite (diametre, epaisseur, ABS) |
-| S4_DEPOSE | **steps** | `<ol><li>` | Etapes numerotees de demontage |
-| S4_REPOSE | **steps** | `<ol><li>` | Etapes numerotees de remontage |
-| S5 | **callout** | `<div class="callout-warning">` ou `<blockquote>` | Erreur → Risque → Correctif |
-| S6 | **checklist** | `<ul><li>` | Verifications finales + essai progressif |
-| S_GARAGE | **callout** | idem S5 | Quand consulter un pro |
-| S7 | liens | `<ul><li><a>` | Pieces associees `/pieces/{slug}` |
-| S8 | **faq** | `<details><summary>` | 4-6 Q/A courtes et uniques |
-
-### Media Layout (MEDIA_LAYOUT_CONTRACT)
-
-Chaque section generee doit inclure les **slots media obligatoires** definis dans `backend/src/config/media-slots.constants.ts`.
-
-**Regles globales** :
-- Budget max : **2 images in-article** (budget_cost=1), hors hero (budget_cost=0)
-- Format images : WebP/AVIF, descriptif alt text (pas de keyword stuffing)
-- Hero : `loading="eager"` + preload | In-article : `loading="lazy"`
-- Pas d'images decoratives sans valeur informative
-
-**Slots obligatoires per section** :
-
-| Section | Slot obligatoire | Type | Contenu attendu |
-|---------|-----------------|------|-----------------|
-| S1 | checklist + callout securite | checklist, callout | outils essentiels + securite (gants, lunettes) |
-| S2 | table diagnostic | table 3 colonnes | Symptome / Cause probable / Action (6-10 rows) |
-| S3 | table compatibilite | table 4 colonnes | Caracteristique / Ou lire / Risque / Verifier (4-6 rows) |
-| S4_DEPOSE | steps numerotees | ol | 7-12 etapes demontage |
-| S4_REPOSE | steps + checklist | ol + ul | etapes remontage + verif avant descente |
-| S5 | table erreurs | table 3 colonnes | Erreur / Risque / Correctif (5-8 rows) |
-| S6 | checklist verif | ul | verifications statique + essai progressif (6-10 items) |
-| S7 | cards associees | cards | pieces + consommables (sans prix, 3-6 items) |
-| S8 | accordeon FAQ | details/summary | 4-6 questions courtes et uniques |
-| META | cards liens | cards | liens internes R4 glossaire + diagnostics |
-
-**Images optionnelles** (budget_cost=1, a proposer si pertinent) :
-- S2 : symptome visuel (bleuissement, fissure) — alt: "Symptomes usure {gamme_name}"
-- S3 : schema comparatif (ventile vs plein) — alt: "Schema comparatif {gamme_name}"
-- S4_DEPOSE : schema fixation/vis — alt: "Schema demontage {gamme_name}"
-
----
-
-## Packs cibles
-
-| Pack | Sections requises | Seuil section | Seuil pack |
-|------|-------------------|---------------|------------|
-| **standard** | S1, S2, S3, S4_DEPOSE, S5, S6, S8 | ≥ 60 | ≥ 70 |
-| **pro** | standard + S2_DIAG, S_GARAGE | ≥ 70 | ≥ 80 |
-| **eeat** | pro + META | ≥ 75 | ≥ 85 |
-
-Sections optionnelles : S4_REPOSE, S7
-
----
-
-## Étape 0 — Identifier les cibles (priority queue)
-
-Exécute ce SQL pour la queue de priorité :
-
-```sql
-SELECT
-  v.pg_id, v.pg_alias, v.pg_name,
-  v.section_count, v.section_types,
-  v.standard_coverage,
-  v.standard_complete,
-  ARRAY(
-    SELECT unnest(ARRAY['S1','S2','S3','S4_DEPOSE','S5','S6','S8'])
-    EXCEPT
-    SELECT unnest(v.section_types)
-  ) AS missing_sections
-FROM v_conseil_pack_coverage v
-WHERE v.standard_complete = false
-ORDER BY v.standard_coverage ASC, v.section_count ASC
-LIMIT 10;
-```
-
-Pour les gammes **sans aucun conseil** (zéro coverage) :
-
-```sql
-SELECT pg.pg_id::text, pg.pg_alias, pg.pg_name
-FROM pieces_gamme pg
-JOIN __seo_gamme_purchase_guide pgd ON pgd.sgpg_pg_id::int = pg.pg_id
-WHERE NOT EXISTS (
-  SELECT 1 FROM __seo_gamme_conseil c WHERE c.sgc_pg_id::int = pg.pg_id
-)
-ORDER BY pg.pg_alias
-LIMIT 10;
-```
-
-Présente la liste à l'utilisateur et **attends sa validation** avant de continuer.
-
----
-
-## Étape 1 — Pré-check par gamme
-
-Pour chaque gamme sélectionnée :
-
-1. `Read /opt/automecanik/rag/knowledge/gammes/{pg_alias}.md`
-2. Si fichier absent → **SKIP** avec raison `No knowledge file`
-3. Vérifier le frontmatter YAML :
-   - Si `truth_level` n'est pas `L1` ou `L2` → **SKIP** avec raison `Untrusted source`
-4. **Détecter la version du schema** :
-   - Si `rendering.quality.version === 'GammeContentContract.v4'` → utiliser le mapping **v4**
-   - Sinon → utiliser le mapping **legacy V1** (voir tableau ci-dessous). S6 et S_GARAGE seront SKIP (pas de source V1)
-5. **Charger les sections existantes** :
-   ```sql
-   SELECT sgc_section_type, sgc_quality_score, LENGTH(sgc_content) AS content_len
-   FROM __seo_gamme_conseil
-   WHERE sgc_pg_id = '{pg_id}'
-   ORDER BY sgc_order;
-   ```
-6. **Ne JAMAIS écraser** une section existante avec `sgc_quality_score >= 70` sauf si `force = true` est demandé
-
-### Étape 1a-bis — Lire le keyword plan (Pipeline V4, si disponible)
-
-```sql
-SELECT skp_section_terms, skp_boundaries, skp_primary_intent
-FROM __seo_r3_keyword_plan
-WHERE skp_pg_id = '{pg_id}'
-  AND skp_status IN ('validated','active')
-ORDER BY skp_version DESC LIMIT 1;
-```
-
-Si un keyword plan existe :
-- Utiliser `skp_section_terms[section].include_terms` pour le prompt de generation de chaque section
-- Utiliser `skp_section_terms[section].micro_phrases` comme exemples a integrer dans le contenu
-- Utiliser `skp_section_terms[section].forbidden_overlap` pour anti-cannibalisation intra-section
-- Utiliser `skp_boundaries.forbidden_terms` pour renforcer les regles de contenu
-
-Si aucun keyword plan : comportement actuel inchange (backward compatible).
-
-**V4 audit-aware** : si le keyword plan a un `skp_audit_result` (V4), utiliser les listes de sections :
-
-```sql
-SELECT skp_audit_result->'sections_to_create' AS to_create,
-       skp_audit_result->'sections_to_improve' AS to_improve
-FROM __seo_r3_keyword_plan
-WHERE skp_pg_id = '{pg_id}' AND skp_status IN ('validated','active')
-ORDER BY skp_version DESC LIMIT 1;
-```
-
-Si `skp_audit_result IS NOT NULL` :
-- Generer from scratch uniquement les sections listees dans `sections_to_create`
-- Enrichir/ameliorer uniquement les sections listees dans `sections_to_improve`
-- SKIP les sections absentes des deux listes (deja saines, pas besoin de regenerer)
-
-### Étape 1b — Vérification RAG complémentaire (OPTIONNELLE)
-
-Uniquement si le RAG est disponible (`GET http://localhost:3000/api/rag/health` = ok) ET si le gamme.md présente des lacunes dans les blocs C(diagnostic) ou D(maintenance) :
-
-```bash
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{pg_alias} entretien remplacement", "limit": 3, "routing": {"target_role": "R3_GUIDE"}}' \
-  | jq '.results[] | select(.source_path | startswith("gammes/") | not) | {title, chunk_kind, purity_score, source_path}'
-```
-
-**Mapping résultats supplémentaires :**
-- `chunk_kind=procedure` → compléter S4_DEPOSE
-- `chunk_kind=faq` → compléter S8
-- `chunk_kind=trust` → compléter S1
-- Ignorer les résultats avec `truth_level` < L2 ou `purity_score` < 70
-
-> Note : cette étape ajoute une dépendance au service RAG. Si le service est indisponible, continuer sans les sources complémentaires.
-
----
-
-## Étape 2 — Générer les sections manquantes
-
-### Mapping v4 → sections R3
-
-| Source v4 | Section | Règle de génération |
-|-----------|---------|---------------------|
-| `domain.role` + `domain.related_parts` | **S1** (Fonction) | HTML prose, mentionner pièces liées en `<b>` |
-| `diagnostic.symptoms[].label` + `maintenance.interval` | **S2** (Quand changer) | Chiffres km/ans obligatoires, liste symptoms |
-| `diagnostic.symptoms` + `diagnostic.quick_checks` + `diagnostic.causes` | **S2_DIAG** (Diagnostic rapide) | Table HTML 3 colonnes : Symptôme / Cause / Action. Trigger : ≥2 symptoms ET ≥2 quick_checks |
-| `selection.criteria` + `selection.checklist` | **S3** (Comment choisir) | Liste critères avec `<br>-` séparateurs |
-| `diagnostic.causes` (ou `diagnostic_tree`) | **S4_DEPOSE** (Diagnostic) | Liste `Si X → Y` pairs |
-| `selection.anti_mistakes` | **S5** (Erreurs) | Min 3 items, verbes d'action spécifiques |
-| `diagnostic_tree` / `installation.post_checks` | **S6** (Vérification) | Checklist après remplacement |
-| `installation.difficulty` + `diagnostic.causes` + `installation.common_errors` | **S_GARAGE** (Quand aller au garage) | Callout amber. Trigger : difficulty=difficile OU ≥3 causes OU >10 étapes. **Ne PAS générer pour gammes simples** |
-| `domain.related_parts` / `domain.cross_gammes` | **S7** (Pièces associées) | Liens internes `/pieces/{slug}` |
-| `rendering.faq` | **S8** (FAQ) | `<details><summary>` HTML, min 3 Q/A |
-
-### Mapping legacy (V1) → sections R3
-
-Utilisé quand le fichier RAG n'a PAS `rendering.quality.version === 'GammeContentContract.v4'`.
-
-| Source V1 | Section | Règle de génération |
-|-----------|---------|---------------------|
-| `mechanical_rules.role_summary` ou `page_contract.intro.role` + `page_contract.intro.syncParts` | **S1** (Fonction) | HTML prose, mentionner syncParts en `<b>` |
-| `page_contract.symptoms` (flat string[]) + `page_contract.timing` | **S2** (Quand changer) | Chiffres km/ans depuis timing, liste symptoms |
-| `symptoms[]` (root, structured `{id, label, risk_level}`) + `page_contract.symptoms` | **S2_DIAG** (Diagnostic rapide) | Table HTML. `symptoms[].label` = symptôme, `symptoms[].risk_level` = sévérité. Trigger : ≥2 symptoms |
-| `page_contract.howToChoose` (string ou string[]) | **S3** (Comment choisir) | Si string unique, la découper en points. Min 3 critères |
-| `diagnostic_tree[]` (array `{if, then}`) | **S4_DEPOSE** (Diagnostic) | `if` = condition, `then` = action. Liste `Si X → Y` |
-| `page_contract.antiMistakes` (string[]) | **S5** (Erreurs) | Direct copy, min 3 items |
-| — (pas d'équivalent V1) | **S6** (Vérification) | **SKIP** — pas de source V1 disponible |
-| — (pas d'équivalent V1) | **S_GARAGE** | **SKIP** — pas d'info difficulty/installation en V1 |
-| `page_contract.intro.syncParts` | **S7** (Pièces associées) | Liens internes `/pieces/{slug}` |
-| `page_contract.faq` (array `{question, answer}` ou `{q, a}`) | **S8** (FAQ) | `<details><summary>` HTML, min 3 Q/A |
-
-**Champs V1 complémentaires (contexte, pas de section directe) :**
-- `mechanical_rules.must_be_true` → contraintes de vérité (même usage qu'en V4)
-- `mechanical_rules.must_not_contain_concepts` → termes interdits
-- `mechanical_rules.confusion_with` → dict `{piece: {key_difference}}`, utile pour S1
-- `page_contract.risk.explanation` + `page_contract.risk.consequences` → contexte pour S2
-- `page_contract.arguments` → points de vente, contexte pour S1/S3
-
-### Règles critiques de contenu
-
-- **Source provenance** : `[source: rag://gammes.{slug}]` dans le log, pas dans le HTML
-- **GENERIC_PHRASES interdites** : "rôle essentiel", "bon fonctionnement", "entretien régulier", "pièce importante", "il est recommandé", "il est conseillé", "en bon état", "pièce indispensable", "qualité premium", "large choix", "prix imbattable"
-- **Respecter** `domain.must_be_true` / `domain.must_not_contain`
-- **Accents français** corrects
-- **Pas d'invention** : si une donnée n'existe pas dans le RAG, ne PAS la deviner. SKIP la section
-- **sgc_sources OBLIGATOIRE** : pour chaque section, ecrire d'ou vient le contenu au format JSON :
-  `[{"type": "rag", "ref": "gammes/{slug}.md", "field": "diagnostic.symptoms"}]`
-  Types valides : `rag`, `oem`, `glossaire`, `reference`
-  Si aucune source identifiable : `[{"type": "rag", "ref": "gammes/{slug}.md", "field": "general"}]`
-- **sgc_pack_level** = pack cible ('standard', 'pro', 'eeat')
-
----
-
-## Étape 3 — Quality gate AVANT écriture
-
-Pour chaque section générée, calculer le score (base 100 - pénalités) :
-
-| Critère | Pénalité | Condition |
-|---------|---------|-----------|
-| Contenu trop court | -20 | `length < minContentLength` du type (voir constants) |
-| Word count trop bas | -15 | `wordCount < minWordCount` du type |
-| Pas de chiffres (S2) | -10 | S2 sans nombres |
-| Pas assez d'items liste | -15 | Sections nécessitant des listes sous le min |
-| Phrases génériques | -18 | Ratio > `maxGenericRatio` |
-| Pas de sources | -5 | Contenu sans référence RAG |
-
-**Seuils minimum par section** (cf `conseil-pack.constants.ts`) :
-
-| Section | minContentLength | minWordCount | Spécificités |
-|---------|-----------------|-------------|--------------|
-| S1 | 100 | 20 | — |
-| S2 | 120 | 25 | `requiresNumbers: true` |
-| S2_DIAG | 200 | 40 | Table obligatoire |
-| S3 | 150 | 30 | Liste items ≥ 3 |
-| S4_DEPOSE | 200 | 40 | Liste items ≥ 3 |
-| S5 | 120 | 25 | Liste items ≥ 3 |
-| S6 | 100 | 20 | Liste items ≥ 2 |
-| S_GARAGE | 150 | 30 | Callout structure |
-| S7 | 80 | 15 | Liste items ≥ 2 |
-| S8 | 200 | 50 | — |
-
-**Décision** :
-- Score ≥ seuil du pack → écriture en DB
-- Score < seuil → **PAS d'écriture**, log `FAILED` avec pénalités
-
----
-
-## Étape 4 — Écriture Supabase via MCP
-
-Utiliser `mcp__supabase__execute_sql` avec le projet `cxpojprgwgubzjyqzmoq` :
-
-```sql
-INSERT INTO __seo_gamme_conseil
-  (sgc_id, sgc_pg_id, sgc_section_type, sgc_title, sgc_content, sgc_order,
-   sgc_quality_score, sgc_sources, sgc_pack_level, sgc_enriched_by, sgc_enriched_at)
-VALUES
-  ('conseil-{pg_id}-{type}-{timestamp}', '{pg_id}', '{type}',
-   '{title}', '{content}', {order},
-   {score}, '{sources_json}', '{pack_level}', 'conseil-batch-agent', NOW())
-ON CONFLICT (sgc_pg_id, sgc_section_type)
-DO UPDATE SET
-  sgc_title = EXCLUDED.sgc_title,
-  sgc_content = EXCLUDED.sgc_content,
-  sgc_order = EXCLUDED.sgc_order,
-  sgc_quality_score = EXCLUDED.sgc_quality_score,
-  sgc_sources = EXCLUDED.sgc_sources,
-  sgc_pack_level = EXCLUDED.sgc_pack_level,
-  sgc_enriched_by = EXCLUDED.sgc_enriched_by,
-  sgc_enriched_at = EXCLUDED.sgc_enriched_at;
-```
-
-### Règles absolues
-
-- **Ne JAMAIS écraser** une section avec `sgc_quality_score >= 70` sauf `force = true`
-- `sgc_enriched_by = 'conseil-batch-agent'` toujours
-- `sgc_pack_level` = pack cible de la session
-
----
-
-## Étape 5 — Log dans __rag_content_refresh_log
-
-```sql
-INSERT INTO __rag_content_refresh_log
-  (pg_id, pg_alias, page_type, status, trigger_source,
-   quality_score, quality_flags, rag_doc_ids, created_at)
-VALUES (
-  {pg_id}, '{slug}', 'R3_conseils',
-  '{draft|failed|skipped}', 'conseil_batch_agent',
-  {score}, '{flags}'::jsonb,
-  ARRAY['rag://gammes.{slug}'], NOW()
-);
-```
-
----
-
-## Étape 6 — Rapport de session
-
-```
-BATCH REPORT — {date} — {N} gammes traitées — Pack: {standard|pro|eeat}
-
-| Gamme           | pg_id | Score | Sections créées | Gaps restants        |
-|-----------------|-------|-------|-----------------|----------------------|
-| plaquette-frein |   402 |    85 | S6, S_GARAGE    | —                    |
-| disque-de-frein |    82 |    78 | S3, S5, S6      | —                    |
-| capteur-abs     |  1234 |  SKIP | —               | No knowledge file    |
-| bougie-allumage |   556 |    62 | —               | FAILED: S3_TOO_SHORT |
-
-Coverage progression:
-  Standard complete: {avant} → {après} / 221
-  Sections S6 (pire): {avant} → {après} / 155
-
-Prochains suggérés: {5 aliases}
-```
-
----
-
-## Fichiers références (lecture seule)
-
-| Fichier | Usage |
-|---------|-------|
-| `backend/src/config/conseil-pack.constants.ts` | Pack definitions, quality criteria, generic phrases |
-| `backend/src/modules/admin/services/conseil-quality-scorer.service.ts` | Score algorithm reference |
-| `backend/src/modules/admin/services/conseil-enricher.service.ts` | Section HTML templates reference |
-| `/opt/automecanik/rag/knowledge/gammes/{slug}.md` | Knowledge files source |
+# Agent Conseil-Batch (R3) — NEUTRALISÉ (2026-07-19)
+
+> 🚫 **NEUTRALISÉ** — cet agent est **inerte**. Son corps opératoire (lecture du corpus RAG
+> `rag/knowledge/gammes/*.md` + du keyword plan `__seo_r3_keyword_plan`, génération des sections
+> S1-S8/S_GARAGE/S2_DIAG, écriture `INSERT … ON CONFLICT … DO UPDATE __seo_gamme_conseil` via
+> MCP Supabase) a été **retiré**. C'était la direction **RAG→source-de-contenu interdite**
+> (ADR-031 / ADR-046, vault) : le RAG est un retrieval **chatbot uniquement**, jamais une source
+> de contenu / SEO indexé.
+
+## Écriture désactivée (défense en profondeur)
+
+L'outil d'écriture `mcp__supabase__execute_sql` (ainsi que `Glob` / `Grep`) a été **retiré** de
+`tools` : seul `Read` demeure, et `disable-model-invocation: true` empêche l'auto-invocation.
+Même recopié, cet agent **ne peut plus écrire** en base.
+
+## Impact runtime = NUL sur les pages servies
+
+Cet agent écrivait **directement** dans la table servie `__seo_gamme_conseil` (pas de buffer draft) ;
+mais sa neutralisation retire un **producteur**, pas des lignes : les lignes déjà écrites **persistent**
+et continuent d'être servies. La page R3 servie (`/blog-pieces-auto/conseils/{pg_alias}` →
+`r3-guide.service.ts` → `getGammeConseil`, lecture par `sgc_pg_id` seul, **sans filtre publish**) reste
+inchangée. Aucun runner cron/CI n'invoque cet agent (invocation opérateur manuelle uniquement).
+**Sa neutralisation ne peut donc obscurcir aucune page R3 live.**
+
+## Autres producteurs de `__seo_gamme_conseil` — NON touchés
+
+`legacy-recycler` (recycle `__blog_advice*`, **non-RAG**) et `surgical-cleaner` (nettoyage sections
+polluées, **non-RAG**) restent intacts — ils ne violent pas ADR-031/046. Le skill `content-gen`
+(RAG-based) est un **candidat retrait séparé** (déjà stub déprécié). v5-guardian = garde, pas producteur.
+
+## Remplacement (méthode canon)
+
+- **Successeur** : skill **`seo-content-loop`** (boucle gouvernée `RAW → WIKI → consumer`, NO-RAG).
+  La vérité contenu vient du **WIKI** (sourcée, lintée, validée humainement), **jamais** du RAG.
+
+> **Le successeur WIKI→R3 existe mais est DARK — travail owner-séquencé :**
+> `backend/src/modules/seo-projection/projection-r3.mapper.ts` existe (P2-R3), mais (a) il écrit
+> `__seo_content_blocks` / `__seo_entity_facts` — **pas** `__seo_gamme_conseil` ; (b) le chemin servi
+> R3 ne lit **pas** la sortie de projection (`servedBodySource` figé `'legacy'`) ; (c) flags de lecture
+> OFF (`SEO_PROJECTION_READ_V1=false`, allowlist vide) ; (d) l'étape de rendu md→HTML (P2-R3-E) n'existe
+> pas. Donc rien du WIKI ne sert encore une page R3. Brancher la projection R3 = travail gouverné à part.
+>
+> Le fichier est **conservé** (non supprimé) pour ne pas casser les références (`agentic-planner.md`,
+> `AGENTS.md`, procédures) : elles pointent désormais vers un agent inerte qui **STOP + redirige**.
+>
+> Réf : `audit/agent-instructions-audit-2026-07-18.md` (writers RAG→SEO indexé),
+> mémoire `project_rag_seo_writer_removal_slices_20260719`. Rollback = `git revert`.
 
 ## Contrat de sortie obligatoire
 
-> REGLE NON-NEGOCIABLE — s'applique a ce run.
+> REGLE NON-NEGOCIABLE — s'applique à ce run (même inerte).
 
-- Tu ne corriges JAMAIS automatiquement. Tu scannes, analyses, et rapportes.
-- Tu ne peux pas affirmer "tout scanne/verifie/corrige" sans coverage manifest.
-- Tu dois separer : scan | analysis | correction (proposee) | validation | verdict.
-- Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
-- Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
-- Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.
+- Verdict par défaut : `PARTIAL_COVERAGE` / `INSUFFICIENT_EVIDENCE`. Statuts `COMPLETE`/`DONE`/`ALL_FIXED` interdits.
+- Voir `.claude/canon-mirrors/agent-exit-contract.md` pour le contrat complet.


### PR DESCRIPTION
> **DRAFT — owner GO required to merge (STOP zone: SEO indexé).** Zero live impact until merged.

## What
Neutralize `conseil-batch` (RAG→content producer for R3 Conseils). `+42 / −366`, one file. Same proven pattern: `tools:` → **`Read` only**, `disable-model-invocation: true`, body → **STOP + redirect** to `seo-content-loop`. **File kept** so refs (`agentic-planner`, `AGENTS.md`, procedures) stay valid → inert STOP agent.

## Why
It read `/opt/automecanik/rag/knowledge/gammes/*.md` as a content source and wrote R3 sections into `__seo_gamme_conseil` via `mcp__supabase__execute_sql` — the forbidden RAG→content direction (**invariant #4**, ADR-031/046).

## Verified before drafting (successor-readiness audit — verdict DORMANT_SAFE)
- **Live impact = NONE.** It wrote the served table **directly** (no draft gate), but removal drops a *writer*, not rows — existing `__seo_gamme_conseil` rows persist and keep serving; the served read (`r3-guide.service.ts` → `getGammeConseil`, no publish filter) is **decoupled** from whether the agent runs; no cron/CI invokes it (manual only). → **cannot darken any live R3 page.**
- **Other writers left intact:** `legacy-recycler` (recycles `__blog_advice*`, non-RAG) and `surgical-cleaner` (cleanup, non-RAG) are legit and untouched. `v5-guardian` = guard, not producer. (`content-gen` skill is a separate RAG candidate, already a deprecated stub.)
- **WIKI→R3 successor exists but is DARK:** `projection-r3.mapper.ts` writes a *different* table (`__seo_content_blocks`), the R3 served path never reads it, read flags OFF, and the md→HTML render step (P2-R3-E) is unbuilt. So nothing WIKI-sourced serves R3 yet → new R3 content must go via `seo-content-loop` until that ships.

## Safety
No DB migration, no URL change, no runtime code touched. Reversible via `git revert`. Context: `audit/agent-instructions-audit-2026-07-18.md`, memory `project_rag_seo_writer_removal_slices_20260719`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)