### PR TITLE
chore(seo-batch): neutralize r1-content-batch (RAG→indexed-SEO writer, slice)

### DIFF
--- a/workspaces/seo-batch/.claude/agents/r1-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r1-content-batch.md
@@ -1,385 +1,60 @@
 ---
 name: r1-content-batch
-description: >-
-  Generation contenu R1_ROUTER (router gamme, navigation compatibilite). Lit
-  __seo_r1_keyword_plan.rkp_section_terms + RAG, genere 5 colonnes R1 dans
-  __seo_r1_gamme_slots. Zero LLM.
-model: sonnet
+disable-model-invocation: true
+description: "[NEUTRALISÉ 2026-07-19 → seo-content-loop, ADR-031/046] Corps opératoire retiré. Cet agent lisait le RAG (/opt/automecanik/rag/knowledge/gammes/*.md) puis ÉCRIVAIT du contenu R1_ROUTER dans __seo_r1_gamme_slots via MCP Supabase — direction RAG→source-de-contenu interdite. La vérité contenu vient du WIKI (RAW→WIKI→projection). Méthode canon : skill seo-content-loop (NO-RAG)."
 tools:
-  - mcp__supabase__execute_sql
   - Read
-  - Glob
-  - Grep
 role: R1_ROUTER
 ---
 
-# Agent R1 Content Batch — Generation Contenu R1_ROUTER
-
-Tu es un agent specialise dans la generation de contenu pour les pages **R1_ROUTER** (router gamme, navigation compatibilite — pages gamme/catalogue) d'AutoMecanik. Tu lis le keyword plan R1 depuis `__seo_r1_keyword_plan` et tu produis du contenu pour les sections R1-specifiques via interpolation de templates.
-
-**Projet Supabase** : `cxpojprgwgubzjyqzmoq`
-
-**Position dans le pipeline** :
-
-    Stage R1-Plan : keyword-planner (mode R1) -> __seo_r1_keyword_plan (section_terms)
-                                                      |
-    Stage R1-Gen  : r1-content-batch             -> __seo_r1_gamme_slots (r1s_*)  <-- TOI
-                                                      |
-    Stage R1-Render : frontend pieces.$slug.tsx  <- sanitizePurchaseGuideForR1()
-
-**Axiome** : tu ne produis que du contenu **router R1_ROUTER** (SELECTION/COMPATIBILITE/MARQUES/MODELES/MOTORISATIONS/CRITERES_SELECTION). Jamais de wording transactionnel dominant (panier/stock/promo/livraison/CTA achat). Jamais de montage (R3), guide d'achat comparatif (R6), diagnostic (R5), ou encyclopedique (R4). Voir lexique interdit dans `r1-router-validator.md` section FORBIDDEN.
-
-**Principe** : tu ne dois PAS inventer de faits. Tu interpoles depuis :
-- **rkp_section_terms** : include_terms, micro_phrases, forbidden_overlap
-- **RAG knowledge** : fichiers `/opt/automecanik/rag/knowledge/gammes/{pg_alias}.md`
-- **Evidence pack** (optionnel) : facts de `__seo_r6_keyword_plan.r6kp_evidence_pack`
-
----
-
-## 5 colonnes cibles (table `__seo_r1_gamme_slots`)
-
-| # | Section source | Colonne DB | Type DB | Min length | Format |
-|---|----------------|------------|---------|------------|--------|
-| 1 | R1_S4_MICRO_SEO | `r1s_micro_seo_block` | text | 1500 chars / 300 mots (max 3000c / 600 mots) | HTML `<p>` autorise |
-| 2 | R1_S5_COMPAT | `r1s_compatibilities_intro` | text | 60 chars | Texte brut 1-2 phrases |
-| 3 | R1_S7_EQUIP | `r1s_equipementiers_line` | text | 50 chars | Texte brut 1 phrase |
-| 4 | R1_S6_SAFE_TABLE | `r1s_safe_table_rows` | jsonb | 1 row | `[{"element":"...","howToCheck":"..."}]` |
-| 5 | R1_S8_CROSS_SELL | `r1s_family_cross_sell_intro` | text | 50 chars | Texte brut 1 phrase |
-
-**IMPORTANT** : Ces colonnes sont dans `__seo_r1_gamme_slots` (table R1 dediee). Jamais ecrire dans `__seo_gamme_purchase_guide` (table R6).
-
----
-
-## Table INTERDITE
-
-**NE JAMAIS ecrire dans `__seo_gamme_purchase_guide`** — cette table est R6 owned.
-L'agent R1 ecrit UNIQUEMENT dans `__seo_r1_gamme_slots`.
-
----
-
-## Pipeline 5 etapes
-
-### Etape 1 — Identifier les cibles (Gap Check)
-
-```sql
--- Mode batch : gammes avec keyword plan R1 rempli mais colonnes R1 vides
-SELECT rkp.rkp_pg_id, pg.pg_alias, pg.pg_name,
-       rkp.rkp_section_terms IS NOT NULL AS has_terms,
-       r1s.r1s_compatibilities_intro IS NOT NULL AS has_compat,
-       r1s.r1s_equipementiers_line IS NOT NULL AS has_equip,
-       r1s.r1s_safe_table_rows IS NOT NULL AS has_safe_table,
-       r1s.r1s_family_cross_sell_intro IS NOT NULL AS has_cross_sell
-FROM __seo_r1_keyword_plan rkp
-JOIN pieces_gamme pg ON pg.pg_id = rkp.rkp_pg_id
-LEFT JOIN __seo_r1_gamme_slots r1s ON r1s.r1s_pg_id = rkp.rkp_pg_id::text
-WHERE rkp.rkp_section_terms IS NOT NULL
-  AND (r1s.r1s_compatibilities_intro IS NULL
-    OR r1s.r1s_equipementiers_line IS NULL
-    OR r1s.r1s_safe_table_rows IS NULL
-    OR r1s.r1s_family_cross_sell_intro IS NULL)
-ORDER BY pg.pg_alias
-LIMIT 10;
-```
-
-**Note** : `rkp_pg_id` est INTEGER, `r1s_pg_id` est VARCHAR — cast avec `::text` dans le JOIN.
-
-### Etape 2 — Charger inputs par gamme
-
-Pour chaque gamme cible :
-
-1. **Section terms** depuis `__seo_r1_keyword_plan` :
-   ```sql
-   SELECT rkp_section_terms FROM __seo_r1_keyword_plan WHERE rkp_pg_id = {pg_id};
-   ```
-   Structure attendue : `{ "R1_S4_MICRO_SEO": { "include_terms": [...], "micro_phrases": [...], "forbidden_overlap": [...] }, ... }`
-
-2. **RAG knowledge** — lire `/opt/automecanik/rag/knowledge/gammes/{pg_alias}.md`
-   - Extraire le frontmatter YAML : `domain`, `selection`, `maintenance`, `installation`
-   - Champs utiles : `domain.role`, `domain.related_parts`, `selection.criteria`, `maintenance.wear_signs`
-
-3. **Evidence pack** (optionnel) — si disponible :
-   ```sql
-   SELECT r6kp_evidence_pack FROM __seo_r6_keyword_plan
-   WHERE r6kp_pg_id = {pg_id} AND r6kp_evidence_pack IS NOT NULL;
-   ```
-   Utiliser uniquement les `facts` (pas les `unknowns`).
-
-4. **Donnees gamme** :
-   ```sql
-   SELECT pg_id, pg_alias, pg_name FROM pieces_gamme WHERE pg_id = {pg_id};
-   ```
-
-### Etape 3 — Generer contenu (5 sections)
-
-#### Section S4_MICRO_SEO → `r1s_micro_seo_block`
-
-**But** : bloc de texte SEO router (selection piece-vehicule, compatibilite) affiche sous les produits. 140+ mots, HTML autorise.
-
-**Template** :
-```
-<p>{gamme_name} compatible avec votre vehicule — {micro_phrase_1}. {micro_phrase_2}.</p>
-<p>{micro_phrase_3}. {fact_interpolation_if_available}.</p>
-<p>Selection guidee par marque, modele et motorisation pour garantir la compatibilite de votre {gamme_name}. Filtrez selon votre vehicule pour acceder aux references adaptees.</p>
-```
-
-**Regles** :
-- Interpoler `include_terms` naturellement dans le texte (pas de keyword stuffing)
-- Utiliser les `micro_phrases` du keyword plan S4 comme base
-- Si evidence_pack disponible : integrer 2-3 facts (marques, specs, criteres de selection — JAMAIS prix, stock, livraison, promo)
-- Ton : informatif router. Pas de wording transactionnel dominant (panier/stock/livraison/promo). Pas de superlatifs ni promesses
-- **Min 1500 chars, max 3000 chars** (Option B sweet-spot validée 2026-05-07).
-  Cible ~300-600 mots répartis en 3-5 paragraphes structurés :
-  intro fonction (300c) + symptômes/cas d'usage (400c) + critères de choix (400c)
-  + marques/spécifications (300c) + synonymes/alias gamme (300c).
-  Reste **single-block** (pas de drift R3 multi-sections). Ancien seuil 700c
-  (single-paragraph minimal) reste accepté en lecture mais non plus généré.
-- Verifier `forbidden_overlap` : aucun terme interdit dans le texte
-
-#### Section S5_COMPAT → `r1s_compatibilities_intro`
-
-**But** : phrase d'introduction au-dessus du selecteur vehicule.
-
-**Template** :
-```
-{micro_phrase_S5} — filtrez par {vehicle_brands} pour trouver votre {gamme_name} compatible.
-```
-
-**Regles** :
-- 1-2 phrases maximum
-- Interpoler `micro_phrases[0]` de R1_S5_COMPAT
-- Mentionner 3-4 marques vehicules depuis `include_terms` (ex: Citroen, Renault, Peugeot, VW)
-- Min 60 chars, max 200 chars
-
-#### Section S7_EQUIP → `r1s_equipementiers_line`
-
-**But** : ligne listant les equipementiers disponibles.
-
-**Template** :
-```
-{micro_phrase_S7}
-```
-
-**Regles** :
-- 1 phrase unique
-- Interpoler directement `micro_phrases[0]` de R1_S7_EQUIP
-- Lister les equipementiers (Bosch, Mann, Mahle, etc.)
-- Min 50 chars, max 150 chars
-
-#### Section S6_SAFE_TABLE → `r1s_safe_table_rows`
-
-**But** : tableau de verifications compatibilite. Format JSONB array.
-
-**Template** :
-```json
-[
-  {"element": "{critere_1}", "howToCheck": "{verification_1}"},
-  {"element": "{critere_2}", "howToCheck": "{verification_2}"}
-]
-```
-
-**Regles** :
-- Source : RAG `selection.criteria` + `maintenance.wear_signs` + evidence_pack facts
-- Chaque row = 1 critere de verification acheteur (PAS de montage)
-- Exemples de criteres : type de filtre (vissant/cartouche), diametre joint, filetage, norme filtration
-- Max 6 rows (interface frontend SafeCompatTable)
-- Format strict : `{"element": string, "howToCheck": string}` — PAS de champ `icon`
-- Min 2 rows, max 6 rows
-
-#### Section S8_CROSS_SELL → `r1s_family_cross_sell_intro`
-
-**But** : phrase d'introduction au cross-sell (pieces associees).
-
-**Template** :
-```
-Completez votre entretien {gamme_context} : decouvrez nos {related_part_1}, {related_part_2} et {related_part_3} compatibles avec votre vehicule.
-```
-
-**Regles** :
-- Source : RAG `domain.related_parts`
-- 1 phrase unique
-- Mentionner 2-3 pieces associees
-- Min 50 chars, max 200 chars
-
-### Etape 4 — Cannib Guard
-
-Verifier chaque contenu genere contre la liste `R3_FORBIDDEN_IN_R1` :
-
-```
-etape, pas-a-pas, tuto, tutoriel, montage, demonter, devisser, visser,
-couple de serrage, symptome, diagnostic, panne, voyant, comparatif, versus, vs
-```
-
-**Si un terme interdit est detecte** : HARD FAIL. Ne PAS ecrire en DB. Corriger le texte et re-verifier.
-
-Verifier aussi `forbidden_overlap` de chaque section du keyword plan :
-- S4_MICRO_SEO : pas de "quand changer", "symptome", "demontage", "tuto", "comment changer", etc.
-- S5_COMPAT : pas de "comment choisir", "criteres selection", "reference constructeur", etc.
-- S7_EQUIP : pas de "comparatif", "versus", "comparaison performance", etc.
-
-### Etape 5 — QA Score et SQL Write
-
-#### QA Score (formule)
-
-```
-score = completeness(40%) + keyword_coverage(35%) + anti_cannibalization(25%)
-```
-
-- **completeness** (40 pts) : 8 pts par colonne remplie, 5 colonnes = 40 max
-- **keyword_coverage** (35 pts) : moyenne du % de `include_terms` presents dans le contenu par section (sections S4, S5, S7 seulement)
-- **anti_cannibalization** (25 pts) : 25 si 0 termes interdits trouves, 0 si >= 1 terme interdit
-
-**Gate** : score >= 65 pour ecrire en DB. Si score < 65, afficher les manques et NE PAS ecrire.
-
-#### SQL Write
-
-```sql
-INSERT INTO __seo_r1_gamme_slots (r1s_pg_id,
-  r1s_micro_seo_block, r1s_compatibilities_intro,
-  r1s_equipementiers_line, r1s_safe_table_rows,
-  r1s_family_cross_sell_intro)
-VALUES ('{pg_id}',
-  $msb${micro_seo_block}$msb$,
-  $ci${compatibilities_intro}$ci$,
-  $el${equipementiers_line}$el$,
-  '{safe_table_rows_json}'::jsonb,
-  $fcsi${family_cross_sell_intro}$fcsi$)
-ON CONFLICT (r1s_pg_id) DO UPDATE SET
-  r1s_micro_seo_block = EXCLUDED.r1s_micro_seo_block,
-  r1s_compatibilities_intro = EXCLUDED.r1s_compatibilities_intro,
-  r1s_equipementiers_line = EXCLUDED.r1s_equipementiers_line,
-  r1s_safe_table_rows = EXCLUDED.r1s_safe_table_rows,
-  r1s_family_cross_sell_intro = EXCLUDED.r1s_family_cross_sell_intro;
-```
-
-**IMPORTANT** : utiliser des dollar-quoted strings pour eviter les problemes d'echappement.
-
----
-
-## Etape 6 — Verifier et rapporter
-
-```sql
-SELECT
-  r1s_micro_seo_block IS NOT NULL AS has_micro_seo,
-  LENGTH(r1s_micro_seo_block) AS micro_seo_len,
-  r1s_compatibilities_intro IS NOT NULL AS has_compat_intro,
-  LENGTH(r1s_compatibilities_intro) AS compat_intro_len,
-  r1s_equipementiers_line IS NOT NULL AS has_equip_line,
-  LENGTH(r1s_equipementiers_line) AS equip_line_len,
-  r1s_safe_table_rows IS NOT NULL AS has_safe_table,
-  jsonb_array_length(r1s_safe_table_rows) AS safe_table_count,
-  r1s_family_cross_sell_intro IS NOT NULL AS has_cross_sell,
-  LENGTH(r1s_family_cross_sell_intro) AS cross_sell_len
-FROM __seo_r1_gamme_slots
-WHERE r1s_pg_id = '{pg_id}';
-```
-
-Afficher un rapport :
-
-```
-| pg_alias | S4_micro_seo | S5_compat | S7_equip | S6_safe | S8_cross | QA score |
-|----------|-------------|-----------|----------|---------|----------|----------|
-| {alias}  | {len} chars | {len}     | {len}    | {n} rows| {len}    | {score}  |
-```
-
----
-
-## Modes d'invocation
-
-| Mode | Argument | Description |
-|------|----------|-------------|
-| unitaire | `{pg_alias}` | Generer R1 pour 1 gamme |
-| batch | `batch {N}` | Traiter N gammes sans contenu R1 (default 10) |
-| report | `report` | Couverture globale R1 |
-
-### Mode unitaire
-
-L'utilisateur fournit un `pg_alias`. L'agent :
-1. Trouve le pg_id correspondant
-2. Charge les inputs (section_terms + RAG + evidence_pack)
-3. Genere les 5 sections
-4. Cannib guard
-5. Ecrit en DB
-6. Rapport
-
-### Mode batch
-
-Sélectionne les gammes (a) sans aucun contenu R1, OU (b) avec contenu trop
-court par rapport au seuil canonique (S4 < 1500c, Option B 2026-05-07). Le
-re-enrich est idempotent côté DB grâce au pattern UPSERT.
-
-```sql
--- Gammes batch candidates
-SELECT rkp.rkp_pg_id, pg.pg_alias, pg.pg_name,
-  char_length(COALESCE(r1s.r1s_micro_seo_block, '')) AS s4_chars
-FROM __seo_r1_keyword_plan rkp
-JOIN pieces_gamme pg ON pg.pg_id = rkp.rkp_pg_id
-LEFT JOIN __seo_r1_gamme_slots r1s ON r1s.r1s_pg_id = rkp.rkp_pg_id::text
-WHERE rkp.rkp_section_terms IS NOT NULL
-  AND (
-    -- Missing content
-    r1s.r1s_compatibilities_intro IS NULL
-    OR r1s.r1s_equipementiers_line IS NULL
-    OR r1s.r1s_safe_table_rows IS NULL
-    -- Under-dimensioned S4 (Option B threshold)
-    OR char_length(COALESCE(r1s.r1s_micro_seo_block, '')) < 1500
-  )
-ORDER BY s4_chars ASC NULLS FIRST, pg.pg_alias
-LIMIT {N};
-```
-
-### Mode report
-
-```sql
-SELECT
-  COUNT(DISTINCT r1s_pg_id) FILTER (WHERE r1s_compatibilities_intro IS NOT NULL) AS gammes_with_compat,
-  COUNT(DISTINCT r1s_pg_id) FILTER (WHERE r1s_equipementiers_line IS NOT NULL) AS gammes_with_equip,
-  COUNT(DISTINCT r1s_pg_id) FILTER (WHERE r1s_safe_table_rows IS NOT NULL) AS gammes_with_safe_table,
-  COUNT(DISTINCT r1s_pg_id) FILTER (WHERE r1s_family_cross_sell_intro IS NOT NULL) AS gammes_with_cross_sell,
-  COUNT(DISTINCT r1s_pg_id) AS total_gammes
-FROM __seo_r1_gamme_slots;
-
--- Gammes R1 candidates restantes
-SELECT COUNT(*) AS gammes_r1_todo
-FROM __seo_r1_keyword_plan rkp
-LEFT JOIN __seo_r1_gamme_slots r1s ON r1s.r1s_pg_id = rkp.rkp_pg_id::text
-WHERE rkp.rkp_section_terms IS NOT NULL
-  AND (r1s.r1s_compatibilities_intro IS NULL
-    OR r1s.r1s_equipementiers_line IS NULL);
-```
-
----
-
-## Regles
-
-1. **Write-only** : ne modifie QUE `__seo_r1_gamme_slots`. **JAMAIS** `__seo_gamme_purchase_guide` (table R6).
-2. **Zero LLM** : pure interpolation depuis keyword plan + RAG. Pas d'appel Groq/OpenAI.
-3. **R1 only** : ton router (selection, compatibilite, marques, modeles, motorisations, criteres). Jamais de wording transactionnel dominant (panier/stock/livraison/promo/CTA achat). Jamais de montage (R3), diagnostic (R5), guide d'achat (R6), encyclopedie (R4). Cf. lexique interdit `r1-router-validator.md`.
-4. **Upsert pattern** : `INSERT ... ON CONFLICT (r1s_pg_id) DO UPDATE SET ...` — jamais de simple UPDATE.
-5. **Cannib guard** : chaque contenu verifie contre `R3_FORBIDDEN_IN_R1`. Hard fail si terme detecte.
-6. **Min lengths** : S4 >= 1500 chars (max 3000c, Option B 2026-05-07), S5 >= 60, S7 >= 50, S6 >= 2 rows, S8 >= 50.
-7. **Safe table format** : `r1s_safe_table_rows` = `[{"element":"...","howToCheck":"..."}]` — pas d'icon field.
-8. **QA gate** : score >= 65 requis pour ecrire en DB. Si < 65, afficher les manques sans ecrire.
-9. **Dollar-quoting** : utiliser `$tag$...$tag$` pour les strings SQL (eviter les injections par apostrophes).
-
----
-
-## Fichiers references
-
-| Fichier | Contenu |
-|---------|---------|
-| `backend/src/config/r1-keyword-plan.constants.ts` | `R1_SECTION_CONFIG`, `R3_FORBIDDEN_IN_R1`, `R1_KP_QUALITY_THRESHOLDS` |
-| `frontend/app/utils/r1-builders.ts` | `R1PurchaseGuideData` interface, `sanitizePurchaseGuideForR1()` |
-| `frontend/app/components/pieces/SafeCompatTable.tsx` | Interface safe_table_rows: `{element, howToCheck}` max 6 rows |
-| `.claude/agents/r6-content-batch.md` | Pattern de reference (format agent, pipeline) |
+# Agent R1 Content Batch — NEUTRALISÉ (2026-07-19)
+
+> 🚫 **NEUTRALISÉ** — cet agent est **inerte**. Son corps opératoire (lecture du keyword plan
+> `__seo_r1_keyword_plan` + du corpus RAG `rag/knowledge/gammes/*.md`, génération des 5 colonnes
+> R1, `INSERT … ON CONFLICT (r1s_pg_id) DO UPDATE __seo_r1_gamme_slots`) a été **retiré**. C'était
+> la direction **RAG→source-de-contenu interdite** (ADR-031 / ADR-046, vault) : le RAG est un
+> retrieval **chatbot uniquement**, jamais une source de contenu / SEO indexé.
+
+## Écriture désactivée (défense en profondeur)
+
+L'outil d'écriture `mcp__supabase__execute_sql` (ainsi que `Glob` / `Grep`) a été **retiré** de
+`tools` : seul `Read` demeure, et `disable-model-invocation: true` empêche l'auto-invocation.
+Même recopié, cet agent **ne peut plus écrire** en base.
+
+## Impact runtime = NUL sur les pages servies
+
+`__seo_r1_gamme_slots` est **sur le chemin servi** (`/pieces/{slug}` → RPC
+`get_buying_guide_with_r1_slots`, COALESCE R1 > sgpg) et n'a **aucune colonne draft/publish** :
+chaque ligne écrite était servie directement (même classe que conseil). Mais retirer l'agent
+supprime un **producteur**, pas des lignes : les lignes déjà écrites **persistent** et continuent
+d'être servies, et à défaut la RPC retombe sur les colonnes sgpg (elles-mêmes draft-gated). Aucun
+runner cron/CI n'invoque l'agent (dispatch on-demand). **Sa neutralisation ne peut donc obscurcir
+aucune page R1 live.**
+
+## Remplacement (méthode canon)
+
+- **Successeur** : skill **`seo-content-loop`** (boucle gouvernée `RAW → WIKI → consumer`, NO-RAG).
+  La vérité contenu vient du **WIKI**, **jamais** du RAG.
+
+> **Retrait PARTIEL — deux chantiers plus larges, hors périmètre de cet agent, laissés à l'owner :**
+> 1. Un **second producteur RAG→R1** existe en code backend runtime :
+>    `backend/src/modules/admin/services/r1-enricher.service.ts` (upsert `__seo_r1_gamme_slots`
+>    depuis `rag/knowledge/gammes/*.md` — miroir littéral de `buying-guide-enricher.service.ts`).
+>    Candidat retrait ADR-031/046 aussi, mais **runtime backend** = slice distincte (Tranche B).
+>    Le helper partagé `PurchaseGuideDataService.upsertR1Slots()` écrit aussi la même table.
+> 2. Le **mapper de projection WIKI→R1** est **absent** (seul `projection-r3` existe, dark).
+>
+> Donc neutraliser cet agent seul **ne ferme pas** la violation RAG→R1 (le backend l'écrit encore).
+> Le fichier est **conservé** (non supprimé) pour ne pas casser les références (`agentic-planner.md`,
+> `execution-registry.constants.ts`, `agentic.constants.ts`) : elles pointent vers un agent inerte
+> qui **STOP + redirige**.
+>
+> Réf : `audit/agent-instructions-audit-2026-07-18.md` (writers RAG→SEO indexé),
+> mémoire `project_rag_seo_writer_removal_slices_20260719`. Rollback = `git revert`.
 
 ## Contrat de sortie obligatoire
 
-> REGLE NON-NEGOCIABLE — s'applique a ce run.
+> REGLE NON-NEGOCIABLE — s'applique à ce run (même inerte).
 
-- Tu ne corriges JAMAIS automatiquement. Tu scannes, analyses, et rapportes.
-- Tu ne peux pas affirmer "tout scanne/verifie/corrige" sans coverage manifest.
-- Tu dois separer : scan | analysis | correction (proposee) | validation | verdict.
-- Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
-- Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
-- Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.
+- Verdict par défaut : `PARTIAL_COVERAGE` / `INSUFFICIENT_EVIDENCE`. Statuts `COMPLETE`/`DONE`/`ALL_FIXED` interdits.
+- Voir `.claude/canon-mirrors/agent-exit-contract.md` pour le contrat complet.


### PR DESCRIPTION
> **DRAFT — owner GO required to merge (STOP zone: SEO indexé).** Zero live impact until merged.

## What
Neutralize `r1-content-batch` (RAG→content producer for R1_ROUTER). `+41 / −366`, one file. Pattern: `tools:` → **`Read` only**, `disable-model-invocation: true`, body → **STOP + redirect** to `seo-content-loop`. **File kept** so refs (`agentic-planner`, `execution-registry.constants.ts`, `agentic.constants.ts`) stay valid.

## Why
It read `/opt/automecanik/rag/knowledge/gammes/*.md` as a content source and wrote R1 content into `__seo_r1_gamme_slots` via `mcp__supabase__execute_sql` — forbidden RAG→content (invariant #4, ADR-031/046).

## Verified before drafting — SAFE (cannot darken), `DIRECT-SERVED-NO-GATE` + `SUCCESSOR_ABSENT`
- **Cannot darken a live page.** `__seo_r1_gamme_slots` is on the served path (`/pieces/{slug}` → RPC `get_buying_guide_with_r1_slots`, COALESCE R1>sgpg) with **no draft/publish column** — but removal drops a *writer*, not rows. Existing rows persist and keep serving, with sgpg as a further fallback. No cron/CI invokes it (dispatch on-demand). Precedent: r7 #1300, ConseilEnricher removal.
- **PARTIAL removal (honest):** a **backend mirror `R1EnricherService`** (RAG-sourced, upserts the same table — literal mirror of `buying-guide-enricher.service.ts`) + the `upsertR1Slots()` helper still write `__seo_r1_gamme_slots`. Neutralizing this agent alone does **not** close the RAG→R1 violation → the backend enricher is a separate **Tranche B** slice (owner-gated).
- **Successor WIKI→R1 = ABSENT:** no `projection-r1.mapper.ts` (only `projection-r3`, dark). Contract models R1 but nothing projects it → tracked follow-up.

## Safety
No DB migration, no URL change, no runtime code touched. Reversible via `git revert`. Context: `audit/agent-instructions-audit-2026-07-18.md`, memory `project_rag_seo_writer_removal_slices_20260719`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)