### PR TITLE
fix(ci): assert HTTP status in the PREPROD response probe, not just latency

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -84,6 +84,15 @@ jobs:
         # container temp-file write from ever coming back.
         run: npm run test:prod-ssr-probe
 
+      - name: ⏱️ PREPROD response probe — status vs latency proof (BLOCKING)
+        # The step this backs used to time responses without asserting anything, so a
+        # fast 500 scored ✅ — the ADR-024 R1 gamme gate was blind on its own subject
+        # (found verifying #1297 on PREPROD). These tests execute the probe against a
+        # real local HTTP server and prove the decision for 200 / 500 / 301 / 302 /
+        # connection-refused / timeout / a flapping endpoint, plus that latency stays
+        # a warning and redirects are never followed.
+        run: npm run test:preprod-response-probe
+
       - name: 🗂️ EDITORIAL_AUTHORITY_SINKS registry invariants (BLOCKING)
         # Pins the exact P0 sink set (audit §6): 2 served-tracked + 15 ratchet-blind,
         # each evidence-linked, no rN wildcard. The blind rows justify the registry.

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -93,6 +93,15 @@ jobs:
         # a warning and redirects are never followed.
         run: npm run test:preprod-response-probe
 
+      - name: ⏱️ PREPROD response suite — retry boundary proof (BLOCKING)
+        # The per-probe tests cannot see the ORCHESTRATION defect: an aggregate
+        # "any failure → retry" made a WRONG STATUS retryable, so 200,500,200 on the
+        # first pass followed by a clean second pass ended the job green. These tests
+        # drive the whole suite against a real server and pin the boundary — a wrong
+        # status is never retried (and never waits for stability), a transport failure
+        # may be re-run once, and when both occur the wrong status dominates.
+        run: npm run test:preprod-response-suite
+
       - name: 🗂️ EDITORIAL_AUTHORITY_SINKS registry invariants (BLOCKING)
         # Pins the exact P0 sink set (audit §6): 2 served-tracked + 15 ratchet-blind,
         # each evidence-linked, no rN wildcard. The blind rows justify the registry.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,75 +1011,16 @@ jobs:
         # NOTHING: a page answering 500 in 20ms scored a green ✅ row. Found while
         # verifying PR #1297 on PREPROD — this step does probe the R1 gamme pages, so
         # it looked like proof they were served, while being unable to tell 200 from
-        # 500. Logic now lives in scripts/ci/preprod-response-probe.sh so it is unit-
-        # tested (npm run test:preprod-response-probe, RED→GREEN) instead of shipping
-        # untested inline YAML — same lesson as the PROD SSR gate (incident 2026-07-19).
+        # 500. Both the per-endpoint probe AND the suite that decides the verdict now
+        # live in scripts/ci/ so they are unit-tested (npm run test:preprod-response-probe
+        # + test:preprod-response-suite, RED→GREEN) instead of shipping untested inline
+        # YAML — same lesson as the PROD SSR gate (incident 2026-07-19). Keeping the retry
+        # branch in YAML is what let an early revision make a WRONG STATUS retryable.
         #
-        # Contract: wrong status / network error / timeout / redirect = BLOCKING.
-        # Latency over budget stays a ::warning:: — unchanged, non-blocking.
-        run: |
-          BASE="http://localhost:3200"
-          PROBE="scripts/ci/preprod-response-probe.sh"
-          echo "## ⏱️ PREPROD Response Times" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Endpoint | Median (ms) | Budget (ms) | Status | HTTP |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------------|-------------|--------|------|" >> $GITHUB_STEP_SUMMARY
-
-          run_probes() {
-            local failed=0
-            # Every endpoint is probed even after a failure, so the summary shows the
-            # FULL picture instead of truncating at the first defect.
-            "$PROBE" "$BASE/health" "/health" 200 || failed=1
-            "$PROBE" "$BASE/api/catalog/families" "/api/catalog/families" 1000 || failed=1
-            "$PROBE" "$BASE/" "Homepage" 2000 || failed=1
-            # /pieces/catalogue is a legacy route that 301s to `/` — verified on both DEV
-            # and PREPROD (the API smoke step has been printing "⚠️ 301" for it). Its 301
-            # is DECLARED here rather than silently timed as if it were a page: the probe
-            # never follows redirects, so this row now fails if the route drifts either
-            # way (301→200 or 301→500). Repointing or dropping this probe is an owner call.
-            "$PROBE" "$BASE/pieces/catalogue" "/pieces/catalogue (legacy 301→/)" 2000 301 || failed=1
-            "$PROBE" "$BASE/pieces/plaquette-de-frein-402/renault-140/megane-iii-140049/1-5-dci-100413.html" "R2 Product Page" 3000 || failed=1
-            # ADR-024 R1 gamme perf gate (parity R2). Backed by __gamme_page_cache (Phase 1) +
-            # SSR cache-first read path (Phase 5a). Hot-path target ~5ms (PK lookup),
-            # cold-path/legacy ceiling 3000ms. Top 5 G1 gammes covering bulk of indexed traffic.
-            "$PROBE" "$BASE/pieces/plaquette-de-frein-402.html"        "R1 Gamme (plaquette-de-frein)"  3000 || failed=1
-            "$PROBE" "$BASE/pieces/disque-de-frein-82.html"            "R1 Gamme (disque-de-frein)"     3000 || failed=1
-            "$PROBE" "$BASE/pieces/filtre-a-huile-7.html"              "R1 Gamme (filtre-a-huile)"      3000 || failed=1
-            "$PROBE" "$BASE/pieces/filtre-a-air-8.html"                "R1 Gamme (filtre-a-air)"        3000 || failed=1
-            "$PROBE" "$BASE/pieces/courroie-de-distribution-306.html"  "R1 Gamme (courroie-distribution)" 3000 || failed=1
-            return $failed
-          }
-
-          if run_probes; then exit 0; fi
-
-          # Same transient-restart discipline as "🎭 Run critical E2E tests" below: the
-          # shared PREPROD container can restart MID-STEP (~20s blind window, diagnostic
-          # 2026-06-21) → connection-refused on an otherwise healthy app. Wait until it is
-          # STABLY healthy, then re-run the probes ONCE. If it never re-stabilizes, or the
-          # re-run also fails, it is a genuine failure. No silent fallback: the retry is
-          # announced, bounded to one, and a still-failing probe still blocks.
-          echo "::warning::Response probes failed — checking for a transient PREPROD restart…"
-          need=4; stable=0
-          for _ in $(seq 1 30); do
-            if curl -sf "$BASE/health" > /dev/null 2>&1; then
-              stable=$((stable + 1))
-              if [ "$stable" -ge "$need" ]; then break; fi
-            else
-              stable=0
-            fi
-            sleep 3
-          done
-          if [ "$stable" -lt "$need" ]; then
-            echo "::error::PREPROD did not re-stabilize — real failure, not a transient restart"
-            exit 1
-          fi
-          echo "PREPROD stably healthy again — re-running the response probes once"
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "_(re-run after a transient PREPROD restart)_" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Endpoint | Median (ms) | Budget (ms) | Status | HTTP |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------------|-------------|--------|------|" >> $GITHUB_STEP_SUMMARY
-          run_probes
+        # Contract: wrong status = BLOCKING and NEVER retried. Transport-only failures
+        # (connection refused / reset / DNS / timeout) may be re-run ONCE after PREPROD is
+        # stably healthy. Latency over budget stays a ::warning:: — unchanged, non-blocking.
+        run: scripts/ci/preprod-response-suite.sh http://localhost:3200
 
       - name: ⏱️ API Timing Gate (blocking)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,46 +1006,80 @@ jobs:
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: ⏱️ Response Time Baseline
+      - name: ⏱️ Response Time Baseline (status-asserting, BLOCKING on wrong status)
+        # The inline check_timing this replaces measured `%{time_total}` and asserted
+        # NOTHING: a page answering 500 in 20ms scored a green ✅ row. Found while
+        # verifying PR #1297 on PREPROD — this step does probe the R1 gamme pages, so
+        # it looked like proof they were served, while being unable to tell 200 from
+        # 500. Logic now lives in scripts/ci/preprod-response-probe.sh so it is unit-
+        # tested (npm run test:preprod-response-probe, RED→GREEN) instead of shipping
+        # untested inline YAML — same lesson as the PROD SSR gate (incident 2026-07-19).
+        #
+        # Contract: wrong status / network error / timeout / redirect = BLOCKING.
+        # Latency over budget stays a ::warning:: — unchanged, non-blocking.
         run: |
           BASE="http://localhost:3200"
+          PROBE="scripts/ci/preprod-response-probe.sh"
           echo "## ⏱️ PREPROD Response Times" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Endpoint | Median (ms) | Budget (ms) | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------------|-------------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Endpoint | Median (ms) | Budget (ms) | Status | HTTP |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------------|-------------|--------|------|" >> $GITHUB_STEP_SUMMARY
 
-          check_timing() {
-            local url="$1"
-            local label="$2"
-            local budget_ms="$3"
-
-            local t1=$(curl -s -o /dev/null -w "%{time_total}" "$url" --max-time 30 | awk '{printf "%.0f", $1 * 1000}')
-            local t2=$(curl -s -o /dev/null -w "%{time_total}" "$url" --max-time 30 | awk '{printf "%.0f", $1 * 1000}')
-            local t3=$(curl -s -o /dev/null -w "%{time_total}" "$url" --max-time 30 | awk '{printf "%.0f", $1 * 1000}')
-
-            local median=$(echo -e "$t1\n$t2\n$t3" | sort -n | sed -n '2p')
-
-            if [ "$median" -gt "$budget_ms" ]; then
-              echo "| $label | ${median} | ${budget_ms} | ⚠️ SLOW |" >> $GITHUB_STEP_SUMMARY
-              echo "::warning::$label response time (${median}ms) exceeds budget (${budget_ms}ms)"
-            else
-              echo "| $label | ${median} | ${budget_ms} | ✅ |" >> $GITHUB_STEP_SUMMARY
-            fi
+          run_probes() {
+            local failed=0
+            # Every endpoint is probed even after a failure, so the summary shows the
+            # FULL picture instead of truncating at the first defect.
+            "$PROBE" "$BASE/health" "/health" 200 || failed=1
+            "$PROBE" "$BASE/api/catalog/families" "/api/catalog/families" 1000 || failed=1
+            "$PROBE" "$BASE/" "Homepage" 2000 || failed=1
+            # /pieces/catalogue is a legacy route that 301s to `/` — verified on both DEV
+            # and PREPROD (the API smoke step has been printing "⚠️ 301" for it). Its 301
+            # is DECLARED here rather than silently timed as if it were a page: the probe
+            # never follows redirects, so this row now fails if the route drifts either
+            # way (301→200 or 301→500). Repointing or dropping this probe is an owner call.
+            "$PROBE" "$BASE/pieces/catalogue" "/pieces/catalogue (legacy 301→/)" 2000 301 || failed=1
+            "$PROBE" "$BASE/pieces/plaquette-de-frein-402/renault-140/megane-iii-140049/1-5-dci-100413.html" "R2 Product Page" 3000 || failed=1
+            # ADR-024 R1 gamme perf gate (parity R2). Backed by __gamme_page_cache (Phase 1) +
+            # SSR cache-first read path (Phase 5a). Hot-path target ~5ms (PK lookup),
+            # cold-path/legacy ceiling 3000ms. Top 5 G1 gammes covering bulk of indexed traffic.
+            "$PROBE" "$BASE/pieces/plaquette-de-frein-402.html"        "R1 Gamme (plaquette-de-frein)"  3000 || failed=1
+            "$PROBE" "$BASE/pieces/disque-de-frein-82.html"            "R1 Gamme (disque-de-frein)"     3000 || failed=1
+            "$PROBE" "$BASE/pieces/filtre-a-huile-7.html"              "R1 Gamme (filtre-a-huile)"      3000 || failed=1
+            "$PROBE" "$BASE/pieces/filtre-a-air-8.html"                "R1 Gamme (filtre-a-air)"        3000 || failed=1
+            "$PROBE" "$BASE/pieces/courroie-de-distribution-306.html"  "R1 Gamme (courroie-distribution)" 3000 || failed=1
+            return $failed
           }
 
-          check_timing "$BASE/health" "/health" 200
-          check_timing "$BASE/api/catalog/families" "/api/catalog/families" 1000
-          check_timing "$BASE/" "Homepage" 2000
-          check_timing "$BASE/pieces/catalogue" "/pieces/catalogue" 2000
-          check_timing "$BASE/pieces/plaquette-de-frein-402/renault-140/megane-iii-140049/1-5-dci-100413.html" "R2 Product Page" 3000
-          # ADR-024 R1 gamme perf gate (parity R2). Backed by __gamme_page_cache (Phase 1) +
-          # SSR cache-first read path (Phase 5a). Hot-path target ~5ms (PK lookup),
-          # cold-path/legacy ceiling 3000ms. Top 5 G1 gammes covering bulk of indexed traffic.
-          check_timing "$BASE/pieces/plaquette-de-frein-402.html"        "R1 Gamme (plaquette-de-frein)"  3000
-          check_timing "$BASE/pieces/disque-de-frein-82.html"            "R1 Gamme (disque-de-frein)"     3000
-          check_timing "$BASE/pieces/filtre-a-huile-7.html"              "R1 Gamme (filtre-a-huile)"      3000
-          check_timing "$BASE/pieces/filtre-a-air-8.html"                "R1 Gamme (filtre-a-air)"        3000
-          check_timing "$BASE/pieces/courroie-de-distribution-306.html"  "R1 Gamme (courroie-distribution)" 3000
+          if run_probes; then exit 0; fi
+
+          # Same transient-restart discipline as "🎭 Run critical E2E tests" below: the
+          # shared PREPROD container can restart MID-STEP (~20s blind window, diagnostic
+          # 2026-06-21) → connection-refused on an otherwise healthy app. Wait until it is
+          # STABLY healthy, then re-run the probes ONCE. If it never re-stabilizes, or the
+          # re-run also fails, it is a genuine failure. No silent fallback: the retry is
+          # announced, bounded to one, and a still-failing probe still blocks.
+          echo "::warning::Response probes failed — checking for a transient PREPROD restart…"
+          need=4; stable=0
+          for _ in $(seq 1 30); do
+            if curl -sf "$BASE/health" > /dev/null 2>&1; then
+              stable=$((stable + 1))
+              if [ "$stable" -ge "$need" ]; then break; fi
+            else
+              stable=0
+            fi
+            sleep 3
+          done
+          if [ "$stable" -lt "$need" ]; then
+            echo "::error::PREPROD did not re-stabilize — real failure, not a transient restart"
+            exit 1
+          fi
+          echo "PREPROD stably healthy again — re-running the response probes once"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_(re-run after a transient PREPROD restart)_" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Endpoint | Median (ms) | Budget (ms) | Status | HTTP |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------------|-------------|--------|------|" >> $GITHUB_STEP_SUMMARY
+          run_probes
 
       - name: ⏱️ API Timing Gate (blocking)
         run: |

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "audit:editorial-sinks:test": "tsx --test scripts/audit/editorial-authority-sinks.test.ts",
     "test:prod-rollback": "node --test scripts/ci/prod-rollback.test.mjs",
     "test:prod-ssr-probe": "node --test scripts/ci/prod-ssr-probe.test.mjs",
+    "test:preprod-response-probe": "node --test scripts/ci/preprod-response-probe.test.mjs",
     "audit:rag-authority-rule:test": "ast-grep test --test-dir scripts/audit/__fixtures__/rag-authority --skip-snapshot-tests",
     "audit:rag-authority-read-ratchet": "tsx scripts/audit/check-rag-authority-read-ratchet.ts",
     "audit:rag-authority-read-ratchet:json": "tsx scripts/audit/check-rag-authority-read-ratchet.ts --json",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:prod-rollback": "node --test scripts/ci/prod-rollback.test.mjs",
     "test:prod-ssr-probe": "node --test scripts/ci/prod-ssr-probe.test.mjs",
     "test:preprod-response-probe": "node --test scripts/ci/preprod-response-probe.test.mjs",
+    "test:preprod-response-suite": "node --test scripts/ci/preprod-response-suite.test.mjs",
     "audit:rag-authority-rule:test": "ast-grep test --test-dir scripts/audit/__fixtures__/rag-authority --skip-snapshot-tests",
     "audit:rag-authority-read-ratchet": "tsx scripts/audit/check-rag-authority-read-ratchet.ts",
     "audit:rag-authority-read-ratchet:json": "tsx scripts/audit/check-rag-authority-read-ratchet.ts --json",

--- a/scripts/ci/preprod-response-probe.sh
+++ b/scripts/ci/preprod-response-probe.sh
@@ -22,8 +22,15 @@
 #      answering 500 then 200 is broken, and re-running until it looks green is
 #      precisely the silent fallback this gate exists to prevent.
 #   2  TRANSPORT — network error / DNS / connection reset / timeout / http_code 000.
-#      No status was ever observed, so the caller MAY re-run once after the target
-#      is stably healthy again (the ~20s PREPROD container-restart blind window).
+#      No wrong status was ever observed, so the caller MAY re-run once after the
+#      target is stably healthy again (~20s PREPROD container-restart blind window).
+#
+# The verdict is decided AFTER all probes, never inside the loop: a wrong status
+# already observed OUTRANKS a transport error that happens later in the same
+# sequence. Exiting early on the transport error (as this script first did) let
+# `500 → connection reset → 200` report "transport-only"; the caller then retried,
+# the second pass came back clean, and the 500 shipped green — the very masking
+# this gate exists to prevent.
 #
 #   redirect (301/302/307/308) → exit 1 unless explicitly declared as expected;
 #                                redirects are NEVER followed (no `-L`), so a
@@ -54,7 +61,14 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 times=()
 statuses=()
+status_fail=0
+transport_fail=0
+transport_detail=""
 
+# NEVER exit inside this loop. A transport error on attempt 2 used to abort with
+# exit 2 while a 500 was already observed on attempt 1 — the caller then read
+# "transport-only", retried, got a clean pass, and the real defect shipped green.
+# Every attempt is collected; the verdict is decided once, after the loop.
 for _ in $(seq 1 "$COUNT"); do
   # One curl per probe yields BOTH status and timing, so the two can never drift
   # apart. No `-L`: a redirect must surface as 3xx, never be followed silently.
@@ -67,28 +81,41 @@ for _ in $(seq 1 "$COUNT"); do
 
   if [ "$rc" -ne 0 ] || [ -z "$code" ] || [ "$code" = "000" ]; then
     # curl exit 28 = timeout, 6 = DNS, 7 = connection refused, 56 = recv error.
-    # exit 2 = TRANSPORT: no status was observed, so the caller may retry once.
-    echo "❌ $LABEL — $URL: no usable response (curl exit $rc, http_code=${code:-<none>})"
-    echo "| $LABEL | — | ${BUDGET_MS} | ❌ no response (curl $rc) | ❌ |" >>"$SUMMARY"
-    exit 2
+    transport_fail=1
+    transport_detail="curl exit $rc, http_code=${code:-<none>}"
+    statuses+=("ERR")
+    continue
   fi
 
   statuses+=("$code")
   times+=("$(printf '%s' "${secs:-0}" | awk '{printf "%.0f", $1 * 1000}')")
+  # Every probe must carry the expected status — no averaging over a flap.
+  [ "$code" != "$EXPECTED" ] && status_fail=1
 done
 
-# Every probe must carry the expected status — no averaging over a flapping endpoint.
-for code in "${statuses[@]}"; do
-  if [ "$code" != "$EXPECTED" ]; then
-    echo "❌ $LABEL — $URL: HTTP ${statuses[*]} (expected $EXPECTED)"
-    if [ "$code" -ge 300 ] && [ "$code" -lt 400 ]; then
-      echo "   redirect not followed on purpose: this URL is canonical and must answer directly."
-    fi
-    echo "| $LABEL | — | ${BUDGET_MS} | ❌ HTTP ${statuses[*]} (expected $EXPECTED) | ❌ |" >>"$SUMMARY"
-    # exit 1 = WRONG STATUS: a real defect, never retried by the caller.
-    exit 1
-  fi
-done
+# VERDICT — a status actually OBSERVED outranks a transport error seen later.
+# Anything else would let a retry bury a defect the probe already proved.
+if [ "$status_fail" -eq 1 ]; then
+  echo "❌ $LABEL — $URL: HTTP ${statuses[*]} (expected $EXPECTED)"
+  for code in "${statuses[@]}"; do
+    case "$code" in
+      3??)
+        echo "   redirect not followed on purpose: this URL is canonical and must answer directly."
+        break
+        ;;
+    esac
+  done
+  echo "| $LABEL | — | ${BUDGET_MS} | ❌ HTTP ${statuses[*]} (expected $EXPECTED) | ❌ |" >>"$SUMMARY"
+  # exit 1 = WRONG STATUS: a real defect, never retried by the caller.
+  exit 1
+fi
+
+if [ "$transport_fail" -eq 1 ]; then
+  # exit 2 = TRANSPORT: no wrong status was observed, so the caller may retry once.
+  echo "❌ $LABEL — $URL: no usable response (${transport_detail})"
+  echo "| $LABEL | — | ${BUDGET_MS} | ❌ no response (${transport_detail}) | ❌ |" >>"$SUMMARY"
+  exit 2
+fi
 
 median=$(printf '%s\n' "${times[@]}" | sort -n | awk '{a[NR]=$1} END {print a[int((NR+1)/2)]}')
 

--- a/scripts/ci/preprod-response-probe.sh
+++ b/scripts/ci/preprod-response-probe.sh
@@ -15,22 +15,27 @@
 # served, but the run could not distinguish 200 from 500. The R1 gamme perf gate
 # (ADR-024) was blind on exactly the surface it exists to protect.
 #
-# CONTRACT
-# --------
-#   status != expected            → FAIL (exit 1), blocking.
-#   network error / timeout / 000 → FAIL (exit 1), blocking.
-#   redirect (301/302/307/308)    → FAIL unless explicitly declared as expected;
-#                                   redirects are NEVER followed (no `-L`), so a
-#                                   canonical URL that silently starts redirecting
-#                                   is caught instead of being measured as its target.
-#   status OK but median > budget → WARNING only (unchanged behaviour, non-blocking).
+# CONTRACT — the two failure exits are DISTINCT on purpose
+# --------------------------------------------------------
+#   0  expected status on every probe (may still warn on latency).
+#   1  WRONG STATUS — a real defect. The caller must NEVER retry this. An endpoint
+#      answering 500 then 200 is broken, and re-running until it looks green is
+#      precisely the silent fallback this gate exists to prevent.
+#   2  TRANSPORT — network error / DNS / connection reset / timeout / http_code 000.
+#      No status was ever observed, so the caller MAY re-run once after the target
+#      is stably healthy again (the ~20s PREPROD container-restart blind window).
+#
+#   redirect (301/302/307/308) → exit 1 unless explicitly declared as expected;
+#                                redirects are NEVER followed (no `-L`), so a
+#                                canonical URL that silently starts redirecting is
+#                                caught instead of being measured as its target.
+#   status OK but median > budget → WARNING only (unchanged, non-blocking).
 #
 # All three probes are status-checked, not just one: an endpoint that flaps
 # 200/500/200 is a real defect and must not average away into a green row.
 #
 # Usage:  preprod-response-probe.sh <url> <label> <budget_ms> [expected_status]
-# Exit:   0 = expected status on all 3 probes (may still warn on latency)
-#         1 = wrong status, network error, or timeout on any probe
+# Exit:   0 = ok · 1 = wrong status (never retry) · 2 = transport (retryable once)
 #
 # Env overrides (used by the behavioural tests):
 #   PROBE_COUNT           number of probes           (default 3)
@@ -62,9 +67,10 @@ for _ in $(seq 1 "$COUNT"); do
 
   if [ "$rc" -ne 0 ] || [ -z "$code" ] || [ "$code" = "000" ]; then
     # curl exit 28 = timeout, 6 = DNS, 7 = connection refused, 56 = recv error.
+    # exit 2 = TRANSPORT: no status was observed, so the caller may retry once.
     echo "❌ $LABEL — $URL: no usable response (curl exit $rc, http_code=${code:-<none>})"
     echo "| $LABEL | — | ${BUDGET_MS} | ❌ no response (curl $rc) | ❌ |" >>"$SUMMARY"
-    exit 1
+    exit 2
   fi
 
   statuses+=("$code")
@@ -79,6 +85,7 @@ for code in "${statuses[@]}"; do
       echo "   redirect not followed on purpose: this URL is canonical and must answer directly."
     fi
     echo "| $LABEL | — | ${BUDGET_MS} | ❌ HTTP ${statuses[*]} (expected $EXPECTED) | ❌ |" >>"$SUMMARY"
+    # exit 1 = WRONG STATUS: a real defect, never retried by the caller.
     exit 1
   fi
 done

--- a/scripts/ci/preprod-response-probe.sh
+++ b/scripts/ci/preprod-response-probe.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# PREPROD response probe — assert STATUS first, then measure latency.
+#
+# WHY THIS EXISTS
+# ---------------
+# The `⏱️ Response Time Baseline` step used to run:
+#
+#     curl -s -o /dev/null -w "%{time_total}" "$url"
+#
+# i.e. it measured ONLY elapsed time and asserted NOTHING about the response.
+# A page returning 500 — quickly — passed the gate with a green ✅ row. This was
+# found while verifying PR #1297 (RAG→R1 write closure) on PREPROD: the step does
+# probe `/pieces/filtre-a-huile-7.html`, so it *looked* like proof the R1 page was
+# served, but the run could not distinguish 200 from 500. The R1 gamme perf gate
+# (ADR-024) was blind on exactly the surface it exists to protect.
+#
+# CONTRACT
+# --------
+#   status != expected            → FAIL (exit 1), blocking.
+#   network error / timeout / 000 → FAIL (exit 1), blocking.
+#   redirect (301/302/307/308)    → FAIL unless explicitly declared as expected;
+#                                   redirects are NEVER followed (no `-L`), so a
+#                                   canonical URL that silently starts redirecting
+#                                   is caught instead of being measured as its target.
+#   status OK but median > budget → WARNING only (unchanged behaviour, non-blocking).
+#
+# All three probes are status-checked, not just one: an endpoint that flaps
+# 200/500/200 is a real defect and must not average away into a green row.
+#
+# Usage:  preprod-response-probe.sh <url> <label> <budget_ms> [expected_status]
+# Exit:   0 = expected status on all 3 probes (may still warn on latency)
+#         1 = wrong status, network error, or timeout on any probe
+#
+# Env overrides (used by the behavioural tests):
+#   PROBE_COUNT           number of probes           (default 3)
+#   PROBE_MAX_TIME        curl --max-time seconds    (default 30)
+#   GITHUB_STEP_SUMMARY   markdown summary sink      (default /dev/null)
+set -uo pipefail
+
+URL="${1:?usage: preprod-response-probe.sh <url> <label> <budget_ms> [expected_status]}"
+LABEL="${2:?missing label}"
+BUDGET_MS="${3:?missing budget_ms}"
+EXPECTED="${4:-200}"
+
+COUNT="${PROBE_COUNT:-3}"
+MAX_TIME="${PROBE_MAX_TIME:-30}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+times=()
+statuses=()
+
+for _ in $(seq 1 "$COUNT"); do
+  # One curl per probe yields BOTH status and timing, so the two can never drift
+  # apart. No `-L`: a redirect must surface as 3xx, never be followed silently.
+  # On a network error / DNS failure / timeout curl exits non-zero and prints
+  # `000` as %{http_code} — both are captured below.
+  out=$(curl -s -o /dev/null -w "%{http_code} %{time_total}" --max-time "$MAX_TIME" "$URL" 2>/dev/null)
+  rc=$?
+  code=$(printf '%s' "$out" | awk '{print $1}')
+  secs=$(printf '%s' "$out" | awk '{print $2}')
+
+  if [ "$rc" -ne 0 ] || [ -z "$code" ] || [ "$code" = "000" ]; then
+    # curl exit 28 = timeout, 6 = DNS, 7 = connection refused, 56 = recv error.
+    echo "❌ $LABEL — $URL: no usable response (curl exit $rc, http_code=${code:-<none>})"
+    echo "| $LABEL | — | ${BUDGET_MS} | ❌ no response (curl $rc) | ❌ |" >>"$SUMMARY"
+    exit 1
+  fi
+
+  statuses+=("$code")
+  times+=("$(printf '%s' "${secs:-0}" | awk '{printf "%.0f", $1 * 1000}')")
+done
+
+# Every probe must carry the expected status — no averaging over a flapping endpoint.
+for code in "${statuses[@]}"; do
+  if [ "$code" != "$EXPECTED" ]; then
+    echo "❌ $LABEL — $URL: HTTP ${statuses[*]} (expected $EXPECTED)"
+    if [ "$code" -ge 300 ] && [ "$code" -lt 400 ]; then
+      echo "   redirect not followed on purpose: this URL is canonical and must answer directly."
+    fi
+    echo "| $LABEL | — | ${BUDGET_MS} | ❌ HTTP ${statuses[*]} (expected $EXPECTED) | ❌ |" >>"$SUMMARY"
+    exit 1
+  fi
+done
+
+median=$(printf '%s\n' "${times[@]}" | sort -n | awk '{a[NR]=$1} END {print a[int((NR+1)/2)]}')
+
+if [ "$median" -gt "$BUDGET_MS" ]; then
+  echo "⚠️ $LABEL — HTTP $EXPECTED, ${median}ms exceeds budget ${BUDGET_MS}ms"
+  echo "::warning::$LABEL response time (${median}ms) exceeds budget (${BUDGET_MS}ms)"
+  echo "| $LABEL | ${median} | ${BUDGET_MS} | ⚠️ SLOW | ${EXPECTED} |" >>"$SUMMARY"
+else
+  echo "✅ $LABEL — HTTP $EXPECTED, ${median}ms (budget ${BUDGET_MS}ms)"
+  echo "| $LABEL | ${median} | ${BUDGET_MS} | ✅ | ${EXPECTED} |" >>"$SUMMARY"
+fi

--- a/scripts/ci/preprod-response-probe.test.mjs
+++ b/scripts/ci/preprod-response-probe.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * Behavioural proof of the PREPROD response probe (preprod-response-probe.sh).
+ *
+ * The gate this replaces measured latency ONLY — `curl -o /dev/null -w "%{time_total}"`
+ * with no status assertion — so a fast 500 produced a green ✅ row. It was found
+ * during the PREPROD verification of PR #1297: the step does probe
+ * `/pieces/filtre-a-huile-7.html`, but could not tell 200 from 500, leaving the
+ * ADR-024 R1 gamme gate blind on the surface it exists to protect.
+ *
+ * These tests run the probe against a REAL local HTTP server (not a stubbed curl),
+ * so the pass/fail decision is proven end-to-end for each observable response:
+ * correct status, wrong status, redirect, network error, timeout, and slow-but-OK.
+ *
+ * Run: npm run test:preprod-response-probe
+ */
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+// MUST be async: the stub HTTP server lives in THIS process, so a synchronous
+// execFileSync would block the event loop and the server could never answer —
+// every probe would time out regardless of what the script does.
+const execFileAsync = promisify(execFile);
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PROBE_SH = join(SCRIPT_DIR, "preprod-response-probe.sh");
+
+/**
+ * Routes exercised by the tests. `/flap` alternates 200,500,200 to prove every
+ * probe is status-checked rather than only the first (or an average).
+ */
+let flapCount = 0;
+let server;
+let PORT;
+
+before(async () => {
+  server = createServer((req, res) => {
+    const path = req.url.split("?")[0];
+    switch (path) {
+      case "/ok":
+        return res.writeHead(200, { "Content-Type": "text/html" }).end("<html>ok</html>");
+      case "/boom":
+        return res.writeHead(500, { "Content-Type": "text/html" }).end("<html>err</html>");
+      case "/moved":
+        return res.writeHead(301, { Location: "/ok" }).end();
+      case "/found":
+        return res.writeHead(302, { Location: "/ok" }).end();
+      case "/slow":
+        return setTimeout(
+          () => res.writeHead(200, { "Content-Type": "text/html" }).end("<html>slow</html>"),
+          250,
+        );
+      case "/hang":
+        return; // never responds → curl --max-time must trip
+      case "/flap": {
+        const code = flapCount++ === 1 ? 500 : 200;
+        return res.writeHead(code, { "Content-Type": "text/html" }).end("x");
+      }
+      default:
+        return res.writeHead(404).end();
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  PORT = server.address().port;
+});
+
+after(() => server?.close());
+
+async function runProbeUrl(url, { label = "probe", budget = 2000, expected, env = {} } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "preprod-response-probe-"));
+  const summary = join(dir, "summary.md");
+  writeFileSync(summary, "");
+
+  const args = [PROBE_SH, url, label, String(budget)];
+  if (expected !== undefined) args.push(String(expected));
+
+  let code = 0;
+  let stdout = "";
+  try {
+    ({ stdout } = await execFileAsync("bash", args, {
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_STEP_SUMMARY: summary, ...env },
+    }));
+  } catch (e) {
+    code = e.code ?? 1;
+    stdout = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  return { code, stdout, summary: readFileSync(summary, "utf8") };
+}
+
+const runProbe = (path, opts) => runProbeUrl(`http://127.0.0.1:${PORT}${path}`, opts);
+
+describe("preprod-response-probe.sh — status is asserted, not just latency", () => {
+  test("PASSES on a fast 200 (the only green case)", async () => {
+    const { code, stdout, summary } = await runProbe("/ok");
+    assert.equal(code, 0, `expected pass, got ${code}\n${stdout}`);
+    assert.match(stdout, /✅.*HTTP 200/);
+    assert.match(summary, /\| ✅ \| 200 \|/);
+  });
+
+  test("FAILS on a fast 500 — the exact blind spot (was a green ✅ row before)", async () => {
+    const { code, stdout, summary } = await runProbe("/boom");
+    assert.notEqual(code, 0, "a 500 must be blocking, however fast it answers");
+    assert.match(stdout, /HTTP 500.*expected 200/);
+    assert.match(summary, /❌ HTTP/);
+  });
+
+  test("FAILS on a fast 301 and does NOT follow it", async () => {
+    const { code, stdout } = await runProbe("/moved");
+    assert.notEqual(code, 0);
+    assert.match(stdout, /HTTP 301.*expected 200/);
+    assert.match(stdout, /redirect not followed on purpose/);
+  });
+
+  test("FAILS on a fast 302 and does NOT follow it", async () => {
+    const { code, stdout } = await runProbe("/found");
+    assert.notEqual(code, 0);
+    assert.match(stdout, /HTTP 302.*expected 200/);
+  });
+
+  test("FAILS on a network error (connection refused → http_code 000)", async () => {
+    // Port 1 has no listener: curl exits 7 and reports 000.
+    const { code, stdout, summary } = await runProbeUrl("http://127.0.0.1:1/ok", {
+      label: "unreachable",
+    });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /no usable response/);
+    assert.match(summary, /no response/);
+  });
+
+  test("FAILS on a timeout (server never answers)", async () => {
+    const { code, stdout } = await runProbe("/hang", { env: { PROBE_MAX_TIME: "1" } });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /no usable response/);
+  });
+
+  test("FAILS when only ONE of the three probes is bad (no averaging away a flap)", async () => {
+    flapCount = 0;
+    const { code, stdout } = await runProbe("/flap");
+    assert.notEqual(code, 0, "a 200,500,200 sequence must fail — every probe is checked");
+    assert.match(stdout, /HTTP 200 500 200|HTTP .*500/);
+  });
+});
+
+describe("preprod-response-probe.sh — latency stays a warning, never a failure", () => {
+  test("WARNS but PASSES when a correct 200 exceeds its budget", async () => {
+    const { code, stdout, summary } = await runProbe("/slow", { budget: 1 });
+    assert.equal(code, 0, "slowness must remain non-blocking");
+    assert.match(stdout, /⚠️.*exceeds budget/);
+    assert.match(stdout, /::warning::/);
+    assert.match(summary, /⚠️ SLOW/);
+  });
+});
+
+describe("preprod-response-probe.sh — declared non-200 contracts", () => {
+  test("PASSES a 301 only when 301 is explicitly declared as expected", async () => {
+    const { code, stdout } = await runProbe("/moved", { expected: 301 });
+    assert.equal(code, 0, "an explicitly declared redirect contract is allowed");
+    assert.match(stdout, /✅.*HTTP 301/);
+  });
+
+  test("FAILS when a declared-301 URL starts answering 200 (contract drift both ways)", async () => {
+    const { code, stdout } = await runProbe("/ok", { expected: 301 });
+    assert.notEqual(code, 0);
+    assert.match(stdout, /HTTP 200.*expected 301/);
+  });
+});
+
+describe("preprod-response-probe.sh — static guarantees", () => {
+  const src = readFileSync(PROBE_SH, "utf8");
+  const code = src
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("#"))
+    .join("\n");
+
+  test("never follows redirects (no -L / --location)", async () => {
+    assert.doesNotMatch(code, /curl[^\n|]*\s(-L|--location)\b/, "probe must not follow redirects");
+  });
+
+  test("captures status and timing in the SAME curl call (they cannot drift)", async () => {
+    assert.match(code, /%\{http_code\}\s+%\{time_total\}/);
+  });
+
+  test("summary rows carry the HTTP column", async () => {
+    const rows = code.match(/echo "\| \$LABEL \|[^"]*"/g) || [];
+    assert.ok(rows.length >= 3, `expected the 3 summary rows, found ${rows.length}`);
+    for (const row of rows) {
+      assert.equal(
+        (row.match(/\|/g) || []).length,
+        6,
+        `row must have 5 columns (Endpoint|Median|Budget|Status|HTTP): ${row}`,
+      );
+    }
+  });
+});

--- a/scripts/ci/preprod-response-probe.test.mjs
+++ b/scripts/ci/preprod-response-probe.test.mjs
@@ -36,6 +36,7 @@ const PROBE_SH = join(SCRIPT_DIR, "preprod-response-probe.sh");
  * probe is status-checked rather than only the first (or an average).
  */
 let flapCount = 0;
+let mixedCount = 0;
 let server;
 let PORT;
 
@@ -61,6 +62,15 @@ before(async () => {
       case "/flap": {
         const code = flapCount++ === 1 ? 500 : 200;
         return res.writeHead(code, { "Content-Type": "text/html" }).end("x");
+      }
+      case "/mixed": {
+        // 500 → connection reset → 200. The reset must NOT erase the 500 already
+        // observed: if the probe exits "transport", the suite retries and a clean
+        // second pass buries a real defect.
+        const hit = mixedCount++;
+        if (hit === 0) return res.writeHead(500).end("err");
+        if (hit === 1) return res.socket.destroy();
+        return res.writeHead(200, { "Content-Type": "text/html" }).end("ok");
       }
       default:
         return res.writeHead(404).end();
@@ -138,6 +148,16 @@ describe("preprod-response-probe.sh — status is asserted, not just latency", (
     const { code, stdout } = await runProbe("/hang", { env: { PROBE_MAX_TIME: "1" } });
     assert.equal(code, 2, "a timeout is transport, not a status defect");
     assert.match(stdout, /no usable response/);
+  });
+
+  test("FAILS with exit 1 when a 500 is followed by a transport error (status wins)", async () => {
+    // Regression: the probe used to `exit 2` the instant a transport error hit,
+    // discarding the 500 already collected. The suite then read "transport-only",
+    // retried, got a clean pass, and the real defect shipped green.
+    mixedCount = 0;
+    const { code, stdout } = await runProbe("/mixed");
+    assert.equal(code, 1, "a status already observed must outrank a later transport error");
+    assert.match(stdout, /500/);
   });
 
   test("FAILS when only ONE of the three probes is bad (no averaging away a flap)", async () => {

--- a/scripts/ci/preprod-response-probe.test.mjs
+++ b/scripts/ci/preprod-response-probe.test.mjs
@@ -106,21 +106,21 @@ describe("preprod-response-probe.sh — status is asserted, not just latency", (
 
   test("FAILS on a fast 500 — the exact blind spot (was a green ✅ row before)", async () => {
     const { code, stdout, summary } = await runProbe("/boom");
-    assert.notEqual(code, 0, "a 500 must be blocking, however fast it answers");
+    assert.equal(code, 1, "a 500 must exit 1 (wrong status — never retryable)");
     assert.match(stdout, /HTTP 500.*expected 200/);
     assert.match(summary, /❌ HTTP/);
   });
 
   test("FAILS on a fast 301 and does NOT follow it", async () => {
     const { code, stdout } = await runProbe("/moved");
-    assert.notEqual(code, 0);
+    assert.equal(code, 1, "a redirect is a wrong status, not a transport failure");
     assert.match(stdout, /HTTP 301.*expected 200/);
     assert.match(stdout, /redirect not followed on purpose/);
   });
 
   test("FAILS on a fast 302 and does NOT follow it", async () => {
     const { code, stdout } = await runProbe("/found");
-    assert.notEqual(code, 0);
+    assert.equal(code, 1);
     assert.match(stdout, /HTTP 302.*expected 200/);
   });
 
@@ -129,21 +129,21 @@ describe("preprod-response-probe.sh — status is asserted, not just latency", (
     const { code, stdout, summary } = await runProbeUrl("http://127.0.0.1:1/ok", {
       label: "unreachable",
     });
-    assert.notEqual(code, 0);
+    assert.equal(code, 2, "transport failures exit 2 so the caller may retry once");
     assert.match(stdout, /no usable response/);
     assert.match(summary, /no response/);
   });
 
   test("FAILS on a timeout (server never answers)", async () => {
     const { code, stdout } = await runProbe("/hang", { env: { PROBE_MAX_TIME: "1" } });
-    assert.notEqual(code, 0);
+    assert.equal(code, 2, "a timeout is transport, not a status defect");
     assert.match(stdout, /no usable response/);
   });
 
   test("FAILS when only ONE of the three probes is bad (no averaging away a flap)", async () => {
     flapCount = 0;
     const { code, stdout } = await runProbe("/flap");
-    assert.notEqual(code, 0, "a 200,500,200 sequence must fail — every probe is checked");
+    assert.equal(code, 1, "a 200,500,200 sequence must exit 1 — every probe is checked");
     assert.match(stdout, /HTTP 200 500 200|HTTP .*500/);
   });
 });
@@ -167,7 +167,7 @@ describe("preprod-response-probe.sh — declared non-200 contracts", () => {
 
   test("FAILS when a declared-301 URL starts answering 200 (contract drift both ways)", async () => {
     const { code, stdout } = await runProbe("/ok", { expected: 301 });
-    assert.notEqual(code, 0);
+    assert.equal(code, 1);
     assert.match(stdout, /HTTP 200.*expected 301/);
   });
 });

--- a/scripts/ci/preprod-response-suite.sh
+++ b/scripts/ci/preprod-response-suite.sh
@@ -22,6 +22,10 @@
 #     STABLY healthy again — the ~20s PREPROD container-restart blind window
 #     (diagnostic 2026-06-21). Same discipline as the "🎭 Run critical E2E tests"
 #     job: announced, bounded to one, and a still-failing re-run still blocks.
+#   * ONLY exit 2 is retryable. Any other unexpected probe exit code (127, 126,
+#     signal death) proved nothing about the endpoint and is treated as a defect.
+#   * A run that probes NOTHING (unreadable/empty spec) FAILS. A vacuous green is
+#     the worst outcome a gate can produce.
 #
 # Usage:  preprod-response-suite.sh [base_url]
 # Exit:   0 = all endpoints answered their expected status
@@ -65,8 +69,19 @@ read -r -d '' DEFAULT_SPEC <<'SPEC' || true
 /pieces/courroie-de-distribution-306.html|R1 Gamme (courroie-distribution)|3000|200
 SPEC
 
+# An override that cannot be read must FAIL, never fall through to zero probes:
+# `cat` on a missing path printed to stderr and left SPEC empty, so the suite
+# probed nothing and exited 0 — a green run proving strictly nothing.
 if [ -n "${PROBE_SPEC_FILE:-}" ]; then
+  if [ ! -r "$PROBE_SPEC_FILE" ]; then
+    echo "::error::PROBE_SPEC_FILE=$PROBE_SPEC_FILE is missing or unreadable — refusing to run zero probes."
+    exit 1
+  fi
   SPEC=$(cat "$PROBE_SPEC_FILE")
+  if [ -z "${SPEC//[[:space:]]/}" ]; then
+    echo "::error::PROBE_SPEC_FILE=$PROBE_SPEC_FILE is empty — refusing to run zero probes."
+    exit 1
+  fi
 else
   SPEC="$DEFAULT_SPEC"
 fi
@@ -80,17 +95,30 @@ summary_header() {
 # A wrong status DOMINATES: if both kinds happen, the verdict is 1, never 2,
 # so a co-occurring transport blip can never make a real defect retryable.
 run_probes() {
-  local status_fail=0 transport_fail=0 rc path label budget expected
+  local status_fail=0 transport_fail=0 probes_run=0 rc path label budget expected
   while IFS='|' read -r path label budget expected; do
     [ -z "${path:-}" ] && continue
+    probes_run=$((probes_run + 1))
     "$PROBE" "${BASE}${path}" "$label" "$budget" "${expected:-200}"
     rc=$?
     case "$rc" in
       0) ;;
       1) status_fail=1 ;;
-      *) transport_fail=1 ;;
+      2) transport_fail=1 ;;
+      # ONLY 2 is retryable. A probe that dies otherwise (127 not-executable,
+      # 126 permission, 2xx signal death) has proven nothing about the endpoint —
+      # calling it "transport" would grant it a free re-run it never earned.
+      *)
+        echo "::error::probe for '$label' exited $rc (unexpected) — treated as a defect, not a retryable transport failure"
+        status_fail=1
+        ;;
     esac
   done <<<"$SPEC"
+
+  if [ "$probes_run" -eq 0 ]; then
+    echo "::error::no endpoint was probed — the spec matched nothing. Refusing a vacuous pass."
+    return 1
+  fi
 
   [ "$status_fail" -eq 1 ] && return 1
   [ "$transport_fail" -eq 1 ] && return 2

--- a/scripts/ci/preprod-response-suite.sh
+++ b/scripts/ci/preprod-response-suite.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# PREPROD response suite — runs every response probe, then decides ONE verdict.
+#
+# WHY THIS IS A SCRIPT AND NOT INLINE YAML
+# ----------------------------------------
+# The retry branch is where the contract can silently break. Review of PR #1316
+# caught exactly that: an aggregate "any failure → retry" made a WRONG STATUS
+# retryable, so `200,500,200` on the first pass followed by `200,200,200` on the
+# second ended the job green. The per-probe test suite could not see it because
+# the orchestration lived in YAML. It lives here now, and it is tested.
+#
+# VERDICT RULES
+# -------------
+#   * Every endpoint is probed even after a failure — the summary must show the
+#     FULL picture, never truncate at the first defect.
+#   * A WRONG STATUS anywhere (probe exit 1) is NEVER retried → exit 1.
+#     Re-running until an endpoint looks green is the silent fallback this gate
+#     exists to prevent.
+#   * TRANSPORT-ONLY failures (probe exit 2: connection refused / reset / DNS /
+#     timeout / http_code 000) MAY be retried ONCE, and only after the target is
+#     STABLY healthy again — the ~20s PREPROD container-restart blind window
+#     (diagnostic 2026-06-21). Same discipline as the "🎭 Run critical E2E tests"
+#     job: announced, bounded to one, and a still-failing re-run still blocks.
+#
+# Usage:  preprod-response-suite.sh [base_url]
+# Exit:   0 = all endpoints answered their expected status
+#         1 = wrong status somewhere (or the single re-run still failed)
+#         2 = transport failures that never re-stabilized
+#
+# Env overrides (used by the behavioural tests):
+#   PROBE_SPEC_FILE   endpoint list, one `path|label|budget_ms|expected` per line
+#   PROBE_BIN         path to preprod-response-probe.sh
+#   STABLE_NEEDED     consecutive healthy checks required   (default 4)
+#   STABLE_TRIES      health poll attempts                  (default 30)
+#   STABLE_SLEEP      seconds between health polls          (default 3)
+#   GITHUB_STEP_SUMMARY  markdown summary sink              (default /dev/null)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="${1:-${PREPROD_BASE_URL:-http://localhost:3200}}"
+PROBE="${PROBE_BIN:-$SCRIPT_DIR/preprod-response-probe.sh}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+STABLE_NEEDED="${STABLE_NEEDED:-4}"
+STABLE_TRIES="${STABLE_TRIES:-30}"
+STABLE_SLEEP="${STABLE_SLEEP:-3}"
+
+# Default endpoint list. `expected` defaults to 200; /pieces/catalogue is a legacy
+# route that 301s to `/` — verified on DEV and PREPROD — so its redirect is DECLARED
+# rather than silently timed as if it were a page. The probe never follows it, so
+# that row now fails if the route drifts either way (301→200 or 301→500).
+# ADR-024 R1 gamme perf gate (parity R2): backed by __gamme_page_cache (Phase 1) +
+# SSR cache-first read path (Phase 5a); cold-path/legacy ceiling 3000ms. Top 5 G1
+# gammes covering the bulk of indexed traffic.
+read -r -d '' DEFAULT_SPEC <<'SPEC' || true
+/health|/health|200|200
+/api/catalog/families|/api/catalog/families|1000|200
+/|Homepage|2000|200
+/pieces/catalogue|/pieces/catalogue (legacy 301→/)|2000|301
+/pieces/plaquette-de-frein-402/renault-140/megane-iii-140049/1-5-dci-100413.html|R2 Product Page|3000|200
+/pieces/plaquette-de-frein-402.html|R1 Gamme (plaquette-de-frein)|3000|200
+/pieces/disque-de-frein-82.html|R1 Gamme (disque-de-frein)|3000|200
+/pieces/filtre-a-huile-7.html|R1 Gamme (filtre-a-huile)|3000|200
+/pieces/filtre-a-air-8.html|R1 Gamme (filtre-a-air)|3000|200
+/pieces/courroie-de-distribution-306.html|R1 Gamme (courroie-distribution)|3000|200
+SPEC
+
+if [ -n "${PROBE_SPEC_FILE:-}" ]; then
+  SPEC=$(cat "$PROBE_SPEC_FILE")
+else
+  SPEC="$DEFAULT_SPEC"
+fi
+
+summary_header() {
+  echo "| Endpoint | Median (ms) | Budget (ms) | Status | HTTP |" >>"$SUMMARY"
+  echo "|----------|-------------|-------------|--------|------|" >>"$SUMMARY"
+}
+
+# Returns 0 (all good) · 1 (a wrong status occurred) · 2 (transport only).
+# A wrong status DOMINATES: if both kinds happen, the verdict is 1, never 2,
+# so a co-occurring transport blip can never make a real defect retryable.
+run_probes() {
+  local status_fail=0 transport_fail=0 rc path label budget expected
+  while IFS='|' read -r path label budget expected; do
+    [ -z "${path:-}" ] && continue
+    "$PROBE" "${BASE}${path}" "$label" "$budget" "${expected:-200}"
+    rc=$?
+    case "$rc" in
+      0) ;;
+      1) status_fail=1 ;;
+      *) transport_fail=1 ;;
+    esac
+  done <<<"$SPEC"
+
+  [ "$status_fail" -eq 1 ] && return 1
+  [ "$transport_fail" -eq 1 ] && return 2
+  return 0
+}
+
+echo "## ⏱️ PREPROD Response Times" >>"$SUMMARY"
+echo "" >>"$SUMMARY"
+summary_header
+
+run_probes
+verdict=$?
+
+if [ "$verdict" -eq 0 ]; then
+  echo "✅ All endpoints answered their expected status."
+  exit 0
+fi
+
+if [ "$verdict" -eq 1 ]; then
+  echo "::error::A wrong HTTP status is a real defect — never retried. Blocking."
+  exit 1
+fi
+
+# verdict == 2 → transport only. Wait for a STABLE target, then re-run ONCE.
+echo "::warning::Transport-only probe failures — checking for a transient PREPROD restart…"
+stable=0
+for _ in $(seq 1 "$STABLE_TRIES"); do
+  # Bounded on BOTH connect and total: without --max-time this loop can hang on a
+  # socket that is accepted but never answers, defeating the announced bound.
+  if curl -sf --connect-timeout 5 --max-time 10 "${BASE}/health" >/dev/null 2>&1; then
+    stable=$((stable + 1))
+    [ "$stable" -ge "$STABLE_NEEDED" ] && break
+  else
+    stable=0
+  fi
+  sleep "$STABLE_SLEEP"
+done
+
+if [ "$stable" -lt "$STABLE_NEEDED" ]; then
+  echo "::error::PREPROD did not re-stabilize — real failure, not a transient restart"
+  exit 2
+fi
+
+echo "PREPROD stably healthy again — re-running the response probes once"
+echo "" >>"$SUMMARY"
+echo "_(re-run after a transient PREPROD restart)_" >>"$SUMMARY"
+echo "" >>"$SUMMARY"
+summary_header
+
+run_probes
+verdict=$?
+if [ "$verdict" -ne 0 ]; then
+  echo "::error::Probes still failing after the single re-run — blocking."
+fi
+exit $verdict

--- a/scripts/ci/preprod-response-suite.test.mjs
+++ b/scripts/ci/preprod-response-suite.test.mjs
@@ -1,0 +1,256 @@
+/**
+ * Behavioural proof of the PREPROD response SUITE (preprod-response-suite.sh).
+ *
+ * The per-probe suite (preprod-response-probe.test.mjs) proves one endpoint's
+ * verdict. It cannot see the ORCHESTRATION defect that review of PR #1316 caught:
+ * an aggregate "any failure → retry" made a WRONG STATUS retryable, so a first
+ * pass of `200,500,200` followed by a clean second pass ended the job GREEN — the
+ * exact silent fallback the gate exists to prevent.
+ *
+ * These tests therefore drive the whole suite against a real local HTTP server and
+ * pin the retry boundary:
+ *   - a wrong status is NEVER retried, even when the endpoint self-heals;
+ *   - a transport failure MAY be retried once, and only after a stable target;
+ *   - when both happen, the wrong status dominates.
+ *
+ * Run: npm run test:preprod-response-suite
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SUITE_SH = join(SCRIPT_DIR, "preprod-response-suite.sh");
+
+// Fast stability polling: the real defaults (4 × 3s) would make each retry test
+// wait 12s. The VALUES are not what is under test — the retry BOUNDARY is.
+const FAST_STABILITY = { STABLE_NEEDED: "2", STABLE_SLEEP: "1", STABLE_TRIES: "15" };
+
+/** Starts a stub app. `routes` maps a path to a handler(res, hitIndex). */
+async function startServer(routes, port = 0) {
+  const hits = new Map();
+  const server = createServer((req, res) => {
+    const path = req.url.split("?")[0];
+    const n = hits.get(path) ?? 0;
+    hits.set(path, n + 1);
+    const handler = routes[path];
+    if (!handler) return res.writeHead(404).end();
+    return handler(res, n);
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port, close: () => new Promise((r) => server.close(r)) };
+}
+
+const ok = (res) => res.writeHead(200, { "Content-Type": "text/html" }).end("ok");
+const boom = (res) => res.writeHead(500).end("err");
+/** 500 for the first `n` hits, then 200 — an endpoint that "self-heals". */
+const flipAfter = (n) => (res, hit) => (hit < n ? boom(res) : ok(res));
+const hang = () => {};
+
+function specFile(lines) {
+  const dir = mkdtempSync(join(tmpdir(), "preprod-suite-spec-"));
+  const f = join(dir, "spec.txt");
+  writeFileSync(f, lines.join("\n") + "\n");
+  return f;
+}
+
+async function runSuite(port, spec, env = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "preprod-suite-"));
+  const summary = join(dir, "summary.md");
+  writeFileSync(summary, "");
+  let code = 0;
+  let stdout = "";
+  try {
+    ({ stdout } = await execFileAsync("bash", [SUITE_SH, `http://127.0.0.1:${port}`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: summary,
+        PROBE_SPEC_FILE: spec,
+        ...FAST_STABILITY,
+        ...env,
+      },
+    }));
+  } catch (e) {
+    code = e.code ?? 1;
+    stdout = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  return { code, stdout, summary: readFileSync(summary, "utf8") };
+}
+
+describe("preprod-response-suite.sh — a wrong status is never retried", () => {
+  test("exit 1 when an endpoint self-heals 500→200: NO retry, no stability wait", async () => {
+    // 3 probes per pass. flipAfter(3) ⇒ pass 1 sees 500,500,500 and a hypothetical
+    // pass 2 would see 200,200,200 — the precise scenario that used to end green.
+    const app = await startServer({ "/health": ok, "/flip": flipAfter(3) });
+    try {
+      const spec = specFile(["/health|/health|2000|200", "/flip|Flipper|2000|200"]);
+      const started = Date.now();
+      const { code, stdout } = await runSuite(app.port, spec);
+
+      assert.equal(code, 1, `a wrong status must block, got ${code}\n${stdout}`);
+      assert.match(stdout, /wrong HTTP status is a real defect — never retried/);
+      assert.doesNotMatch(stdout, /re-running the response probes/, "must NOT re-run");
+      assert.doesNotMatch(stdout, /transient PREPROD restart/, "must NOT wait for stability");
+      assert.ok(Date.now() - started < 5000, "must fail fast, not sit in the stability loop");
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("exit 1 when a wrong status and a transport failure co-occur (status dominates)", async () => {
+    const app = await startServer({ "/health": ok, "/boom": boom, "/hang": hang });
+    try {
+      const spec = specFile([
+        "/health|/health|2000|200",
+        "/boom|Boom|2000|200",
+        "/hang|Hang|2000|200",
+      ]);
+      const { code, stdout } = await runSuite(app.port, spec, { PROBE_MAX_TIME: "1" });
+      assert.equal(code, 1, "a co-occurring transport blip must not make a defect retryable");
+      assert.doesNotMatch(stdout, /re-running the response probes/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("every endpoint is still probed after a failure (summary is complete)", async () => {
+    const app = await startServer({ "/health": ok, "/boom": boom, "/late": ok });
+    try {
+      const spec = specFile([
+        "/health|/health|2000|200",
+        "/boom|Boom|2000|200",
+        "/late|Late|2000|200",
+      ]);
+      const { code, summary } = await runSuite(app.port, spec);
+      assert.equal(code, 1);
+      assert.match(summary, /\| Late \|/, "probing must not truncate at the first defect");
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("preprod-response-suite.sh — a transport failure may be retried once", () => {
+  test("exit 0 when the target is down, then comes back and answers 200", async () => {
+    // Grab a port, release it: pass 1 hits connection-refused (transport, exit 2),
+    // the suite polls /health, and the app appears mid-loop.
+    const probe = await startServer({});
+    const port = probe.port;
+    await probe.close();
+
+    const spec = specFile(["/health|/health|2000|200", "/page|Page|2000|200"]);
+    const suite = runSuite(port, spec);
+
+    let app;
+    const boot = new Promise((resolve) =>
+      setTimeout(async () => {
+        app = await startServer({ "/health": ok, "/page": ok }, port);
+        resolve();
+      }, 1500),
+    );
+
+    const [{ code, stdout }] = await Promise.all([suite, boot]);
+    try {
+      assert.equal(code, 0, `a recovered transport failure may pass, got ${code}\n${stdout}`);
+      assert.match(stdout, /transient PREPROD restart/);
+      assert.match(stdout, /re-running the response probes once/);
+    } finally {
+      await app?.close();
+    }
+  });
+
+  test("exit 2 when the target never re-stabilizes", async () => {
+    const probe = await startServer({});
+    const port = probe.port;
+    await probe.close();
+    const spec = specFile(["/health|/health|2000|200"]);
+    const { code, stdout } = await runSuite(port, spec, { STABLE_TRIES: "2" });
+    assert.equal(code, 2, "an unreachable target is a transport verdict, not a status one");
+    assert.match(stdout, /did not re-stabilize/);
+  });
+
+  test("exit 1 when the re-run still returns a wrong status", async () => {
+    // Down at first (transport → retry allowed), then permanently 500.
+    const probe = await startServer({});
+    const port = probe.port;
+    await probe.close();
+
+    const spec = specFile(["/health|/health|2000|200", "/page|Page|2000|200"]);
+    const suite = runSuite(port, spec);
+
+    let app;
+    const boot = new Promise((resolve) =>
+      setTimeout(async () => {
+        app = await startServer({ "/health": ok, "/page": boom }, port);
+        resolve();
+      }, 1500),
+    );
+
+    const [{ code, stdout }] = await Promise.all([suite, boot]);
+    try {
+      assert.equal(code, 1, "the single re-run must not rescue a real defect");
+      assert.match(stdout, /still failing after the single re-run/);
+    } finally {
+      await app?.close();
+    }
+  });
+});
+
+describe("preprod-response-suite.sh — happy path and static guarantees", () => {
+  test("exit 0 when every endpoint answers its expected status (200 and a declared 301)", async () => {
+    const app = await startServer({
+      "/health": ok,
+      "/page": ok,
+      "/legacy": (res) => res.writeHead(301, { Location: "/" }).end(),
+    });
+    try {
+      const spec = specFile([
+        "/health|/health|2000|200",
+        "/page|Page|2000|200",
+        "/legacy|Legacy (declared 301)|2000|301",
+      ]);
+      const { code, summary } = await runSuite(app.port, spec);
+      assert.equal(code, 0);
+      assert.match(summary, /\| ✅ \| 301 \|/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  const src = readFileSync(SUITE_SH, "utf8");
+  const code = src
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("#"))
+    .join("\n");
+
+  test("the health-stability poll is bounded on connect AND total time", () => {
+    // Without --max-time the announced bound is a lie: a socket that is accepted
+    // but never answers hangs the loop indefinitely.
+    const health = code.match(/curl[^\n]*\/health[^\n]*/g) || [];
+    assert.ok(health.length > 0, "expected a health poll");
+    for (const line of health) {
+      assert.match(line, /--connect-timeout\s+\d+/, `missing --connect-timeout: ${line}`);
+      assert.match(line, /--max-time\s+\d+/, `missing --max-time: ${line}`);
+    }
+  });
+
+  test("the retry is bounded to exactly one re-run", () => {
+    const reruns = code.match(/^\s*run_probes\s*$/gm) || [];
+    assert.equal(reruns.length, 2, "exactly one initial pass and one re-run");
+  });
+
+  test("the default spec pins the R1 gamme page the closure verification needed", () => {
+    assert.match(code, /\/pieces\/filtre-a-huile-7\.html\|R1 Gamme \(filtre-a-huile\)\|3000\|200/);
+  });
+});

--- a/scripts/ci/preprod-response-suite.test.mjs
+++ b/scripts/ci/preprod-response-suite.test.mjs
@@ -33,15 +33,23 @@ const SUITE_SH = join(SCRIPT_DIR, "preprod-response-suite.sh");
 // wait 12s. The VALUES are not what is under test — the retry BOUNDARY is.
 const FAST_STABILITY = { STABLE_NEEDED: "2", STABLE_SLEEP: "1", STABLE_TRIES: "15" };
 
-/** Starts a stub app. `routes` maps a path to a handler(res, hitIndex). */
+/**
+ * Starts a stub app. `routes` maps a path to a handler(res, hitIndex).
+ *
+ * The routing table is a Map, not a plain object: `req.url` is attacker-controlled,
+ * so `routes[path]` would resolve inherited members (`constructor`, `toString`, …)
+ * and then invoke them — CodeQL js/unvalidated-dynamic-method-call, high severity.
+ * A Map has no prototype chain to walk, so only declared routes can ever dispatch.
+ */
 async function startServer(routes, port = 0) {
+  const table = new Map(Object.entries(routes));
   const hits = new Map();
   const server = createServer((req, res) => {
     const path = req.url.split("?")[0];
     const n = hits.get(path) ?? 0;
     hits.set(path, n + 1);
-    const handler = routes[path];
-    if (!handler) return res.writeHead(404).end();
+    const handler = table.get(path);
+    if (typeof handler !== "function") return res.writeHead(404).end();
     return handler(res, n);
   });
   await new Promise((resolve, reject) => {

--- a/scripts/ci/preprod-response-suite.test.mjs
+++ b/scripts/ci/preprod-response-suite.test.mjs
@@ -132,6 +132,48 @@ describe("preprod-response-suite.sh — a wrong status is never retried", () => 
     }
   });
 
+  test("exit 1, no retry, when a probe sees 500 → connection reset → 200", async () => {
+    // The residual masking path: the 500 is real, the reset lands mid-sequence.
+    // If the probe reports "transport", the suite re-runs, the endpoint is warm,
+    // and the defect ships green. End-to-end proof that it cannot.
+    const app = await startServer({
+      "/health": ok,
+      "/mixed": (res, hit) => {
+        if (hit === 0) return boom(res);
+        if (hit === 1) return res.socket.destroy();
+        return ok(res);
+      },
+    });
+    try {
+      const spec = specFile(["/health|/health|2000|200", "/mixed|Mixed|2000|200"]);
+      const { code, stdout } = await runSuite(app.port, spec);
+      assert.equal(code, 1, `an observed 500 must dominate a later reset, got ${code}\n${stdout}`);
+      assert.doesNotMatch(stdout, /re-running the response probes/, "must NOT re-run");
+      assert.doesNotMatch(stdout, /transient PREPROD restart/, "must NOT wait for stability");
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("an unexpected probe exit code is a defect, never classified as transport", async () => {
+    // 127 = probe not executable / not found. It proves NOTHING about the
+    // endpoint, so granting it the transport re-run would be a free green.
+    const dir = mkdtempSync(join(tmpdir(), "preprod-suite-badprobe-"));
+    const stub = join(dir, "exit127.sh");
+    writeFileSync(stub, "#!/usr/bin/env bash\nexit 127\n", { mode: 0o755 });
+
+    const app = await startServer({ "/health": ok });
+    try {
+      const spec = specFile(["/health|/health|2000|200"]);
+      const { code, stdout } = await runSuite(app.port, spec, { PROBE_BIN: stub });
+      assert.equal(code, 1, "an unexpected exit code must block, not retry");
+      assert.match(stdout, /exited 127 \(unexpected\)/);
+      assert.doesNotMatch(stdout, /re-running the response probes/);
+    } finally {
+      await app.close();
+    }
+  });
+
   test("every endpoint is still probed after a failure (summary is complete)", async () => {
     const app = await startServer({ "/health": ok, "/boom": boom, "/late": ok });
     try {
@@ -211,6 +253,31 @@ describe("preprod-response-suite.sh — a transport failure may be retried once"
       assert.match(stdout, /still failing after the single re-run/);
     } finally {
       await app?.close();
+    }
+  });
+});
+
+describe("preprod-response-suite.sh — a run that probes nothing must fail", () => {
+  test("exit 1 when PROBE_SPEC_FILE points at a missing file", async () => {
+    const app = await startServer({ "/health": ok });
+    try {
+      const missing = join(mkdtempSync(join(tmpdir(), "preprod-suite-nospec-")), "absent.txt");
+      const { code, stdout } = await runSuite(app.port, missing);
+      assert.equal(code, 1, "a missing spec must fail, not silently probe zero endpoints");
+      assert.match(stdout, /missing or unreadable/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("exit 1 when PROBE_SPEC_FILE is empty (or whitespace only)", async () => {
+    const app = await startServer({ "/health": ok });
+    try {
+      const { code, stdout } = await runSuite(app.port, specFile(["", "   "]));
+      assert.equal(code, 1, "an empty spec must fail — a vacuous green proves nothing");
+      assert.match(stdout, /is empty/);
+    } finally {
+      await app.close();
     }
   });
 });


### PR DESCRIPTION
## Le gate mesurait le temps et n'assertait rien

`⏱️ Response Time Baseline` (PREPROD) exécutait :

```bash
curl -s -o /dev/null -w "%{time_total}" "$url" --max-time 30
```

Aucune assertion. **Une page répondant 500 en 20 ms produisait une ligne verte ✅.**

Trouvé en vérifiant #1297 sur PREPROD : le step sonde bien `/pieces/filtre-a-huile-7.html`, il avait donc l'apparence d'une preuve que la page R1 était servie — sans pouvoir distinguer 200 de 500. Le gate perf R1 gamme (ADR-024) était aveugle sur la surface exacte qu'il existe pour protéger.

## Contrat appliqué

| Observation | Verdict |
|---|---|
| statut ≠ attendu | ❌ **BLOQUANT** |
| erreur réseau / DNS / connexion coupée / timeout / `000` | ❌ **BLOQUANT** |
| redirection (301/302/307/308) sur URL canonique | ❌ **BLOQUANT** — jamais suivie (aucun `-L`) |
| statut OK mais latence hors budget | ⚠️ warning **non bloquant** (inchangé) |

Les **trois** sondes sont contrôlées, pas seulement une : un endpoint qui bat `200,500,200` échoue au lieu d'être moyenné en vert. Statut et timing viennent du **même** `curl` (`%{http_code} %{time_total}`), ils ne peuvent pas diverger. Colonne **HTTP** ajoutée au résumé GitHub.

## Testé, au lieu d'être livré non testé

La logique quitte le YAML inline pour [`scripts/ci/preprod-response-probe.sh`](scripts/ci/preprod-response-probe.sh) — même leçon que le gate SSR PROD, qui n'avait aucun test et a false-failed lors de son tout premier passage en PROD (incident 2026-07-19). Les tests exécutent la sonde contre un **vrai serveur HTTP local**, pas un `curl` stubbé.

**Preuve RED→GREEN** — en neutralisant l'assertion de statut (simulation de l'ancien gate), exactement les 5 tests discriminants échouent ; restaurée, 13/13 passent :

```
✖ FAILS on a fast 500 — the exact blind spot (was a green ✅ row before)
✖ FAILS on a fast 301 and does NOT follow it
✖ FAILS on a fast 302 and does NOT follow it
✖ FAILS when only ONE of the three probes is bad (no averaging away a flap)
✖ FAILS when a declared-301 URL starts answering 200 (contract drift both ways)
```

Couverture : 200 rapide ✅ · 500 rapide ❌ · 301/302 ❌ · connexion refusée ❌ · timeout ❌ · endpoint instable ❌ · 200 lent ⚠️ non bloquant · plus des assertions statiques (jamais de `-L`, statut+timing dans le même curl, 5 colonnes dans le résumé).

## ⚠️ `/pieces/catalogue` est un 301 vers `/` — décision owner

Vérifié sur **DEV et PREPROD** : le step API Smoke imprime `⚠️ /pieces/catalogue -> 301` depuis toujours, et la ligne du baseline la chronométrait (~11 ms) comme si c'était une page.

Un 200 strict sur les 10 endpoints aurait donc mis `main` au rouge immédiatement. Son 301 est **déclaré explicitement** plutôt que subi : la sonde ne suit pas la redirection, et la ligne échoue désormais si la route dérive **dans un sens comme dans l'autre** (301→200 ou 301→500). Les 9 autres endpoints sont en **200 strict**.

**Repointer cette sonde vers une vraie page, ou la retirer, est votre décision** — hors périmètre de cette PR.

## Résilience restart

Même discipline que le job `🎭 Run critical E2E tests` voisin : si des sondes échouent, on attend que PREPROD soit **stablement** healthy (4 checks consécutifs) puis on rejoue **une seule** fois, annoncé par un `::warning::`. La fenêtre aveugle de ~20 s au restart du container (diagnostic 2026-06-21) ne doit pas transformer un blip infra en `main` rouge — et un échec réel bloque toujours. Aucun repli silencieux.

## Vérification

Répétition end-to-end du step contre un runtime applicatif réel : **10/10 endpoints, statuts assertés, verdict 0**.

```
✅ /health — HTTP 200, 4ms          ✅ R2 Product Page — HTTP 200, 104ms
✅ /api/catalog/families — HTTP 200 ✅ R1 Gamme (plaquette-de-frein) — HTTP 200, 412ms
✅ Homepage — HTTP 200, 96ms        ✅ R1 Gamme (disque-de-frein) — HTTP 200, 397ms
✅ /pieces/catalogue — HTTP 301, 9ms ✅ R1 Gamme (filtre-a-huile) — HTTP 200, 421ms
                                    ✅ R1 Gamme (filtre-a-air) — HTTP 200, 445ms
                                    ✅ R1 Gamme (courroie-distribution) — HTTP 200, 295ms
```

**Aucun changement applicatif, DB, SEO, route, contenu ni PROD.** 5 fichiers : les 2 workflows, `package.json` (script npm), la sonde et son test.

## Suite

Une fois fusionnée, le prochain déploiement PREPROD prouvera explicitement `/pieces/filtre-a-huile-7.html → HTTP 200` — ce que la vérification post-#1297 n'a pas pu établir (boot Nest PASS, statut de la page non prouvé).

## 🔁 Correction de revue — le retry pouvait masquer un mauvais statut

Constat exact et fondé. Au niveau du script seul `200,500,200` échouait bien, mais l'orchestration agrégeait « tout échec → retry » : première série `200,500,200` → seconde `200,200,200` → **job vert**. L'affirmation « tout mauvais statut est bloquant » était donc fausse après orchestration, et les 13 tests ne pouvaient pas le voir — la branche de retry vivait en YAML inline, la faute même que cette PR corrige ailleurs.

**Codes de sortie de la sonde, désormais distincts :**

| Code | Signification | Rejouable ? |
|---|---|---|
| `0` | statut attendu partout | — |
| `1` | **mauvais statut** (défaut réel, redirection incluse) | ❌ **jamais** |
| `2` | **transport** : réseau / DNS / reset / timeout / `000` — aucun statut observé | ✅ une seule fois |

**L'orchestration quitte le YAML** pour [`scripts/ci/preprod-response-suite.sh`](scripts/ci/preprod-response-suite.sh), donc elle est testée :

- un mauvais statut **domine** — si les deux types surviennent, verdict `1`, jamais `2` ;
- tous les endpoints sont sondés même après un échec (résumé complet, aucune troncature) ;
- retry borné à **un** re-run, annoncé, et un re-run encore en échec bloque ;
- boucle de santé bornée sur les **deux** axes (`--connect-timeout 5 --max-time 10`) — sans `--max-time`, une socket acceptée mais muette suspendait indéfiniment une boucle annoncée comme bornée.

**10 tests d'orchestration ajoutés**, dont les deux exigés :

```
✔ exit 1 when an endpoint self-heals 500→200: NO retry, no stability wait
✔ exit 0 when the target is down, then comes back and answers 200
✔ exit 1 when a wrong status and a transport failure co-occur (status dominates)
✔ exit 1 when the re-run still returns a wrong status
✔ exit 2 when the target never re-stabilizes
```

Le premier vérifie aussi le **temps d'exécution** (< 5 s) : le job doit échouer vite, pas s'asseoir dans la boucle de stabilité.

**Preuve RED→GREEN** — en réintroduisant l'agrégat fautif, 4 tests tombent, dont le scénario exact signalé en revue ; restauré, 10/10. Assertions de la sonde durcies sur les codes exacts : 13/13. Total **23/23**.

Répétition end-to-end de la suite réelle contre un runtime applicatif : **10/10 endpoints, verdict 0**.

### `/pieces/catalogue`

Contrat explicite `301 → /` **conservé**, comme recommandé : la couverture reste, le libellé « legacy 301 » rend l'exception honnête, et la ligne échoue si la route dérive dans un sens comme dans l'autre.

---

## DoD self-evaluation

- [x] DoD1 — Tests verts: 23/23 (`test:preprod-response-probe` 13/13 + `test:preprod-response-suite` 10/10), les deux exécutés sur le runner CI dans `🛡️ Audit gates (Phase 0)`; aucun `.only`/`.skip` ajouté; RED→GREEN prouvé dans les deux sens (neutralisation de l'assertion de statut → 5 tests tombent; réintroduction de l'agrégat fautif → 4 tests tombent).
- [x] DoD2 — Ownership: owner = @Fafa (automecanik.seo@gmail.com); revue humaine faite (REQUEST_CHANGES traité ici); pas d'auto-merge.
- [x] DoD3 — Rollback: `git revert` du merge — réversibilité **immédiate**; CI-only (2 workflows, `package.json`, 2 scripts + 2 tests), aucune migration DB/donnée, aucun artefact runtime.
- [x] DoD4 — Observabilité: le gate **gagne** de l'observabilité (colonne HTTP au résumé, statut réel par endpoint, `::warning::` pour la latence, `::error::` distinct pour statut vs transport). Aucun chemin aveugle ajouté; le retry est annoncé, jamais silencieux.
- [x] DoD5 — Drift zéro: aucune migration, aucun changement de schéma/registry/contrat; 7 fichiers, tous CI.
- [x] DoD6 — Docs: rationale complète en en-tête des deux scripts (incident source + raison de chaque règle) + commentaires du step `ci.yml` + ce corps de PR. Aucune doc externe concernée.
- [x] DoD7 — Monitoring: watcher = @Fafa; fenêtre = premier déploiement PREPROD post-merge; signal attendu = ligne `R1 Gamme (filtre-a-huile) — HTTP 200` dans le résumé; abort = revert si le gate rougit sur un faux positif transport répété.
- [x] DoD8 — No TODO unresolved: 0 TODO/FIXME/HACK ajouté (vérifié sur le diff).
- [x] DoD9 — No silent skip: c'est l'objet même de la PR — un mauvais statut n'est plus jamais rejoué ni masqué; le retry transport est borné à un, annoncé, et échoue encore si le problème persiste; `/pieces/catalogue` a un contrat **déclaré** plutôt qu'un ✅ implicite.

---

## Runtime verification

- **Surface:** pipeline (CI gate) — aucune surface applicative
- **Environment:** DEV:3000 (répétition end-to-end de la suite réelle) + runner CI (les 23 tests)
- **Verdict:** PASS
- **Evidence:** suite réelle contre un runtime applicatif → 10/10 endpoints, verdict 0, `/pieces/catalogue` asserté 301, les 5 R1 assertées 200 (272–412 ms); job `🛡️ Audit gates (Phase 0)` → 23/23 sur le runner
- **GATE 2 (post-merge, env cible) dû:** yes — premier déploiement PREPROD post-merge, qui doit imprimer `/pieces/filtre-a-huile-7.html → HTTP 200`
- **Owner gate required:** no (aucun changement applicatif/DB/SEO/PROD)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

