### PR TITLE
docs(audit): record the TS7 PARKED decision and its exact reopening trigger

### DIFF
--- a/audit/dependencies/ts7-shadow-parity-2026-07-26.md
+++ b/audit/dependencies/ts7-shadow-parity-2026-07-26.md
@@ -56,8 +56,9 @@ runs these in parallel with content caching, and `ci.yml` additionally restores
 `.tsbuildinfo` across runs.
 
 Be precise about `--affected`: it is appended **only on `pull_request` events**. Pushes
-to `main` and `dev` run a **full** typecheck — [`ci.yml:157-167`](../../.github/workflows/ci.yml)
-narrows on PRs deliberately and never on the pre-deploy gate. So `--affected` is not what
+to `main` and `dev` run a **full** typecheck — see the `🔎 Type check` step of
+[`ci.yml`](../../.github/workflows/ci.yml) (referenced by step name, not line number, which
+will drift): it narrows on PRs deliberately and never on the pre-deploy gate. So `--affected` is not what
 makes the aggregate misleading on the push path; Turbo parallelism, content caching and
 the restored `.tsbuildinfo` are. The conclusion is unchanged either way.
 
@@ -244,18 +245,33 @@ Operationally, and until the reopening trigger below fires:
 > `typescript@7.x`**, permitting a full upgrade of the TypeScript/ESLint cluster.
 
 **A range that merely opens to TypeScript 6.x unblocks nothing.** Do not settle for
-"the peer moved past `<6.1.0`" — that is the trap. Verified 2026-07-27:
+"the peer moved past `<6.1.0`" — that is the trap. Verified 2026-07-29:
 `typescript-eslint@8.65.0` (latest stable) still declares
 `typescript: ">=4.8.4 <6.1.0"`, and central rule #6 of the `peer_dependency_cluster`
 forbids upgrading the cluster partially.
 
-### Sequence at reopening, in this order
+### Sequence at reopening — `nodenext` FIRST, cluster upgrade LAST
 
-Grouped cluster upgrade → `npm ci` → typed lint → harness → `nodenext` migration **per
-project** (smallest blast radius first: `seo-url-contract` 3 files → `domain-commerce` 6
-→ … → `backend` 1389; `packages/registry` is already clean at the resolution level) →
-resolution traces → emit → consumer tests → PREPROD. Expect projects to move
-`BLOCKED_CONFIG` → `PARITY` as each step lands.
+**The order matters and the intuitive one is wrong.** Upgrading the cluster first — i.e.
+letting TS7 become the repo compiler before the migration — would immediately produce the
+**8 `TS5108` errors** documented above. The repository could not stay green between steps.
+So TS7 enters the lockfile only once its configuration blockers are already gone:
+
+1. Verify a **stable** `typescript-eslint` explicitly supports `typescript@7.x` (see the
+   trigger above — a 6.x-only opening does not qualify).
+2. Re-run the harness to refresh the baseline.
+3. **Keeping TS6 as the repo compiler**, migrate to `nodenext` **project by project**,
+   smallest blast radius first (`seo-url-contract` 3 files → `domain-commerce` 6 → … →
+   `backend` 1389; `packages/registry` is already clean at the resolution level).
+   **Do not flip the shared `node-cjs-legacy.json`** — migrate each project on its own.
+4. After **each** project: TS7 harness, resolution traces, emit, consumer tests.
+5. Once every `BLOCKED_CONFIG` is eliminated, upgrade the **whole** TypeScript/ESLint
+   cluster in a **single atomic PR** → `npm ci` → typed lint → full typecheck / build /
+   tests → PREPROD.
+
+What this buys: the `nodenext` migrations stay green under TS6; the harness proves
+`BLOCKED_CONFIG` → `PARITY` incrementally; TS7 lands only after its blockers are cleared;
+and central rule #6 (no partial cluster upgrade) is respected throughout.
 
 The node10 debt stays on the books, unpaid: it does not justify diverting time now from
 commerce-loop-v1, the runtime truths, Web Vitals, and the content pipeline.

--- a/audit/dependencies/ts7-shadow-parity-2026-07-26.md
+++ b/audit/dependencies/ts7-shadow-parity-2026-07-26.md
@@ -53,9 +53,16 @@ error TS5108: Option 'moduleResolution=node10' has been removed.
 
 **Do not read the 45 s aggregate saving as a CI or dev saving.** `turbo typecheck`
 runs these in parallel with content caching, and `ci.yml` additionally restores
-`.tsbuildinfo` across runs and narrows to `--affected` on PRs. The honest reading is
-per-project cold latency, dominated by `frontend` (24.0 s → 2.2 s) and `backend`
-(19.8 s → 2.0 s).
+`.tsbuildinfo` across runs.
+
+Be precise about `--affected`: it is appended **only on `pull_request` events**. Pushes
+to `main` and `dev` run a **full** typecheck — [`ci.yml:157-167`](../../.github/workflows/ci.yml)
+narrows on PRs deliberately and never on the pre-deploy gate. So `--affected` is not what
+makes the aggregate misleading on the push path; Turbo parallelism, content caching and
+the restored `.tsbuildinfo` are. The conclusion is unchanged either way.
+
+The honest reading is per-project cold latency, dominated by `frontend` (24.0 s → 2.2 s)
+and `backend` (19.8 s → 2.0 s).
 
 ## Finding 1 — removing the node10 line is a compatibility fix, not a migration
 
@@ -131,8 +138,9 @@ That is not "inert", so it fails the bar this removal was allowed under.
 
 **Consequence.** Deleting the line trades a loud, correct TS7 error for a silent
 resolution change. The right fix is an explicit, supported `moduleResolution` — i.e.
-the real `nodenext` migration — not omission. The 4–7 day estimate stands; the shortcut
-does not exist.
+the real `nodenext` migration — not omission. The shortcut does not exist. The 4–7 day
+figure is a **planning estimate, not a measured duration** — no pilot has been run, so
+it must not be cited as an observed number.
 
 Remaining matrix items (`tsc-alias`, `node dist/main` boot, Jest DI, the 29 dynamic
 `import()` sites, Docker + PREPROD smoke) were **not run**: the decision rule already
@@ -217,19 +225,40 @@ and both are exactly what a resolution-mode change can flip. Suppressing them co
 turn a real difference into a false PARITY. Neither occurs in this repo today (verified
 across all 12 projects on both compilers), so including them costs nothing.
 
-## Next actions (owner-gated)
+## Decision — PARKED (owner, 2026-07-27)
 
-1. **Do not remove the two lines.** The matrix returned NO-GO (see Finding 1): `.js` is
-   byte-identical but backend module resolution changes on 27 specifiers, with 6 new
-   ESM declaration surfaces on a CommonJS backend.
-2. The unblock is the real migration to an explicit supported `moduleResolution`
-   (`nodenext`, with `module: nodenext`), scoped per project, smallest blast radius
-   first (`seo-url-contract` 3 files → `domain-commerce` 6 → … → `backend` 1389).
-   `packages/registry` is already clean at the resolution level, which de-risks the
-   consumer previously assumed hardest.
-3. Re-run `npm run audit:ts7-shadow` after each step; expect projects to move
-   `BLOCKED_CONFIG` → `PARITY`.
-4. Leave TS7 out-of-band until `typescript-eslint` opens its peer range.
+**TS7 is parked. No action is open.** Recommendation accepted on the reasoning that the
+blocker is external (Finding 3), the measured gain is a cold sequential benchmark rather
+than a CI saving, and TS7 appears in none of the five canonical priorities.
+
+Operationally, and until the reopening trigger below fires:
+
+- **Do not** modify `packages/typescript-config/node-cjs-legacy.json`.
+- **Do not** start the `nodenext` pilot on `packages/seo-url-contract`.
+- **Do not** add TS7 to the repository (no dependency, no lockfile entry).
+- Keep **only** the observation harness (`npm run audit:ts7-shadow`).
+
+### Reopening trigger — state it exactly
+
+> A **stable** `typescript-eslint` release whose peer range **explicitly includes
+> `typescript@7.x`**, permitting a full upgrade of the TypeScript/ESLint cluster.
+
+**A range that merely opens to TypeScript 6.x unblocks nothing.** Do not settle for
+"the peer moved past `<6.1.0`" — that is the trap. Verified 2026-07-27:
+`typescript-eslint@8.65.0` (latest stable) still declares
+`typescript: ">=4.8.4 <6.1.0"`, and central rule #6 of the `peer_dependency_cluster`
+forbids upgrading the cluster partially.
+
+### Sequence at reopening, in this order
+
+Grouped cluster upgrade → `npm ci` → typed lint → harness → `nodenext` migration **per
+project** (smallest blast radius first: `seo-url-contract` 3 files → `domain-commerce` 6
+→ … → `backend` 1389; `packages/registry` is already clean at the resolution level) →
+resolution traces → emit → consumer tests → PREPROD. Expect projects to move
+`BLOCKED_CONFIG` → `PARITY` as each step lands.
+
+The node10 debt stays on the books, unpaid: it does not justify diverting time now from
+commerce-loop-v1, the runtime truths, Web Vitals, and the content pipeline.
 
 Editing `packages/typescript-config/node-cjs-legacy.json` invalidates every turbo cache
 entry (it is in `turbo.json` `globalDependencies`) and the CI `.tsbuildinfo` cache key —


### PR DESCRIPTION
Owner decision 2026-07-27: **TS7 is PARKED.** No `nodenext` pilot, no change to
`node-cjs-legacy.json`, no TS7 dependency in the repo — keep only the observation
harness (`npm run audit:ts7-shadow`, merged in #1318).

This records that decision in the audit dossier itself, which is where the next agent
will look, and tightens three statements that were imprecise enough to mislead.

### 1. The reopening trigger was too loose

It read *"Leave TS7 out-of-band until `typescript-eslint` opens its peer range."*
A range that merely opens to TypeScript **6.x** would satisfy that sentence while
unblocking nothing. Now stated exactly:

> A **stable** `typescript-eslint` release whose peer range **explicitly includes
> `typescript@7.x`**, permitting a full upgrade of the TypeScript/ESLint cluster.

Re-verified today against npm: `typescript-eslint@8.65.0` (latest stable) still declares
`typescript: ">=4.8.4 <6.1.0"`. Central rule #6 of the `peer_dependency_cluster` forbids
upgrading the cluster partially.

### 2. The 4–7 day figure read as measured

*"The 4–7 day estimate stands"* invited it to be quoted as an observed duration. No pilot
has been run. Marked explicitly as a **planning estimate, not a measured duration**.

### 3. `--affected` was stated loosely

It is appended **only on `pull_request` events**; pushes to `main` and `dev` run a **full**
typecheck — `ci.yml:157-167`, whose own comment says *"never narrow the pre-deploy gate"*.
So `--affected` is not what makes the 50 s → 5.4 s aggregate misleading on the push path;
Turbo parallelism, content caching and the restored `.tsbuildinfo` are. **The conclusion is
unchanged** — the aggregate is still a cold sequential benchmark, not a CI saving.

Also adds the reopening sequence (grouped cluster upgrade → `npm ci` → typed lint → harness
→ per-project `nodenext` → resolution traces → emit → consumer tests → PREPROD) and states
that the node10 debt stays on the books, unpaid, because it does not justify diverting time
from commerce-loop-v1, the runtime truths, Web Vitals and the content pipeline.

### Scope

Documentation only — one file. No config change, no dependency, no lockfile mutation, no
runtime delta. Per the standing rule, this carries no PROD promotion of its own and rides
with the next release that has a runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)