### PR TITLE
fix(frontend): defer sort/view/navigate state updates to unblock mobile INP on /pieces/*

### DIFF
--- a/frontend/app/components/pieces/PiecesGroupedDisplay.tsx
+++ b/frontend/app/components/pieces/PiecesGroupedDisplay.tsx
@@ -11,7 +11,7 @@
  */
 
 import { ChevronDown } from "lucide-react";
-import { useState, useCallback, memo } from "react";
+import { useState, useCallback, useMemo, memo } from "react";
 import {
   type PieceData,
   type PiecesFilters,
@@ -140,22 +140,27 @@ export const PiecesGroupedDisplay = memo(function PiecesGroupedDisplay({
     setVisibleCounts((prev) => ({ ...prev, [groupKey]: totalCount }));
   }, []);
 
-  // Filtrer les groupes par position si un filtre est actif
-  const filteredGroups = groupedPieces.filter((group) => {
-    if (!activeFilters.position || activeFilters.position === "all") {
-      return true;
-    }
-    return group.filtre_side === activeFilters.position;
-  });
+  // ⚡ Mémoïser le filtrage/tri par groupe : ne recalculer que si groupedPieces
+  // ou activeFilters changent, pas à chaque re-render déclenché par la pagination
+  // (handleLoadMore), la sélection (selectedPieces) ou le changement de vue (INP fix)
+  const filteredGroups = useMemo(() => {
+    return groupedPieces
+      .filter((group) => {
+        if (!activeFilters.position || activeFilters.position === "all") {
+          return true;
+        }
+        return group.filtre_side === activeFilters.position;
+      })
+      .map((group) => ({
+        group,
+        groupPieces: applyFilters(group.pieces || [], activeFilters),
+      }))
+      .filter(({ groupPieces }) => groupPieces.length > 0);
+  }, [groupedPieces, activeFilters]);
 
   return (
     <div className="space-y-8">
-      {filteredGroups.map((group, idx) => {
-        // Appliquer les filtres sur les pièces du groupe
-        const groupPieces = applyFilters(group.pieces || [], activeFilters);
-
-        if (groupPieces.length === 0) return null;
-
+      {filteredGroups.map(({ group, groupPieces }, idx) => {
         // Clé unique pour ce groupe
         const groupKey = `${group.filtre_gamme}-${group.filtre_side}-${idx}`;
 

--- a/frontend/app/hooks/use-pieces-filters.ts
+++ b/frontend/app/hooks/use-pieces-filters.ts
@@ -351,6 +351,26 @@ export function usePiecesFilters(inputPieces: PieceData[] | undefined | null) {
     [startTransition],
   );
 
+  // ⚡ Wrap setSortBy/setViewMode in startTransition (INP fix — these two setters
+  // were the only ones in this hook not deferred, unlike setActiveFilters above)
+  const setSortByTransitioned = useCallback(
+    (value: SortBy | ((prev: SortBy) => SortBy)) => {
+      startTransition(() => {
+        setSortBy(value);
+      });
+    },
+    [startTransition],
+  );
+
+  const setViewModeTransitioned = useCallback(
+    (value: ViewMode | ((prev: ViewMode) => ViewMode)) => {
+      startTransition(() => {
+        setViewMode(value);
+      });
+    },
+    [startTransition],
+  );
+
   return {
     // État
     activeFilters,
@@ -371,8 +391,8 @@ export function usePiecesFilters(inputPieces: PieceData[] | undefined | null) {
 
     // Actions
     setActiveFilters: setActiveFiltersTransitioned,
-    setSortBy,
-    setViewMode,
+    setSortBy: setSortByTransitioned,
+    setViewMode: setViewModeTransitioned,
     setShowRecommendations,
     resetAllFilters,
     togglePieceSelection,

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -9,7 +9,7 @@
  * /pieces/kit-d-embrayage-479.html
  */
 
-import { useEffect, useMemo, useState, Suspense } from "react";
+import { useEffect, useMemo, useState, useTransition, Suspense } from "react";
 import {
   redirect,
   type LoaderFunctionArgs,
@@ -606,6 +606,9 @@ export default function PiecesDetailPage() {
   >() as unknown as PiecesPageLoaderData;
   const navigation = useNavigation();
   const navigate = useNavigate();
+  // ⚡ Defer the vehicle-select navigation so the browser can paint the tap
+  // feedback before React reconciles this page's full tree (INP fix)
+  const [, startVehicleSelectTransition] = useTransition();
 
   // Nom de la gamme en minuscule pour les titres
   const n = (data.content?.pg_name || "pièce").toLowerCase();
@@ -770,9 +773,11 @@ export default function PiecesDetailPage() {
             type_alias:
               vehicle.type.type_alias || normalizeAlias(vehicle.type.type_name),
           });
-          navigate(
-            `/pieces/${gammeSlug}/${brandSlug}/${modelSlug}/${typeSlug}.html`,
-          );
+          startVehicleSelectTransition(() => {
+            navigate(
+              `/pieces/${gammeSlug}/${brandSlug}/${modelSlug}/${typeSlug}.html`,
+            );
+          });
         }}
         selectedVehicle={selectedVehicle}
       />


### PR DESCRIPTION
## Summary
- GSC reports ~521ms INP (poor, >500ms threshold) on ~1680 `/pieces/*` URLs (mobile). Investigation (5 parallel agents reading the live DEV VPS code) ranked 3 fixes as highest-confidence causes.
- `use-pieces-filters.ts`: `setSortBy`/`setViewMode` were the only setters in the hook not wrapped in `startTransition` (the others already are, with an explicit "wrapped in startTransition for INP" comment) — every toolbar tap forced a synchronous full-list recompute.
- `PiecesGroupedDisplay.tsx`: `applyFilters()` (filter+map+sort) ran unmemoized in the render body, recomputed on every re-render (pagination, selection, view change).
- `pieces.$slug.tsx`: `onVehicleSelect`'s `navigate()` call ran synchronously, forcing a full page reconciliation before the browser could paint the tap.

## Test plan
- [x] `npx tsc --noEmit` clean on DEV VPS after all 3 changes
- [x] Smoke-tested the two GSC example URLs on DEV (200, correct `<title>`, no error content in payload)
- [ ] Manual mobile/throttled-CPU verification of INP improvement (not done from this environment — no browser automation tooling available)
- [ ] Reviewer: note a prior root-cause audit (`audit/inp-pieces-541-root-cause-2026-07-14.md`, untracked) found a separate, likely still-open issue — ~790KB of inline hydration payload (5328 motorisations serialized vs 12 shown) in `pieces.$slug.tsx`/`MotorisationsSection.tsx`. Not addressed by this PR — flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)