### PR TITLE
fix(test): use a run-relative cookie.expires in session-store fixture

### DIFF
--- a/backend/src/modules/session/session-store.test.ts
+++ b/backend/src/modules/session/session-store.test.ts
@@ -56,7 +56,10 @@ const touchSession = (store: Store, sid: string, data: object): Promise<void> =>
 const makeFixture = () => ({
   cookie: {
     originalMaxAge: TTL_SECONDS * 1000,
-    expires: new Date('2026-08-01T00:00:00.000Z'),
+    // Relative to run time, not a fixed calendar date — a hardcoded date
+    // eventually lands in the past, making (expires - now) go negative and
+    // silently skip the Redis write (session treated as already-expired).
+    expires: new Date(Date.now() + TTL_SECONDS * 1000),
     httpOnly: true,
     path: '/',
     sameSite: 'lax' as const,


### PR DESCRIPTION
## Summary
- Discovered while investigating an unrelated PR (#1332) blocked by a reproducible `Backend Tests` failure.
- `session-store.test.ts` (PR-9e.2, connect-redis@5↔@9 wire-format compatibility) derives the Redis TTL from `cookie.expires` (`ceil((expires - now)/1000)`). The fixture hardcoded an absolute date, `2026-08-01T00:00:00.000Z` — still in the future when PR-9e.2 merged (2026-06-25), but now in the past.
- Once `expires < now`, the derived TTL goes non-positive and `connect-redis` silently skips the Redis write (session treated as already-expired). Every subsequent read returns `null`/`undefined`, failing the FORWARD/BACKWARD/byte-identical tests — a ticking-time-bomb bug unrelated to the migration's actual correctness.
- Confirmed root cause: the last green run on `main` was 2026-07-29 (before the cutoff, identical code/deps); the failure reproduced identically twice on an unrelated branch after 2026-08-01.

## Fix
Derive `expires` from `Date.now() + TTL_SECONDS * 1000` at run time instead of a fixed calendar date — the fixture stays exactly "30 days out" regardless of when the suite runs, preserving the original test intent (a session with a real expiry) without the wall-clock dependency.

## Test plan
- [x] Root cause isolated by reading the test source + comparing CI runs before/after the cutoff date
- [ ] CI (`🧪 Backend Tests`) should now pass on this branch — verify before merge
- [ ] This fix unblocks PR #1332 (frontend INP fix), which is currently `BLOCKED` by this same failing required check with zero backend changes in its diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)