### PR TITLE
fix(ci): eliminate printf|grep pipefail false-negative in prod-ssr-probe.sh

### DIFF
--- a/scripts/ci/prod-ssr-probe.sh
+++ b/scripts/ci/prod-ssr-probe.sh
@@ -59,15 +59,23 @@ if [ "${status:-}" != "200" ]; then
   echo "  ❌ [$LABEL] GET / -> ${status:-no response} (expected 200)"
   exit 1
 fi
-if ! echo "$ctype" | grep -qi 'text/html'; then
+if ! grep -qi 'text/html' <<< "$ctype"; then
   echo "  ❌ [$LABEL] GET / Content-Type is not text/html"
   exit 1
 fi
-if ! printf '%s' "$body" | grep -qF "$MARKER"; then
+# grep -q (and -qF/-qi) exits as soon as it finds a match, WITHOUT reading the
+# rest of stdin. Piped into `printf`/`echo`, that early exit can SIGPIPE the
+# writer before it finishes — and under `set -o pipefail` (above) that failed
+# write, not grep's actual (matching) exit code, decides the pipeline's status.
+# On a large body (real pages run 200KB+) this false-failed even when the
+# marker WAS present (PROD deploy incident 2026-08-07, tag v4.7.8 — rejected a
+# healthy build, then rejected its own rollback the same way). A herestring
+# has bash write directly into grep's stdin — one process, no pipe, no race.
+if ! grep -qF "$MARKER" <<< "$body"; then
   echo "  ❌ [$LABEL] GET / lacks the stable SSR marker $MARKER — document was not server-rendered"
   exit 1
 fi
-if echo "$robots" | grep -qi 'noindex'; then
+if grep -qi 'noindex' <<< "$robots"; then
   echo "  ❌ [$LABEL] GET / served X-Robots-Tag: noindex — homepage is in DEGRADED FALLBACK (families empty)"
   exit 1
 fi

--- a/scripts/ci/prod-ssr-probe.test.mjs
+++ b/scripts/ci/prod-ssr-probe.test.mjs
@@ -156,3 +156,39 @@ describe("prod-ssr-probe.sh — must not write a temp file in the container (202
     assert.match(code, /-O\s+\/dev\/null/, "headers must discard body to /dev/null");
   });
 });
+
+describe("prod-ssr-probe.sh — must not pipe a captured var into an early-exiting grep (2026-08-07 regression)", () => {
+  const src = readFileSync(PROBE_SH, "utf8");
+  const code = src
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("#"))
+    .join("\n");
+
+  // `grep -q`/`-qF`/`-qi` exits the instant it finds a match, without draining
+  // the rest of stdin. Piped from `printf`/`echo`, that early exit can SIGPIPE
+  // the writer before it finishes — and under `set -o pipefail` (this script
+  // sets it), that failed WRITE, not grep's actual (matching) exit code,
+  // decides the pipeline's status. On a large body (real pages run 200KB+)
+  // this false-failed a healthy homepage AND its own rollback verification
+  // (PROD deploy incident 2026-08-07, tag v4.7.8). A herestring has bash write
+  // directly into grep's stdin: one process, no pipe, no race — this is a
+  // *static*, deterministic check because the underlying bug is a timing race
+  // that a dynamic large-body test can only reproduce flakily.
+  test("never pipes a captured variable into grep -q", () => {
+    const riskyPipes =
+      code.match(/\b(printf|echo)\b[^|\n]*\|\s*grep\s+-[a-zA-Z]*q/g) || [];
+    assert.deepEqual(
+      riskyPipes,
+      [],
+      `probe must not pipe printf/echo into an early-exiting grep -q (SIGPIPE + pipefail false-negative on large bodies). Found: ${riskyPipes.join(", ")}`,
+    );
+  });
+
+  test("uses herestrings (<<<) for the grep -q checks against captured vars", () => {
+    const grepQChecks = code.match(/grep\s+-[a-zA-Z]*q\S*[^\n]*/g) || [];
+    assert.ok(grepQChecks.length >= 3, "expected at least 3 grep -q checks (Content-Type, marker, noindex)");
+    for (const line of grepQChecks) {
+      assert.match(line, /<<</, `grep -q check must read via herestring, not a pipe: "${line.trim()}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **PROD deploy incident 2026-08-07** (tag `v4.7.8`): the SSR gate rejected a healthy homepage, then rejected its own rollback verification the same way — `❌ Rollback SSR gate FAILED — MANUAL INTERVENTION REQUIRED`, despite the site being genuinely healthy (confirmed live: `curl https://www.automecanik.com/` → 200, correct `<title>`, `__reactRouterContext` marker present, right after the script claimed it was absent).
- Root cause: `printf '%s' "$body" | grep -qF "$MARKER"` (and the same pattern for Content-Type / noindex). `grep -q` exits the instant it finds a match, without draining the rest of stdin. On a large body (real pages run 200KB+) with the marker near the start, `printf` can still be mid-write when `grep` exits → SIGPIPE. Under `set -o pipefail` (already set), that failed *write* — not grep's actual matching exit code — decides the whole pipeline's status.
- A secondary `[RM V2] Failed: RM Page V2 API failed: 404` log line appeared in the same job output (from `docker logs --tail 30`) — investigated and confirmed **unrelated**: it's an ordinary "no products for this vehicle combo" 404 from `pieces-vehicle.loader.server.ts`, incidentally captured in the tail dump, not a cause of the deploy failure.

## Fix
Read the captured variable via a herestring (`grep ... <<< "$var"`) instead of piping `printf`/`echo` into `grep`. Bash writes directly into grep's stdin — one process, no pipe, no race. Applied consistently to all 3 `grep -q` checks in the script (Content-Type, SSR marker, noindex), not just the one that happened to fire.

## Tests
- All 7 existing behavioural tests in `prod-ssr-probe.test.mjs` still pass unmodified.
- Added a **deterministic static** regression test (source-pattern check, same style as the existing 2026-07-19 temp-file regression test right below it) rather than a dynamic large-body reproduction — the underlying bug is a genuine timing race, so a dynamic test could only reproduce it flakily (verified: a naive large-body dynamic test attempt was flaky even at 1MB+ and was dropped in favor of this static check).
- Manually verified against the pre-fix script (`git show origin/main:scripts/ci/prod-ssr-probe.sh`) with a 100KB synthetic body + clean env (`env -i`): pre-fix script relies on the same pipe pattern the static test flags; post-fix script passes.
- New static test confirmed to **fail** against the pre-fix source and **pass** against the fixed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)