### PR TITLE
fix(frontend): precompute editorial blocks server-side + global nav pending UI

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -329,6 +329,18 @@ function AppShell({ children }: { children: React.ReactNode }) {
       className="min-h-screen flex flex-col max-w-[100vw]"
       {...pageRoleAttrs}
     >
+      {/* ⏳ Indicateur de navigation global (INP fix) — sans lui, un clic sur un
+          <Link> ne peint RIEN avant la fin du chargement de la page cible, donc
+          toute cette fenêtre (réseau + rendu) est comptée dans l'INP du clic.
+          Même pattern déjà utilisé localement dans pieces.$slug.tsx, généralisé
+          ici à toutes les routes (ex: reference-auto/*, qui n'en avait aucun). */}
+      {navigation.state !== "idle" && (
+        <div
+          role="status"
+          aria-label="Chargement en cours"
+          className="fixed top-0 left-0 right-0 z-[60] h-1 bg-blue-500 animate-pulse"
+        />
+      )}
       {!hideGlobalNavbar && <Navbar />}
       <main className="grow flex flex-col">
         <div className="grow">{children}</div>

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -52,6 +52,7 @@ import { buildCacheHeaders } from "~/utils/cache-control";
 import {
   extractEditorialBlocks,
   mergeFaqBlocks,
+  type EditorialBlocks,
 } from "~/utils/editorial-parser";
 import { parseGammePageData } from "~/utils/gamme-page-contract.utils";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
@@ -391,6 +392,9 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         status: pageData.status,
         meta: pageData.meta,
         content: pageData.content,
+        editorialBlocks: extractEditorialBlocks(
+          pageData.content?.content || "",
+        ),
         breadcrumbs: pageData.breadcrumbs,
         famille: pageData.famille,
         performance: pageData.performance,
@@ -589,6 +593,10 @@ type PiecesPageSyncData = Omit<
     title?: string;
     items?: Array<{ title: string; description?: string; image?: string }>;
   } | null;
+  // ⚡ Precomputed server-side (loader) instead of client useMemo — the DOMPurify
+  // sanitize + regex classification only needs to run once (SSR), not a second
+  // time during client hydration (INP fix — see extractEditorialBlocks call site)
+  editorialBlocks: EditorialBlocks;
 };
 
 // Loader payload complet: sync + deferred Promises
@@ -613,14 +621,11 @@ export default function PiecesDetailPage() {
   // Nom de la gamme en minuscule pour les titres
   const n = (data.content?.pg_name || "pièce").toLowerCase();
 
-  // Extraire les blocs éditoriaux par section narrative (6 H2).
-  // useMemo : extractEditorialBlocks = DOMPurify.sanitize (~9,5KB) + regex —
-  // sans mémo, ré-exécuté à CHAQUE re-render (dont les 2 transitions
-  // useNavigation de chaque clic) → coût INP mobile récurrent.
-  const editorialBlocks = useMemo(
-    () => extractEditorialBlocks(data.content?.content || ""),
-    [data.content?.content],
-  );
+  // Blocs éditoriaux par section narrative (6 H2), précalculés dans le loader
+  // (SSR). DOMPurify.sanitize (~9,5KB) + regex ne s'exécutent donc plus une
+  // seconde fois côté client à l'hydratation (INP fix — l'ancien useMemo
+  // protégeait les re-renders suivants, mais pas ce premier passage client).
+  const editorialBlocks = data.editorialBlocks;
 
   // FAQ unique fusionnée (éditorial + fallback statique)
   const mergedFaq = useMemo(
@@ -714,14 +719,9 @@ export default function PiecesDetailPage() {
       >
         Aller au contenu principal
       </a>
-      {/* ⏳ Indicateur de chargement */}
-      {isLoading && (
-        <div
-          role="status"
-          aria-label="Chargement en cours"
-          className="fixed top-0 left-0 right-0 z-[60] h-1 bg-blue-500 animate-pulse"
-        />
-      )}
+      {/* Indicateur de chargement désormais géré globalement dans root.tsx
+          (AppShell, navigation.state !== "idle") — évite un doublon de barre
+          identique empilée sur cette route. */}
       <GammeHero
         gammeName={
           data.sectionPack?.sections.hero.data.h1Override?.replace(


### PR DESCRIPTION
## Summary
Two follow-up INP fixes from investigating the GSC CWV "200-500ms" (needs improvement) report — separate from the ">500ms" fix already deployed (tag v4.7.10).

**1. `pieces.$slug.tsx` — eliminate the client-side DOMPurify pass, don't just memoize it**
`extractEditorialBlocks` (DOMPurify.sanitize ~9.5KB + regex classification) was wrapped in `useMemo`, which protects subsequent re-renders but not the *first* client render during hydration — React re-executes the component function fresh on the client, so the sanitize pass ran twice total: once server-side (SSR, doesn't count toward INP) and once client-side during hydration (does count, blocks the main thread in the INP measurement window). Moved the computation into the loader (already Node/SSR) and pass `editorialBlocks` through loader data — the client-side pass is now eliminated, not deferred.

**2. `root.tsx` (AppShell) — global navigation pending indicator**
No route had visual feedback during React Router client-side transitions — `useNavigation()` was only used to dedupe GA pageview tracking. Without a paint between click and destination-page-ready, the full network+render window of the next page counts toward the click's INP. Added a global pending bar (`navigation.state !== "idle"`) reusing the exact visual `pieces.$slug.tsx` already had *locally* — now applies to every route, including `reference-auto/*` (GSC's other 200-500ms group, `support-de-boite-vitesse`, which had no equivalent at all). Removed the now-redundant local bar in `pieces.$slug.tsx`.

## Investigation trail
- `reference-auto.$slug.tsx` (the route serving the 80 affected URLs) has no heavy interaction handler at all — confirmed by reading it and its child components in full. The mechanism there is "no paint during navigation," not a blocking click handler, consistent with 200-500ms rather than the >500ms pattern already fixed.
- A third candidate (ChatWidget/BottomNav hydration-guard asymmetry) was investigated and **refuted**: the compiled build shows `BottomNav` is already bundled statically into the shared `app-shell` chunk regardless of any `useHydrated()` guard, so adding one would be cosmetic only — not included in this PR.

## Test plan
- [x] `npx tsc --noEmit` clean (0 errors)
- [ ] Manual smoke test on DEV / preprod before merge
- [ ] Post-deploy: confirm no duplicate/flashing pending bar on `/pieces/*` navigations (local bar removed, global one takes over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)