### PR TITLE
fix(seo): guard R8 vehicle-page transform against null part/family names (GSC 5xx)

### DIFF
--- a/frontend/app/components/vehicle/r8/r8-transform.ts
+++ b/frontend/app/components/vehicle/r8/r8-transform.ts
@@ -161,8 +161,10 @@ export function transformRpcToLoaderData(
     (f: any) => ({
       mf_id: parseInt(f.mf_id),
       mf_name: f.mf_name,
-      mf_description: f.mf_description || `Système ${f.mf_name.toLowerCase()}`,
-      mf_pic: f.mf_pic || `${f.mf_name.toLowerCase()}.webp`,
+      mf_description:
+        f.mf_description ||
+        (f.mf_name ? `Système ${f.mf_name.toLowerCase()}` : "Système"),
+      mf_pic: f.mf_pic || (f.mf_name ? `${f.mf_name.toLowerCase()}.webp` : ""),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       gammes: (f.gammes || []).map((g: any) => ({
         pg_id: g.pg_id,
@@ -189,7 +191,8 @@ export function transformRpcToLoaderData(
       cgc_pg_id: p.pg_id,
       pg_alias: p.pg_alias,
       pg_name: p.pg_name,
-      pg_name_meta: p.pg_name_meta || p.pg_name.toLowerCase(),
+      pg_name_meta:
+        p.pg_name_meta || (p.pg_name ? p.pg_name.toLowerCase() : ""),
       pg_img: p.pg_img || null,
       addon_content: generateSeoContent(p.pg_name, vehicleData, type_id + idx),
     }),

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -360,11 +360,26 @@ export async function loader({ params }: LoaderFunctionArgs) {
   // ========================================
   // 🔄 TRANSFORMATION RPC → LoaderData
   // ========================================
-  const loaderData = transformRpcToLoaderData(rpcResult.data, {
-    brand,
-    model,
-    type,
-  });
+  let loaderData: ReturnType<typeof transformRpcToLoaderData>;
+  try {
+    loaderData = transformRpcToLoaderData(rpcResult.data, {
+      brand,
+      model,
+      type,
+    });
+  } catch (transformErr) {
+    logger.error(
+      `💥 [LOADER] transformRpcToLoaderData failed for type_id=${type_id}:`,
+      transformErr instanceof Error ? transformErr.message : transformErr,
+    );
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_TRANSFORM_CRASH",
+      `transformRpcToLoaderData threw for type_id=${type_id}: ${transformErr instanceof Error ? transformErr.message : String(transformErr)}`,
+      { type_id },
+    );
+    throw seoError(503, "Service temporairement indisponible");
+  }
 
   // Mettre en cache mémoire
   loaderCache.set(cacheKey, {


### PR DESCRIPTION
## Summary
- `transformRpcToLoaderData()` called `.toLowerCase()` on `mf_name`/`pg_name` without a null check, crashing to a raw HTTP 500 on `/constructeurs/{marque}/{modele}/{type}.html` whenever the backend RPC returned a catalog family or popular part with an empty name.
- The sibling `/pieces/...` loader already guards its equivalent transform call with `try/catch` → 503; this brings `/constructeurs/...` to the same resilience level (`try/catch` around `transformRpcToLoaderData`, degrading to `seoError(503, ...)` + `notify503ToErrorLog`, matching the file's existing pattern).
- Found while re-investigating a Google Search Console "Erreur serveur (5xx)" report (~1070 pages, validation failed 08/08/2026) — a live sample of 87 reported URLs currently returns 0 real 5xx, so this fix addresses a real-but-narrow remaining gap rather than the bulk of the report (mostly stale GSC crawl data / already-fixed causes).

## Test plan
- [ ] CI: lint + typecheck + build (could not run locally — no `node_modules` installed in this checkout)
- [ ] Manual: hit a `/constructeurs/{marque}/{modele}/{type}.html` page where the backend returns a catalog family/popular part with a null name → confirm 503 (not 500) instead of a crash
- [ ] Manual: confirm normal `/constructeurs/...` pages with valid data are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)