### PR TITLE
fix(governance+security): G1 registry freshness authoritative + SEC-01 code closure

### DIFF
--- a/.claude/rules/guardrails.md
+++ b/.claude/rules/guardrails.md
@@ -1,0 +1,63 @@
+# Gardes de gouvernance — diagnostiquer avant de corriger
+
+> Règle de conduite née de deux erreurs commises le même jour (2026-08-13), sur I6 puis
+> sur le protocole PR-8b. À charger avant toute modification d'un ratchet, d'une règle
+> ast-grep, d'un invariant, d'un gate CI ou d'un script `scripts/audit/**`.
+
+## Le symptôme trompeur
+
+**Une garde correcte exécutée au mauvais moment produit exactement les mêmes symptômes
+qu'une garde défectueuse.** Dans les deux cas : rien n'est signalé, la dette s'accumule,
+et le réflexe est de « réparer le détecteur ».
+
+Cas réel : `registry-fresh.yml` lançait `npm run registry` — qui **reconstruit**
+`canonical.json` — **avant** `registry:validate-invariants`. L'invariant **I6**
+(`checkCanonicalFresh`) était complet, `severity: error`, `exit 1` — mais il ne validait
+jamais que du fraîchement régénéré. **Vacant par construction de l'ordre des steps.**
+Diagnostic initial « détecteur cassé » : faux. Correction appliquée : déplacer le step,
+pas toucher la logique.
+
+## Les 4 passes obligatoires, dans cet ordre
+
+**1. Lire les tests de la garde.** Ce repo encode ses décisions de conception dans des
+tests **anti-overclaim** explicites. Exemple :
+
+> `scripts/audit/build-drift-dashboard.test.ts` — *« canonical liveness ignores recorded
+> inputHashes — the dashboard is NOT the freshness engine (I6 is) […] if Signal 2 ever
+> goes ⚠️ on hash mismatch it has re-become a freshness gate duplicating I6 »*
+
+Ajouter la comparaison de hash au dashboard créait la **SoT dupliquée** que l'invariant #2
+interdit. Le test l'a rattrapé.
+
+**2. Chercher qui d'autre porte la responsabilité.** Invariants (`validate-invariants.ts`),
+ratchets (`audit/baselines/**` + `scripts/audit/check-*-ratchet.ts`), README de la zone
+(`audit/README.md`, `audit/cleanup/README.md`). Si un composant la porte déjà : le réparer
+**lui**, ne pas en créer un second.
+
+**3. Vérifier l'ordre d'exécution** — dans le workflow, dans le hook, dans le script.
+Une garde qui contrôle un artefact doit s'exécuter **avant** ce qui le régénère.
+
+**4. Lire le contrat de périmètre de la garde.** Une garde a un scope documenté, et
+l'appliquer hors scope la déforme. Exemple : `audit/README.md` documente le protocole
+PR-8b comme *« non-runtime, non-`backend/src/modules/**` »* — mesure : **12 candidats
+éligibles sur 275**, tous des fichiers de types sans imports. Vouloir y faire entrer du
+code de module NestJS était le mauvais instrument, pas un seuil à assouplir : la procédure
+prévue était les **conditions #0–#8** et la phase **PR-3 backend NestJS-aware**.
+
+## Interdits
+
+- ❌ Assouplir un seuil pour faire passer un cas qui sort du périmètre de la garde.
+- ❌ Ajouter un second détecteur pour une responsabilité déjà portée ailleurs.
+- ❌ Traiter un `BLOCKED` comme un verdict de vie quand l'outil dit *« review each hit »* —
+  `scripts/cleanup/validate-before-delete.sh` bloque à la granularité du **sous-arbre**
+  (il grep tous les `@Controller('…')` de `SUBTREE_DIR`), donc il bloque identiquement les
+  fichiers vivants et morts d'un module à surface HTTP vivante. Sa sortie est une consigne
+  de revue et de **suppression bottom-up**, pas une preuve d'atteignabilité.
+- ❌ Conclure « détecteur cassé » avant les 4 passes ci-dessus.
+
+## Quand la garde est réellement défectueuse
+
+Corriger la cause racine, jamais le symptôme, et **prouver la correction sur un cas réel**
+avant de la déclarer livrée (sortie de commande dans le corps de la PR). Si la correction
+change la sémantique d'un artefact gouverné, rafraîchir la baseline du ratchet **dans la
+même PR** — les ratchets symétriques échouent aussi sur une réduction non déclarée.

--- a/.github/workflows/registry-deps-self-heal.yml
+++ b/.github/workflows/registry-deps-self-heal.yml
@@ -46,9 +46,30 @@ name: ♻️ Registry deps self-heal (main)
 #        SELF_HEAL_APP_PRIVATE_KEY = the generated .pem contents
 #   3. Ensure "Allow auto-merge" is enabled in repo settings (already used here).
 #
-# SCOPE: only the two projections (NOT canonical.json — separate blast radius).
-# SUPPLY-CHAIN: npm ci --ignore-scripts; builders are pure fs/crypto, never run
-# the bumped dependency's code. Runs on main after human review of the merge.
+# SCOPE: the two L1 projections + the L3 reprojection they invalidate (4 files).
+#
+# WHY canonical.json IS NOW IN SCOPE (was excluded until 2026-08-13)
+# ------------------------------------------------------------------
+# `audit/registry/deps.json` is an INPUT of `audit/registry/canonical.json` — it
+# is listed in `canonical.meta.inputHashes`. Healing deps.json therefore makes
+# canonical.json inconsistent BY CONSTRUCTION: this workflow was trading one
+# drift for another, and closing the loop it claimed to close only halfway.
+# Measured on 2026-08-13: canonical.meta.inputHashes declared deps.json at
+# 9b722879… while the file on disk was 6f667991… — a divergence produced by this
+# very workflow's healing runs (#1242-era, then 110ba90b3 / 2cd7e1785).
+# `.claude/knowledge/REPO_MAP.md` is a projection OF canonical, so it follows.
+#
+# BOUNDARY — what this reprojection does NOT claim
+# ------------------------------------------------
+# Rebuilding canonical here makes it consistent with its inputs AS THEY ARE ON
+# MAIN. It does NOT assert that files.json/runtime.json themselves match the live
+# source tree — that is a different gate (registry-fresh.yml, whose `paths:` now
+# include backend/src/** and frontend/app/**). Do not read a green self-heal as
+# "the registry is fresh"; read it as "the projection matches its inputs".
+#
+# SUPPLY-CHAIN: npm ci --ignore-scripts; builders are pure fs/crypto (plain node,
+# no tsx), never run the bumped dependency's code. Runs on main after human
+# review of the merge.
 # WHERE: runs-on ubuntu-latest = GitHub cloud runner (works with DEV off).
 
 on:
@@ -107,22 +128,29 @@ jobs:
       - name: Regenerate PR-9 modernization inventory
         run: npm run audit:pr-9-modernization-inventory
 
+      # deps.json is an input of canonical.json (meta.inputHashes). Healing the
+      # input without reprojecting leaves L3 stale — see header §WHY.
+      - name: Reproject L3 canonical + LLM repo map (deps.json is one of its inputs)
+        run: npm run registry:build:canonical && npm run registry:build:llm-map
+
       - name: Scope-guard + detect drift
         id: stage
         run: |
           set -euo pipefail
           DEPS="audit/registry/deps.json"
           INV="audit/dependencies/dependency-modernization-inventory.json"
+          CANON="audit/registry/canonical.json"
+          MAP=".claude/knowledge/REPO_MAP.md"
 
           CHANGED="$(git diff --name-only HEAD -- . | sort -u)"
           UNEXPECTED="$(printf '%s\n' "$CHANGED" \
-            | grep -vE '^(audit/registry/deps\.json|audit/dependencies/dependency-modernization-inventory\.json)$' \
+            | grep -vE '^(audit/registry/deps\.json|audit/dependencies/dependency-modernization-inventory\.json|audit/registry/canonical\.json|\.claude/knowledge/REPO_MAP\.md)$' \
             || true)"
           if [ -n "$UNEXPECTED" ]; then
             {
               echo "## ❌ Registry self-heal touched unexpected files"
               echo ""
-              echo "Regeneration must change ONLY the two projections. Unexpected:"
+              echo "Regeneration must change ONLY the four allowlisted projections. Unexpected:"
               echo '```'
               printf '%s\n' "$UNEXPECTED"
               echo '```'
@@ -131,12 +159,12 @@ jobs:
             exit 1
           fi
 
-          if git diff --quiet -- "$DEPS" "$INV"; then
+          if git diff --quiet -- "$DEPS" "$INV" "$CANON" "$MAP"; then
             echo "status=identical" >> "$GITHUB_OUTPUT"
-            echo "✓ deps.json + inventory already fresh — idempotent no-op."
+            echo "✓ deps.json + inventory + canonical + repo map already fresh — idempotent no-op."
           else
             echo "status=changed" >> "$GITHUB_OUTPUT"
-            git --no-pager diff --stat -- "$DEPS" "$INV"
+            git --no-pager diff --stat -- "$DEPS" "$INV" "$CANON" "$MAP"
           fi
 
       - name: Resolve bot identity (App preferred, user token fallback)
@@ -174,17 +202,28 @@ jobs:
           add-paths: |
             audit/registry/deps.json
             audit/dependencies/dependency-modernization-inventory.json
-          commit-message: "chore(registry): self-heal deps.json + modernization inventory"
-          title: "chore(registry): self-heal deps.json + modernization inventory"
+            audit/registry/canonical.json
+            .claude/knowledge/REPO_MAP.md
+          commit-message: "chore(registry): self-heal deps.json + modernization inventory + L3 reprojection"
+          title: "chore(registry): self-heal deps.json + modernization inventory + L3 reprojection"
           labels: dependencies
           body: |
             Auto-generated by `.github/workflows/registry-deps-self-heal.yml`.
 
-            Regenerates the two deterministic registry projections from the live
-            workspace manifests (`npm run registry:build:deps` +
+            Regenerates the two deterministic L1 projections from the live workspace
+            manifests (`npm run registry:build:deps` +
             `npm run audit:pr-9-modernization-inventory`) after a dependency bump
-            landed on main without them. Deterministic, scope-guarded (2 files),
-            derived from `package.json` (ADR-058/062) — safe to auto-merge.
+            landed on main without them — **then reprojects L3**
+            (`registry:build:canonical` + `registry:build:llm-map`), because
+            `deps.json` is one of `canonical.meta.inputHashes` and healing it
+            without reprojecting leaves canonical stale by construction.
+
+            Deterministic, scope-guarded (4 files), derived from `package.json`
+            (ADR-058/062) — safe to auto-merge.
+
+            Scope note: a green run means "the projection matches its inputs on
+            main", NOT "the registry matches the live source tree" — that is
+            `registry-fresh.yml`'s job.
 
             DO NOT EDIT manually.
 
@@ -208,9 +247,10 @@ jobs:
             echo ""
             echo "**Manual heal:** run"
             echo '```'
-            echo "npm run registry:build:deps && npm run audit:pr-9-modernization-inventory"
+            echo "npm run registry:build:deps && npm run audit:pr-9-modernization-inventory \\"
+            echo "  && npm run registry:build:canonical && npm run registry:build:llm-map"
             echo '```'
-            echo "then open a PR with the two changed files (e.g. as in #1242)."
+            echo "then open a PR with the four changed files (e.g. as in #1242)."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::warning::registry drift on main; no self-heal identity configured — manual heal required."
 

--- a/.github/workflows/registry-fresh.yml
+++ b/.github/workflows/registry-fresh.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      # --- Builder + overlay : la CONFIG du registre ---
       - "scripts/registry/**"
       - "scripts/audit/build-deep-inventory.js"
       - "scripts/audit/build-db-usage-map.js"
@@ -22,12 +23,22 @@ on:
       - "backend/supabase/migrations/**"
       - ".github/workflows/registry-fresh.yml"
       - "package.json"
+      # --- Arbres INDEXÉS par files.json (2728 entrées) ---
+      # Sans eux, une PR qui ajoute/supprime 50 fichiers TS ne déclenchait jamais
+      # le gate de fraîcheur du registre qui les recense. C'est la cause directe
+      # de la dérive de 164 commits constatée le 2026-08-13 (canonical buildé au
+      # 217d47912 / 2026-06-23 alors que HEAD était à 172f07c24 / 2026-08-09).
+      - "backend/src/**"
+      - "frontend/app/**"
+      - "packages/**"
   push:
     branches: [main]
     paths:
       - "scripts/registry/**"
-      - "packages/registry/**"
+      - "packages/**"
       - ".spec/00-canon/repository-registry/**"
+      - "backend/src/**"
+      - "frontend/app/**"
 
 jobs:
   registry-fresh:
@@ -48,8 +59,90 @@ jobs:
       - name: Install
         run: npm ci
 
+      # ⚠️ CE STEP DOIT RESTER AVANT TOUT REBUILD — c'est le seul endroit où I6
+      # peut dire quelque chose.
+      #
+      # I6 (`checkCanonicalFresh`, scripts/registry/validate-invariants.ts)
+      # compare `canonical.meta.inputHashes` aux sha256 réels des sources. Il est
+      # complet, `severity: error`, et sort 1. Mais il n'était invoqué qu'APRÈS
+      # le step « Build Layer 1 + Layer 3 canonical » : à ce moment-là canonical
+      # vient d'être régénéré depuis les sources courantes, donc ses inputHashes
+      # correspondent forcément. **I6 était vacant par construction de l'ordre
+      # des steps** — pas cassé, jamais consulté sur l'état commité.
+      #
+      # Constaté le 2026-08-13 : canonical.json commité affichait 3 inputHashes
+      # divergents sur 10 (automation-reality.yaml, ownership.yaml, deps.json)
+      # sans qu'aucun gate ne le signale, pour une dérive de 164 commits.
+      #
+      # Le step post-rebuild plus bas reste utile pour I1..I5 (structure du
+      # canonical reconstruit) — mais il ne prouve RIEN sur la fraîcheur.
+      - name: I6 — freshness of the COMMITTED canonical (must precede any rebuild)
+        run: npm run registry:validate-invariants
+
       - name: Run upstream audit producers
         run: npm run audit:inventory
+
+      # `audit:inventory:check` existait dans package.json mais n'était appelé
+      # par AUCUN workflow ni hook (0 occurrence). Résultat : les 7 projections
+      # deep-inventory (dont dead-code-candidates.json, l'input du ratchet
+      # d'orphelins) étaient figées au 217d47912 / 2026-06-23 sans que rien ne
+      # le signale. On le câble ici — même workflow, même nature de signal
+      # (fraîcheur d'une projection générée), et les `paths:` corrigés ci-dessus
+      # font qu'il se déclenche enfin sur les arbres qu'il indexe.
+      #
+      # PÉRIMÈTRE : `audit/*.json` uniquement — c'est exactement ce que
+      # build-deep-inventory.js + build-db-usage-map.js écrivent (AUDIT_DIR).
+      # NE PAS étendre à `audit/registry/*.json` : ces fichiers sont produits par
+      # les builders `registry:build:*`, pas par `audit:inventory`. Le gate
+      # rapporterait « deep inventory périmé » pour une dérive du registre —
+      # deux signaux distincts conflatés. La fraîcheur de `audit/registry/**` est
+      # couverte par le step « Freshness diff » plus bas + le finding
+      # `canonical_stale` (build-drift-dashboard.ts, inputHashes).
+      #
+      # ⚠️ LISTE EXPLICITE, PAS DE GLOB — 7 attendus = 7 contrôlés.
+      #
+      # Historique de ce choix, en deux temps :
+      #   1. `audit/*.json` SANS magic pathspec sélectionnait 296 fichiers : en
+      #      pathspec git, `*` matche aussi `/` (wildmatch sans WM_PATHNAME). Le
+      #      gate couvrait donc `audit/registry/*.json` — que le paragraphe
+      #      ci-dessus interdit explicitement — plus les 5 ratchets
+      #      `audit/baselines/**`, `audit/cleanup/pr-8-*.json` et les ~280
+      #      `audit/content/raw-evidence/**`.
+      #   2. `:(glob)audit/*.json` ramenait à 12, mais 5 d'entre eux sont des
+      #      snapshots one-off que `audit:inventory` ne produit PAS
+      #      (`compatibility-*`, `pilot-*.verdict.json`, `seo-v9-inventaire-*` —
+      #      ce dernier explicitement documenté comme tel dans audit/README.md).
+      #
+      # Dans les deux cas le périmètre DÉCLARÉ n'était pas le périmètre APPLIQUÉ.
+      # La liste ci-dessous est exactement ce que `build-deep-inventory.js` (6) et
+      # `build-db-usage-map.js` (1) écrivent sous AUDIT_DIR. Un 8e artefact
+      # contractuel devra être ajouté ICI, intentionnellement et visiblement
+      # dans le diff — jamais capté par élargissement silencieux d'un motif.
+      #
+      # PROMOTION : `continue-on-error` au niveau du job le rend non-bloquant
+      # aujourd'hui. Le retirer quand les 7 artefacts sont régénérés et stables.
+      - name: Deep-inventory freshness (les 7 artefacts contractuels)
+        run: |
+          set -euo pipefail
+          ARTEFACTS="
+            audit/runtime-entrypoints.json
+            audit/module-boundaries.json
+            audit/dynamic-import-edges.json
+            audit/cycle-map.json
+            audit/duplicate-map.json
+            audit/dead-code-candidates.json
+            audit/db-usage-map.json
+          "
+          # Fail-closed : un artefact contractuel disparu est une dérive, pas un no-op.
+          for f in $ARTEFACTS; do
+            [ -f "$f" ] || { echo "::error::artefact contractuel absent : $f"; exit 1; }
+          done
+          git diff --stat -- $ARTEFACTS || true
+          if ! git diff --exit-code --quiet -- $ARTEFACTS; then
+            echo "::error::deep-inventory drifted vs sources — run \`npm run audit:inventory\` and commit the 7 projections"
+            exit 1
+          fi
+          echo "✓ deep-inventory projections in sync (7/7)"
 
       - name: Build Layer 1 + Layer 3 canonical
         run: npm run registry
@@ -57,7 +150,12 @@ jobs:
       - name: Validate overlay (Layer 2)
         run: npm run registry:validate
 
-      - name: Validate canonical invariants (V1-4 minimal)
+      # Structure du canonical RECONSTRUIT (I1..I5). I6 est vacant ici par
+      # construction — le rebuild vient de réaligner les inputHashes. La preuve
+      # de fraîcheur est le step « I6 — freshness of the COMMITTED canonical »
+      # exécuté avant le rebuild. Ne pas déplacer ce step vers le haut ni
+      # supprimer celui du haut : ils ne testent pas la même chose.
+      - name: Validate rebuilt canonical invariants (I1..I5 structural)
         run: npm run registry:validate-invariants
 
       - name: Determinism check (V1-2 — canonical hash stable across 2 runs)
@@ -75,16 +173,25 @@ jobs:
           fi
 
       - name: Freshness diff (canonical.json committed = canonical.json rebuilt)
-        # Phase 1 warn-only : do not exit 1 on drift. Drift may be transient
-        # (main moved between commit and CI run). Promotion to ERROR happens
-        # in PR-G strict gate + V1.5 baseline ratchet.
+        # Le step SORT EN ERREUR sur dérive. Le job reste non-bloquant via le
+        # `continue-on-error: true` du job (Phase 1) — mais le signal est désormais
+        # RÉEL : un job rouge non-bloquant, pas une annotation noyée.
+        #
+        # POURQUOI ce changement : l'ancien `if git diff --exit-code …; then … else
+        # echo "::warning::" ; fi` neutralisait `--exit-code` par construction.
+        # Le step sortait 0 même en dérive, y compris si `continue-on-error` était
+        # retiré. Deux défenses empilées contre le blocage, dont une invisible.
+        #
+        # PROMOTION : retirer `continue-on-error` du job après N runs verts
+        # consécutifs, avec le décompte inscrit ici (modèle audit.yml §Trigger
+        # satisfied). Ne pas promouvoir sur une intuition.
         run: |
-          if git diff --exit-code audit/registry/canonical.json; then
-            echo "✓ canonical.json in sync with sources"
-          else
-            echo "::warning::audit/registry/canonical.json drifted vs Layer 1+2 sources (run \`npm run registry\` locally to refresh)"
-            git diff --stat audit/registry/canonical.json || true
+          git diff --stat audit/registry/canonical.json || true
+          if ! git diff --exit-code --quiet audit/registry/canonical.json; then
+            echo "::error::audit/registry/canonical.json drifted vs Layer 1+2 sources — run \`npm run registry\` and commit the projection"
+            exit 1
           fi
+          echo "✓ canonical.json in sync with sources"
 
       - name: Run RPC parser fixture tests
         run: npm run registry:test:rpc-parser

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,11 +33,6 @@ title = "AutoMecanik Gitleaks Config"
     '''cxpojprgwgubzjyqzmoq''',
     # Mock Supabase URL used in tests/fixtures
     '''https://mock\.supabase\.co''',
-    # DEV RAG API key referenced in agents/rag-lead/AGENTS.md.
-    # TODO(devsecops): tech debt — should move to env var per
-    # MEMORY feedback_no_hardcoded_infra_in_agentsmd.md. Tracked
-    # for follow-up after ticket #5 (history audit).
-    '''856528eb83bd8b36867bc0bbf8ead7796f69de30fa6888a6876b54f4d98be08a''',
     # PR-B test fixture for the vehicle_ctx JWS HS256 secret. Named "test-secret"
     # explicitly to communicate intent ; high entropy from a-z trips the
     # generic-api-key rule otherwise. Used only in vehicle-context unit tests

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,35 @@
+# gitleaks — exceptions par FINGERPRINT (commit:file:rule-id:line)
+#
+# POURQUOI CE FICHIER EXISTE, ET POURQUOI PAS UNE ALLOWLIST DE VALEUR
+# -------------------------------------------------------------------
+# Jusqu'au 2026-08-13, la clé RAG de production était exceptée dans
+# `.gitleaks.toml` sous `[allowlist].regexes`, c'est-à-dire **par sa valeur**.
+# Une allowlist par valeur matche PARTOUT et POUR TOUJOURS : elle a été ajoutée
+# dans le commit même qui introduisait la fuite (b29d97671, 2026-02-22), puis la
+# clé a été recopiée dans 3 autres fichiers sans qu'aucun scan ne la signale.
+# Six mois d'exposition sur un dépôt PUBLIC, service bindé 0.0.0.0:8000.
+#
+# Un fingerprint ne couvre qu'UNE occurrence précise. Une réintroduction du même
+# secret ailleurs produit un fingerprint différent → gitleaks ÉCHOUE. C'est la
+# seule forme d'exception qui ne se transforme pas en angle mort permanent.
+#
+# RÈGLES
+#   - fingerprints COMMIT-SPÉCIFIQUES uniquement (4 segments).
+#     Le format global `file:rule-id:line` est INTERDIT : il couvrirait toutes
+#     les occurrences présentes et futures du fichier — on recréerait le défaut.
+#   - copiés EXACTEMENT depuis `finding.Fingerprint` d'un rapport gitleaks,
+#     jamais retapés ni reconstruits à la main.
+#   - toute entrée ici DOIT avoir une entrée correspondante avec `revoked_at`
+#     et une preuve de rotation dans `audit/baselines/revoked-secrets-baseline.json`.
+#     `scripts/audit/check-revoked-secrets-ratchet.ts` échoue sinon.
+#   - JAMAIS la valeur d'un secret dans ce fichier.
+#
+# Produit par : gitleaks 8.21.2 — `gitleaks git --report-format json`
+# exécuté APRÈS la rotation SEC-01 du 2026-08-13.
+
+# SEC-01 — clé RAG de production, révoquée le 2026-08-13.
+# Preuve de révocation : ancienne clé → HTTP 401 sur /search et /chat ;
+# nouvelle clé → 200. Détail dans revoked-secrets-baseline.json.
+442b67b36813cdd73a1a33c994b403173ff32230:agents/rag-lead/AGENTS.md:generic-api-key:21
+04765b8c0dea3fbb04d4aee34230307cc28fa400:docker-compose.ci-deploy.yml:generic-api-key:39
+a96e9c23e578145a7481da7e4d0d23fc87a6fde4:docker-compose.prod.yml:generic-api-key:33

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -183,6 +183,16 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: high
+  # SEC-01 (2026-08-13) : exceptions gitleaks par FINGERPRINT commit-specifique.
+  # Remplace l'allowlist par VALEUR de .gitleaks.toml, qui matchait partout et
+  # pour toujours — elle a masque une cle de production reelle pendant 6 mois.
+  # Chaque entree doit avoir une preuve de revocation dans
+  # audit/baselines/revoked-secrets-baseline.json.
+  - glob: .gitleaksignore
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
   - glob: .spec/00-canon/repository-registry/**
     domain: D15
     owner: '@ak125'

--- a/agents/rag-lead/AGENTS.md
+++ b/agents/rag-lead/AGENTS.md
@@ -20,13 +20,14 @@ Tu reçois des tickets (issues) décrivant des opérations sur le pipeline RAG :
 
 ### RAG FastAPI (port 8000) — corpus Weaviate
 ```
-Base : http://46.224.118.55:8000
-Auth : -H "X-RAG-API-Key: 856528eb83bd8b36867bc0bbf8ead7796f69de30fa6888a6876b54f4d98be08a"
+Base : `RAG_SERVICE_URL` (provisionnée dans l'environnement d'exécution)
+Auth : -H "X-RAG-API-Key: $RAG_API_KEY" — la valeur provient du secret
+       runtime, jamais du dépôt (rotation SEC-01, 2026-08-13).
 ```
 
 ### NestJS API (port 3000) — pipeline applicatif
 ```
-Base : http://46.224.118.55:3000
+Base : `NESTJS_API_URL` (provisionnée dans l'environnement d'exécution)
 Auth : si `ADMIN_API_KEY` est provisionnée dans l'environnement d'exécution
        (secrets CI / Docker / systemd / Coolify), les endpoints
        `/api/rag/admin/*` sont accessibles via `X-Admin-Api-Key`.
@@ -153,7 +154,7 @@ curl -s -w "\nHTTP %{http_code}" -X POST \
   -H "X-Internal-Key: $INTERNAL_KEY" \
   -H "Content-Type: application/json" \
   -d '{"title":"Test","content":"Contenu technique OEM (50 chars min)...","gamme_aliases":["disque-de-frein"]}' \
-  http://46.224.118.55:3000/api/rag/internal/ingest/manual
+  "$NESTJS_API_URL/api/rag/internal/ingest/manual"
 # → HTTP 201, réponse contient "id" ou "skipped":true
 ```
 

--- a/audit/baselines/revoked-secrets-baseline.json
+++ b/audit/baselines/revoked-secrets-baseline.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0.0",
+  "_generated_by": "SEC-01 remediation, 2026-08-13",
+  "_contract": "Toute entrée de .gitleaksignore DOIT avoir ici une entrée avec un fingerprint identique, un revoked_at non nul et une rotation_evidence. La valeur d'un secret n'apparaît JAMAIS dans ce fichier — le fingerprint gitleaks (commit:file:rule-id:line) ne la contient pas.",
+  "gitleaksVersion": "8.21.2",
+  "revoked": [
+    {
+      "incident": "SEC-01",
+      "fingerprint": "442b67b36813cdd73a1a33c994b403173ff32230:agents/rag-lead/AGENTS.md:generic-api-key:21",
+      "rule_id": "generic-api-key",
+      "file": "agents/rag-lead/AGENTS.md",
+      "start_line": 21,
+      "introduced_at": "2026-04-04",
+      "revoked_at": "2026-08-13",
+      "rotation_evidence": "Ancienne clé → HTTP 401 sur POST /search et POST /chat ; nouvelle clé → 200 sur /search. Service rag-api-prod recréé (619c12fc… → 3abb0ecc…), health=healthy.",
+      "owner": "@ak125"
+    },
+    {
+      "incident": "SEC-01",
+      "fingerprint": "04765b8c0dea3fbb04d4aee34230307cc28fa400:docker-compose.ci-deploy.yml:generic-api-key:39",
+      "rule_id": "generic-api-key",
+      "file": "docker-compose.ci-deploy.yml",
+      "start_line": 39,
+      "introduced_at": "2026-03-10",
+      "revoked_at": "2026-08-13",
+      "rotation_evidence": "Même rotation que ci-dessus — clé unique partagée par les 3 occurrences.",
+      "owner": "@ak125"
+    },
+    {
+      "incident": "SEC-01",
+      "fingerprint": "a96e9c23e578145a7481da7e4d0d23fc87a6fde4:docker-compose.prod.yml:generic-api-key:33",
+      "rule_id": "generic-api-key",
+      "file": "docker-compose.prod.yml",
+      "start_line": 33,
+      "introduced_at": "2026-02-22",
+      "revoked_at": "2026-08-13",
+      "rotation_evidence": "Même rotation que ci-dessus — clé unique partagée par les 3 occurrences.",
+      "owner": "@ak125"
+    }
+  ],
+  "_known_detection_gap": {
+    "description": "Un 4e emplacement historique de la même clé existe — .spec/reports/rag_audit_fast_20260312_141752.md:246 (commit 77ebec8c1). Il n'apparaît PAS dans les 397 findings de la config courante parce que .gitleaks.toml exclut le chemin '.spec/' via [allowlist].paths. Il n'est donc pas fingerprinté ici. Ce fichier n'existe plus à HEAD et le secret est révoqué, mais l'allowlist de CHEMIN reste un angle mort de détection : elle a masqué un secret de production réel. Décision owner requise avant de l'élargir ou de la retirer — un scan sans aucune allowlist remonte 476 findings contre 397.",
+    "measured_at": "2026-08-13",
+    "scan_without_allowlist_findings": 476,
+    "scan_with_current_config_findings": 397
+  }
+}

--- a/docker-compose.ci-deploy.yml
+++ b/docker-compose.ci-deploy.yml
@@ -36,7 +36,7 @@ services:
       - BRIEF_GATES_OBSERVE_ONLY=true
       - KEYWORD_DENSITY_GATE_ENABLED=true
       - RAG_SERVICE_URL=http://rag-api:8000
-      - RAG_API_KEY=856528eb83bd8b36867bc0bbf8ead7796f69de30fa6888a6876b54f4d98be08a
+      - RAG_API_KEY=${RAG_API_KEY}
       - INTERNAL_API_KEY=${INTERNAL_API_KEY}
       # Sitemap regen legacy kill-switch (Phase 5 = true → Phase 10 = remove).
       # All other OIDC validation invariants hardcoded in GithubOidcService

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
       - BRIEF_GATES_OBSERVE_ONLY=true
       - KEYWORD_DENSITY_GATE_ENABLED=true
       - RAG_SERVICE_URL=http://rag-api:8000
-      - RAG_API_KEY=856528eb83bd8b36867bc0bbf8ead7796f69de30fa6888a6876b54f4d98be08a
+      - RAG_API_KEY=${RAG_API_KEY}
       # Internal API key for RAG webhook → NestJS auth
       - INTERNAL_API_KEY=${INTERNAL_API_KEY}
       # Sitemap regen legacy kill-switch (Phase 5 = true → Phase 10 = remove).

--- a/knip.json
+++ b/knip.json
@@ -29,7 +29,6 @@
       "ignore": [
         "dist/**",
         "rm/**",
-        "scripts/**",
         "**/*.spec.ts",
         "**/*.e2e-spec.ts"
       ],

--- a/scripts/audit/build-deep-inventory.js
+++ b/scripts/audit/build-deep-inventory.js
@@ -185,6 +185,25 @@ function lastModifiedMap() {
   return map;
 }
 
+// Cross-platform npm launcher — two distinct Windows obstacles, both required.
+//
+//  1. `execFileSync` without a shell resolves a LITERAL filename, and on Windows
+//     `npx` only exists as `npx.cmd` / `npx.ps1`, never extension-less
+//     → `spawnSync npx ENOENT`.
+//  2. Since the CVE-2024-27980 mitigation (Node ≥ 18.20.2 / 20.12.2 / 21.7.3),
+//     Node REFUSES to spawn a `.cmd`/`.bat` without `shell: true`
+//     → `spawnSync npx.cmd EINVAL`.
+//
+// Without both, the deep inventory — and therefore the registry build, which
+// consumes its cache — cannot run on any Windows checkout at all.
+//
+// `shell` is enabled on win32 ONLY. Every argument passed to runJson() below is
+// a static literal (no user input, no spaces, no shell metacharacters), so the
+// usual shell-injection concern does not apply here. No behaviour change on
+// POSIX: `NPX === 'npx'` and `SHELL === false`.
+const IS_WIN = process.platform === 'win32';
+const NPX = IS_WIN ? 'npx.cmd' : 'npx';
+
 function runJson(cmd, args, label) {
   log(`[build-deep-inventory] running ${label}…`);
   // stderr is *evidence*, not noise: capture it, tee it to audit/cache/tool-<label>.stderr.log
@@ -196,7 +215,7 @@ function runJson(cmd, args, label) {
   let stderr = '';
   let failure = null;
   try {
-    stdout = execFileSync(cmd, args, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] });
+    stdout = execFileSync(cmd, args, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'], shell: IS_WIN });
   } catch (e) {
     // many of these tools exit non-zero when they find issues — keep stdout/stderr
     stdout = (e.stdout || '').toString();
@@ -217,7 +236,7 @@ function runJson(cmd, args, label) {
 
 function loadDepcruise() {
   const j = runJson(
-    'npx',
+    NPX,
     ['--no-install', 'depcruise', '--config', '.dependency-cruiser.cjs', '--output-type', 'json', 'backend/src', 'frontend/app'],
     'dependency-cruiser',
   );
@@ -273,7 +292,7 @@ async function loadCycles() {
 // ---------------------------------------------------------------------------
 
 function loadKnip() {
-  const j = runJson('npx', ['--no-install', 'knip', '--reporter', 'json', '--no-exit-code'], 'knip');
+  const j = runJson(NPX, ['--no-install', 'knip', '--reporter', 'json', '--no-exit-code'], 'knip');
   const unusedFiles = new Set();
   const duplicates = [];
   const unusedExports = [];


### PR DESCRIPTION
## Objet

Fermer deux prérequis avant la purge G3+P2 :

1. **G1** — rendre la fraîcheur du registry réellement autoritaire
2. **SEC-01** — fermer côté code l'incident de clé RAG exposée puis révoquée

Cette PR ne contient **aucune suppression G3/P2**.

## Commits

- `0721881aa` — `fix(governance): make registry freshness checks authoritative`
- `e0696a95e` — `fix(security): close exposed RAG API key handling`

Les deux sont signés (`G`) par `vault-signing@automecanik.com`.

---

## G1 — Registry freshness

### Défaut

Le contrôle **I6** (`checkCanonicalFresh`) pouvait donner l'illusion que le registry était frais **parce qu'il était exécuté après sa régénération**. `registry-fresh.yml` lançait `npm run registry` (rebuild) avant `registry:validate-invariants` : I6 ne validait donc jamais que du fraîchement régénéré.

I6 n'était pas cassé — il était **vacant par construction de l'ordre des steps**.

Le registry commité était pourtant en dérive de :

- **165 commits**
- `files` : **2728 → 2841**

### Corrections

- I6 exécuté **avant tout rebuild**
- `registry-fresh.yml` déclenché sur les arbres réellement indexés (`backend/src/**`, `frontend/app/**`, `packages/**`) — il se déclenchait sur sa propre config, pas sur ses entrées
- `git diff --exit-code` n'est plus neutralisé par un `if/else`
- `audit:inventory:check` câblé — il existait dans `package.json`, appelé par aucun workflow ni hook
- `registry-deps-self-heal` reprojette L3 après heal : `deps.json` est un input de `canonical.meta.inputHashes`, le heal creusait la dérive qu'il prétendait soigner
- contradiction `knip.json` `entry ∩ ignore` sur `scripts/**` supprimée
- `build-deep-inventory.js` rendu portable Windows (il était Linux-only : `ENOENT` sur `npx`, puis `EINVAL` — mitigation CVE-2024-27980)
- contrôle limité aux **7 artefacts contractuels exacts**, extraits des producteurs — pas un glob
- **fail-closed** si un de ces 7 artefacts est absent

### Preuve reproductible

Après revert des artefacts régénérés, donc contre le `canonical.json` **réellement commité** :

```
$ npm run registry:validate-invariants

[validate-invariants] 3 error(s) :
  [ERROR] I6-canonical-fresh: canonical.json STALE vs .spec/00-canon/repository-registry/automation-reality.yaml
  [ERROR] I6-canonical-fresh: canonical.json STALE vs .spec/00-canon/repository-registry/ownership.yaml
  [ERROR] I6-canonical-fresh: canonical.json STALE vs audit/registry/deps.json

exit 1
```

Le défaut reste reproductible **sans dépendre d'un artefact issu du rebuild**.

### Périmètre des 7 artefacts — pourquoi une liste explicite

`audit/*.json` **sans magic pathspec** sélectionne **296 fichiers** : en pathspec git, `*` matche aussi `/`. Le gate aurait couvert `audit/registry/*.json` (que son propre commentaire interdit), les 5 ratchets `audit/baselines/**` et ~280 `audit/content/raw-evidence/**`.

`:(glob)audit/*.json` ramène à 12, mais 5 sont des snapshots one-off que `audit:inventory` ne produit pas.

Dans les deux cas, le périmètre **déclaré** n'était pas le périmètre **appliqué**. La liste explicite a été vérifiée identique — 7/7 — à ce que `build-deep-inventory.js` (6) et `build-db-usage-map.js` (1) écrivent.

---

## P0 — mesures reproduites

Les estimations antérieures sont remplacées par des mesures :

| Mesure | Valeur |
|---|---|
| Code orphelin | **5 421 LOC / 17 fichiers** |
| P2 tracké | **2 839 LOC / 10 fichiers** |
| Références mortes | **70 occurrences / 44 cibles** |
| Références hors Markdown | **44 / 70 (63 %)** |

Le code orphelin est établi par **atteignabilité transitive** depuis les entrypoints backend réels, sur le registre reconstruit — pas par comptage d'orphelins-feuilles.

Les 63 % hors Markdown justifient de traiter les références mortes par un ratchet de références dépôt, et pas seulement par un link-checker Markdown.

---

## SEC-01 — fermeture côté code

L'ancienne clé RAG a été **révoquée côté infrastructure** et est désormais refusée en **401**. Vérifié avant remédiation : c'était bien la clé de production active, exposée depuis le 2026-02-22 sur un dépôt public, service bindé `0.0.0.0:8000`.

La cause n'est pas l'oubli d'un secret : **la fuite a été convertie en exception permanente dans le commit même qui l'introduisait** (`.gitleaks.toml` `[allowlist].regexes`, avec un `TODO(devsecops)` jamais traité). Une allowlist par **valeur** matche partout et pour toujours — la clé a ensuite été recopiée dans 3 autres fichiers sans qu'aucun scan ne la signale.

Cette PR :

- remplace la clé dans les deux compose par `${RAG_API_KEY}`
- retire la valeur **et** les IP de `agents/rag-lead/AGENTS.md`
- supprime l'allowlist Gitleaks **par valeur** (0 ligne ajoutée, 5 retirées ; bloc `paths` inchangé)
- ajoute **3 fingerprints commit-spécifiques exacts**, copiés depuis `finding.Fingerprint` d'un rapport gitleaks 8.21.2 post-révocation
- **refuse tout fingerprint global** (`file:rule-id:line`) : il couvrirait toutes les occurrences présentes et futures du fichier, soit exactement le défaut corrigé
- ajoute la baseline de secrets révoqués — chaque fingerprint doit porter `revoked_at` + une preuve de rotation
- ajoute l'ownership minimal requis (1 glob)

### Contre-épreuves Gitleaks

| Test | Résultat |
|---|---|
| **A** — occurrences historiques connues | ignorées **par leur fingerprint uniquement** : 397 → 394 (−3, attendu 3) |
| **B** — **même** secret à un emplacement **nouveau** | **détecté, exit 1** |

Le fingerprint ne dégénère donc pas en allowlist de valeur.

**La baseline ne contient aucune valeur de secret.**

---

## Règle de conduite ajoutée

`.claude/rules/guardrails.md` formalise quatre vérifications obligatoires avant de modifier une garde :

1. lire ses tests — ce dépôt épingle ses décisions dans des tests anti-overclaim
2. chercher les autres détenteurs de responsabilité
3. vérifier l'**ordre d'exécution**
4. vérifier le contrat de **périmètre**

Principe issu de G1 :

> Une garde correcte exécutée après l'artefact qu'elle devait contrôler produit exactement l'illusion d'une garde défectueuse.

---

## Validation locale

- arbre propre après les deux commits
- **12 fichiers exactement**
- YAML parsé avec `js-yaml` (5 fichiers), JSON valide (2)
- `validate-agents-md.sh --all` → `blocks: 0`
- `validate-agents-md.sh --staged` → `blocks: 0`
- aucune IP restante dans `AGENTS.md`
- aucun secret en clair ajouté
- aucun élargissement d'allowlist
- **7/7** artefacts contractuels identiques aux producteurs
- aucun artefact généré laissé dans le diff

---

## ⚠️ Comportement attendu en CI

**`registry-fresh` peut passer rouge (non-bloquant) sur cette PR. Ce n'est pas une régression.**

Le contrôle voit désormais la dérive historique de **165 commits** qu'il masquait auparavant. C'est précisément l'objet de la PR. Même logique pour le contrôle deep-inventory si les projections commitées sont périmées.

**Cette PR ne doit pas « réparer » ces rouges en relâchant les gardes** — ni en réintroduisant une tolérance, ni en neutralisant l'échec, ni en remettant un glob permissif. Les artefacts seront reprojetés selon le protocole prévu.

Le job reste `continue-on-error: true` : le signal est réel sans bloquer le merge.

---

## Hors périmètre

- **G3 + P2** — prochaine PR, atomique
- **394 findings** historiques Gitleaks — triage séparé
- **37 findings `private-key`** — caractérisation séparée
- **paiement PSP** — confirmation externe séparée
- **conteneur zombie DEV** — opération séparée
- **P3 / G5c** — toujours HOLD

---

## Suite

Après merge :

1. repartir du nouveau `main`
2. ouvrir la PR atomique **G3+P2**, ordre bottom-up :
   1. retirer les 2 blocs de tests morts (ils maintiennent 4 fichiers en vie)
   2. supprimer les 2 racines de cluster
   3. supprimer les 6 feuilles devenues sans importeur
   4. documenter les 6 faux positifs `HTTP-ROUTE-CALLER` (granularité sous-arbre)
   5. build ×2 + tests + revue humaine

Refs: ADR-058, SEC-01
