### PR TITLE
fix(registry): declare ownership for 4 unowned backend subtrees

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -493,6 +493,27 @@ entries:
     owner: '@ak125/admin-team'
     sourceConfidence: medium
     risk: medium
+  # D8 serving layer — two backend subtrees that serve the Read Model alongside
+  # backend/src/modules/admin/** above. staff/ holds back-office accounts (table
+  # ___config_admin only — never customer data), remix/ is the NestJS <-> React
+  # Router SSR bridge. Both were absent from this overlay, so every file in them
+  # resolved to UNKNOWN. Revealed when Layer 1 was regenerated (files.json
+  # 2728 -> 2833) after 164 commits of freeze; same shape as the D9 workers hole
+  # documented below.
+  - glob: backend/src/modules/staff/**
+    domain: D8
+    owner: '@ak125/admin-team'
+    sourceConfidence: medium
+    risk: medium
+  # remix/ carries the sessioned-data cache-privacy invariant
+  # (remix.controller.ts: SESSIONED_DATA_CACHE_HEADERS,
+  # enforceSessionedDataCachePrivacy) -> risk: high. Owner is the one domains.yaml
+  # declares for D8; D8 already spans backend via backend/src/modules/admin/**.
+  - glob: backend/src/remix/**
+    domain: D8
+    owner: '@ak125/frontend-team'
+    sourceConfidence: medium
+    risk: high
   # D14 Gamme Aggregates & V-Level — the aggregate/V-Level services & controllers
   # live physically under admin/ (D8) but are SEO-critical (V-Level scoring powers
   # R1/R2/R8 indexability). These globs are more specific than admin/** so
@@ -507,6 +528,15 @@ entries:
     domain: D14
     owner: '@ak125/seo-team'
     sourceConfidence: high
+    risk: high
+  # substitution/ calls the get_substitution_data RPC and decides the httpStatus of
+  # R1 gamme hubs. The exact entry for that RPC migration
+  # (20260625_fix_get_substitution_data_group_by_unknown_slug.sql, near the top of
+  # this file) is already D14/seo-team — same concern, same domain, same risk.
+  - glob: backend/src/modules/substitution/**
+    domain: D14
+    owner: '@ak125/seo-team'
+    sourceConfidence: medium
     risk: high
   # D9 Import / ETL / Normalisation — ETL workers. The glob is declared in
   # domains.yaml but was missing here, leaving the 11 worker files UNKNOWN.
@@ -1155,6 +1185,13 @@ entries:
     domain: D10
     owner: '@ak125'
     sourceConfidence: high
+    risk: medium
+  # errors/ is error journalling (__error_logs, global-error.filter,
+  # error-log.service) — the same concern as observability/** above, so D10.
+  - glob: backend/src/modules/errors/**
+    domain: D10
+    owner: '@ak125'
+    sourceConfidence: medium
     risk: medium
   # AI additive layer (PR #714) — "AI Visibility = couche additive du Search
   # Control Plane" doctrine. 6 livrables petits extending existing services.


### PR DESCRIPTION
## Objet

Déclarer `domain` + `owner` pour quatre sous-arbres backend absents de l'overlay L2 :

```text
backend/src/modules/errors/**
backend/src/modules/staff/**
backend/src/modules/substitution/**
backend/src/remix/**
```

Un fichier, 37 lignes, **`ownership.yaml` seul**. Débloque le ratchet `Contract Drift (PR-7a)` sur #1349 sans toucher ni à la baseline ni au code.

---

## Pourquoi maintenant

La régénération de la Layer 1 dans #1349 fait passer `files.json` de 2728 à 2833 entrées et révèle **5 nouveaux `ownership_gap`** :

```text
backend/src/modules/errors/services/error-status-population.test.ts
backend/src/modules/staff/services/staff-data.service.test.ts
backend/src/modules/substitution/services/substitution.service.light-mode.test.ts
backend/src/remix/remix-api.service.test.ts
backend/src/remix/session-data-cache-privacy.test.ts
```

Le détecteur `signal3_ownership` lit **exactement deux fichiers** — `ownership.yaml` et `audit/registry/files.json` ([build-drift-dashboard.ts:282-314](../blob/main/scripts/audit/build-drift-dashboard.ts#L282-L314)). Ni `canonical.json`, ni le working tree. La Layer 1 était gelée au commit `217d47912` (2026-06-23), date à laquelle la baseline a été figée à 541 findings. Les cinq fichiers ont été ajoutés **après** ce gel (#1153, #1269, #1272, #1285 ×2) : ils n'ont jamais eu l'occasion d'y entrer.

C'est donc de la dette révélée, pas une régression de #1349.

---

## Ce ne sont pas 5 tests, ce sont 4 sous-arbres

Aucun des 216 globs ne couvre ces quatre chemins, et leurs **24 fichiers frères** — services, controllers, modules Nest, DTO — sont **déjà** dans la baseline en `ownership_gap`.

Déclarer des globs de chemin exact pour les 5 tests donnerait un propriétaire aux tests mais pas à leurs sources. Les globs de répertoire déclarent le propriétaire réel.

Preuve que le détecteur ne maltraite pas les tests :

```text
backend/src/remix/remix.controller.test.ts
  → même répertoire non-possédé
  → EST dans la baseline
  → parce qu'il a été ajouté par le commit de gel lui-même
```

La seule variable discriminante est la date d'ajout relative au 2026-06-23.

---

## Attribution : la règle du repo, pas un arbitrage

`domains.yaml` déclare `owner` **par domaine** et donne le mapping chemin → domaine :

```text
D8   @ak125/frontend-team   Read Model / Serving (RM)
     globs: frontend/app/routes/**, backend/src/modules/admin/**
D10  @ak125                 Quality, Monitoring & Observabilité
     globs: backend/src/cache/**, backend/src/modules/observability/**
D11  @ak125/payments-team   Commerce & Users
D14  @ak125/seo-team        Gamme Aggregates & V-Level
```

| sous-arbre | domaine | preuve |
|---|---|---|
| `errors/**` | D10 `@ak125` | même concern que `observability/**` (journalisation `__error_logs`, `global-error.filter`) |
| `staff/**` | D8 `@ak125/admin-team` | hérite de `admin/**` ; lit **exclusivement** `___config_admin`, compte back-office, jamais de donnée client — donc pas D11 « Commerce & Users » |
| `substitution/**` | D14 `@ak125/seo-team` | l'entrée exacte de la migration de la RPC `get_substitution_data` qu'il appelle est **déjà** D14/seo-team |
| `remix/**` | D8 `@ak125/frontend-team` | D8 couvre déjà du backend via `admin/**` ; owner = celui que `domains.yaml` déclare pour D8 |

Les `globs:` de `domains.yaml` sont **illustratifs, pas exhaustifs** — précédent établi : `backend/src/modules/seo-logs/**` est D3 dans `ownership.yaml` sans y figurer. Ajouter ici seul est la convention, pas une divergence entre deux SoT.

`risk: high` sur `remix/**` : le module porte l'invariant de cache-privacy des réponses `.data` sessionnées (`SESSIONED_DATA_CACHE_HEADERS`, `enforceSessionedDataCachePrivacy`).

---

## Effet déclaré, pas subi

Les globs de répertoire ne retirent pas seulement les 5 findings bloquants : ils résolvent **291 findings déjà baselinés**.

C'est autorisé — le ratchet est `block-new-only`, les réductions passent toujours — mais cela doit être **visible**, pas découvert plus tard. Le script suggère lui-même un `refresh-down`, qui **resserre** le plafond et ne l'élargit pas ; c'est une décision distincte, non prise ici.

Aucune baseline n'est touchée. `--refresh` n'est pas invoqué.

---

## Mesures

```text
registry:validate      220 entrées, 16 domaines, 90.8% couverture, valide
globs résolus          errors 9 · staff 6 · substitution 7 · remix 7 fichiers réels
                       → aucune autorisation morte (invariant I4)

ratchet sur main       250 courants / 541 plafond · 0 nouveau · 291 résolus · exit 0
ratchet sur #1349      249 courants / 541 plafond · 0 nouveau · 292 résolus · exit 0
```

---

## Comportement CI attendu

`canonical.json` n'est **pas** régénéré ici, volontairement : la reprojection est le rôle de #1349, et la régénérer ici produirait un conflit textuel avec ses ~5918 lignes.

```text
Block new contract-drift findings   ✅ attendu vert (0 nouveau)
Registry freshness                  ❌ attendu rouge sur I6
```

I6 échoue **déjà** sur `main` aujourd'hui sur 3 `inputHashes` divergents ; `ownership.yaml` en est un, cette PR en ajoute un 4ᵉ à un `canonical` que #1349 s'apprête à reconstruire entièrement. Le job est `continue-on-error` et n'est pas un required check. C'est assumé, pas découvert.

---

## Séquence

```text
1. merge de cette PR
2. rebase de #1349 sur main + npm run registry
   → la projection consomme le nouvel ownership.yaml
   → les 4 inputHashes reviennent en accord
3. ne pas laisser la fenêtre ouverte : npm run registry reconstruit TOUTE la
   Layer 1 et ré-aspirerait la dérive de main accumulée entre-temps
```

---

## Ce que cette PR ne corrige pas

Le gate d'**admission** exempte les tests ([check-new-files.js:70-76](../blob/main/scripts/registry/check-new-files.js#L70-L76) : `**/*.test.ts` → verdict `ok`, « exception path ») alors que le gate de **mesure** n'exempte rien. Un test ajouté dans un sous-arbre possédé passe les deux ; dans un sous-arbre orphelin, il passe l'admission et casse le ratchet à la régénération suivante. C'est exactement le scénario des 5, et 53 `.test.ts` figurent déjà dans la baseline des 541.

Deux gardes portent la même responsabilité avec des périmètres opposés. C'est une décision ADR au vault (ADR-058), pas un correctif à glisser dans cette PR ni dans #1349.

Refs: ADR-058
