### PR TITLE
fix(dependabot): group the react-router family atomically (dev + runtime)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,20 @@ updates:
       # ecosystem version-bumped en minor matchait dev-dependencies en premier
       # et bypassait son groupe ecosystem (cas #280 storybook 9 vs
       # addon-onboarding@10 le 2026-05-04, re-fire sur PR #605 le 2026-05-18).
+      #
+      # react-router-ecosystem : variante cross-dependency-type du même incident.
+      # La famille est scindée entre devDeps (@react-router/dev,
+      # @react-router/remix-routes-option-adapter) et deps runtime (react-router,
+      # @react-router/express|node|serve), toutes épinglées exactes. Le groupe
+      # dev-dependencies (dependency-type: development) n'a pris QUE la moitié dev
+      # → peer react-router@^8.3.0 de @react-router/dev@8.3.0 vs react-router@8.0.1
+      # runtime → ERESOLVE sur npm ci → 21 checks rouges (PR #1353, 2026-08-14).
+      # Donc PAS de dependency-type ici (il faut les deux moitiés) et PAS de
+      # update-types (un major scindé rejouerait exactement le même ERESOLVE).
+      react-router-ecosystem:
+        patterns:
+          - "react-router"
+          - "@react-router/*"
       storybook-ecosystem:
         patterns:
           - "storybook"
@@ -54,6 +68,8 @@ updates:
         dependency-type: "development"
         update-types: ["minor", "patch"]
         exclude-patterns:
+          - "react-router"
+          - "@react-router/*"
           - "storybook"
           - "@storybook/*"
           - "@chromatic-com/storybook"


### PR DESCRIPTION
## Contexte — PR #1353 : 21 checks rouges, **une seule** cause

Le bump Dependabot [#1353](https://github.com/ak125/nestjs-remix-monorepo/pull/1353) (`dev-dependencies`, 26 mises à jour) fait échouer 21 checks. Ce ne sont pas 21 régressions : **tous meurent à l'install**, en 10-30 s.

```
npm error Conflicting peer dependency: react-router@8.3.0
npm error   peer react-router@"^8.3.0" from @react-router/dev@8.3.0
npm error     dev @react-router/dev@"8.3.0" from the root project
```

| Check | Symptôme observé | Job |
|---|---|---|
| ʦ TypeScript, ⬣ ESLint, 🔒 Core Build, 🧪 Backend/Frontend Tests | `ERESOLVE` au step *Install dependencies* | [94829382505](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/31819589243/job/94829382505) |
| 🛡️ Deterministic gates | `sh: 1: tsx: not found`, exit 127 | [94829380942](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/31819588948/job/94829380942) |
| 🚨 Baseline regression gate | `node_modules out of sync (missing: knip, madge, dependency-cruiser, @ast-grep/cli)` | idem |
| 🕸️ No new deep PR-stacks | même `ERESOLVE` au step `Install deps` → le verdict **« NEW DEEP STACK »** est un **faux positif d'install**, pas une mesure de stack | [94829381038](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/31819589075/job/94829381038) |

## Cause racine — la famille `react-router` est scindée entre dev et runtime

| Package | Emplacement | Version |
|---|---|---|
| `@react-router/dev` | `devDependencies` (root, frontend) | 8.0.1 → **8.3.0** ✅ bumpé |
| `@react-router/remix-routes-option-adapter` | `devDependencies` (frontend) | 8.0.1 → **8.3.0** ✅ bumpé |
| `react-router` | `dependencies` (root, frontend, backend) | 8.0.1 ❌ laissé |
| `@react-router/express` | `dependencies` (root, frontend, backend) | 8.0.1 ❌ laissé |
| `@react-router/node`, `@react-router/serve` | `dependencies` (root, frontend) | 8.0.1 ❌ laissé |

Le groupe `dev-dependencies` porte `dependency-type: "development"` : il ne **peut** voir que la moitié dev de la famille. Les six packages sont épinglés **exacts**, donc le peer `react-router@^8.3.0` de `@react-router/dev@8.3.0` ne peut pas être satisfait par le `react-router@8.0.1` runtime → `npm ci` refuse.

C'est la **variante cross-dependency-type** de l'incident déjà traité dans ce fichier : cas #280 (storybook 9 vs `addon-onboarding@10`, 2026-05-04), re-fire sur PR #605, corrigé par [PR #607](https://github.com/ak125/nestjs-remix-monorepo/pull/607). Le patron de correction existe déjà dans `.github/dependabot.yml` — ce PR l'étend, il n'en invente pas un nouveau.

## Correctif

1. Nouveau groupe `react-router-ecosystem`, déclaré **avant** `dev-dependencies` (Dependabot évalue les groupes top-down).
   - **Sans `dependency-type`** — c'est le cœur du fix : le groupe doit capturer les deux moitiés, dev *et* runtime.
   - **Sans `update-types`** — un major sorti du groupe rejouerait exactement le même `ERESOLVE`. Contrairement à Storybook, `react-router` n'a pas d'`ignore` major ici, donc restreindre à minor/patch rouvrirait le trou.
2. `react-router` + `@react-router/*` ajoutés aux `exclude-patterns` de `dev-dependencies` (ceinture-bretelles sur la précédence, comme #607).

**Ce PR ne bumpe aucune version** : il corrige le *producteur* de PR, pas les manifests.

### Evidence-after

```
$ node -e "... parse .github/dependabot.yml ..."
YAML OK — groups order: react-router-ecosystem > storybook-ecosystem > tiptap-ecosystem > vite-ecosystem > dev-dependencies
react-router-ecosystem: {"patterns":["react-router","@react-router/*"]}
dev-dependencies excludes: ["react-router","@react-router/*","storybook","@storybook/*","@chromatic-com/storybook","@tiptap/*","vite","vitest","@vitejs/*","@vitest/*","vite-tsconfig-paths"]
```

Vérification **partielle** par construction : la sémantique de groupage n'est observable qu'au prochain run Dependabot, côté GitHub. Le check reproductible ici est la validité YAML + l'ordre de précédence.

## Suite (owner-gated, hors de ce PR)

1. Merger ce PR → la config atterrit sur `main`.
2. Commenter `@dependabot recreate` sur #1353 → il se régénère **sans** la paire `@react-router/*` ; les 24 autres bumps repassent au vert seuls.
3. Dependabot émettra ensuite un PR `react-router-ecosystem` atomique (dev + runtime en 8.3.0). Point d'attention pour sa revue : RR 8.3.0 note *« Restart react-router dev with `--conditions=development` if not already set »*.

**Non appliqué volontairement** (hors périmètre) : aucun `ignore` de major `react-router` n'a été ajouté. Le groupe sans `update-types` rend un major atomique plutôt que scindé, ce qui suffit à fermer cette cause ; ajouter un `ignore` serait un changement de politique séparé.

## 🧾 DoD self-evaluation

- [x] **DoD1** Tests verts : aucun test touché ; validation = parse YAML + ordre des groupes (sortie ci-dessus). CI de ce PR fait foi.
- [x] **DoD2** Ownership : `.github/dependabot.yml`, infra CI, owner Fafa.
- [x] **DoD3** Rollback : revert PR (1 fichier, +16 lignes, aucun effet runtime).
- [x] **DoD4** Observabilité : l'effet est directement observable — le prochain PR Dependabot porte le groupe `react-router-ecosystem` ou ne le porte pas.
- [x] **DoD5** Drift zéro : aucun artefact généré, aucun registry, aucun manifest, aucun lockfile touché.
- [x] **DoD6** Docs : le « pourquoi » est inline dans le fichier (commentaire au-dessus du groupe) + ce corps de PR.
- [ ] **DoD7** Monitoring : N/A — changement de config du bot, pas de surface runtime.
- [x] **DoD8** No TODO : aucun TODO/FIXME introduit.
- [x] **DoD9** No silent skip : aucun gate désactivé, aucun `--legacy-peer-deps`, aucun `continue-on-error` ajouté. Le fix supprime la cause de l'échec au lieu de le contourner.
