### PR TITLE
perf(ssr): loader→API calls on loopback + stop masking transient faults as 404 (LCP mobile /conseils/*)

### DIFF
--- a/audit/module-boundaries.json
+++ b/audit/module-boundaries.json
@@ -259,7 +259,7 @@
         "frontend/app/routes/_public+"
       ],
       "files_count": 246,
-      "loc_total": 115271,
+      "loc_total": 115308,
       "has_barrel": false
     },
     "frontend-shared": {
@@ -342,7 +342,7 @@
         "frontend/app/utils/seo"
       ],
       "files_count": 597,
-      "loc_total": 113383,
+      "loc_total": 113428,
       "has_barrel": true
     },
     "gamme-rest": {
@@ -955,8 +955,8 @@
         "services/remotion-renderer/src/types",
         "tests/registry"
       ],
-      "files_count": 220,
-      "loc_total": 38682,
+      "files_count": 221,
+      "loc_total": 38819,
       "has_barrel": true
     },
     "upload": {

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -138,6 +138,16 @@ function buildHeroBadges(page: R3GuidePage): HeroBadge[] {
 
 // ── Loader ───────────────────────────────────────────────
 
+/**
+ * Marks a genuine "this guide does not exist" outcome. Everything else that can
+ * go wrong on the way to the payload (429 from the app's own rate limiter, 5xx,
+ * abort/timeout, socket error) is TRANSIENT and must NOT be reported as 404:
+ * these URLs are indexed, and answering 404 on a transient fault invites
+ * deindexing. Transient faults answer 503 + Retry-After instead, which Google
+ * treats as "come back later" and which is never cached.
+ */
+class R3GuideNotFoundError extends Error {}
+
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const { pg_alias } = params;
 
@@ -161,10 +171,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
     if (!response.ok) {
       if (response.status === 404) {
-        throw data(
-          { message: `Guide R3 introuvable: ${pg_alias}` },
-          { status: 404 },
-        );
+        throw new R3GuideNotFoundError(`Guide R3 introuvable: ${pg_alias}`);
       }
       throw new Error(`R3 guide endpoint returned ${response.status}`);
     }
@@ -173,10 +180,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     const guide = result?.data as R3GuidePayload | null;
 
     if (!guide) {
-      throw data(
-        { message: `Pas de donnees R3 pour: ${pg_alias}` },
-        { status: 404 },
-      );
+      throw new R3GuideNotFoundError(`Pas de donnees R3 pour: ${pg_alias}`);
     }
 
     // Fetch R4 reference as a deferred promise (non-blocking for TTFB)
@@ -259,10 +263,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   } catch (error) {
     clearTimeout(timeoutId);
     if (error instanceof Response) throw error;
+
+    // Genuine absence — the only case that legitimately answers 404.
+    if (error instanceof R3GuideNotFoundError) {
+      throw data({ message: error.message }, { status: 404 });
+    }
+
+    // Transient fault (429 / 5xx / abort / socket). Answer 503 so the URL stays
+    // indexable, and pin no-store so neither Cloudflare nor the browser can
+    // retain the failure under the route's public `max-age=300` policy.
     logger.error(`[R3 Guide] Error loading guide for: ${pg_alias}`, error);
     throw data(
       { message: `Erreur chargement guide R3: ${pg_alias}` },
-      { status: 404 },
+      {
+        status: 503,
+        headers: { "Cache-Control": "no-store", "Retry-After": "60" },
+      },
     );
   }
 }

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -270,15 +270,14 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     }
 
     // Transient fault (429 / 5xx / abort / socket). Answer 503 so the URL stays
-    // indexable, and pin no-store so neither Cloudflare nor the browser can
-    // retain the failure under the route's public `max-age=300` policy.
+    // indexable. Cache-Control is deliberately NOT set here: `headers` below
+    // (buildCacheHeaders) is this route's single owner and already stamps the
+    // canonical no-store on a thrown error — setting it here would override
+    // that with a weaker value.
     logger.error(`[R3 Guide] Error loading guide for: ${pg_alias}`, error);
     throw data(
       { message: `Erreur chargement guide R3: ${pg_alias}` },
-      {
-        status: 503,
-        headers: { "Cache-Control": "no-store", "Retry-After": "60" },
-      },
+      { status: 503, headers: { "Retry-After": "60" } },
     );
   }
 }

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -347,7 +347,13 @@ export async function loader({ params }: LoaderFunctionArgs) {
     const res = await referencePromise;
 
     if (!res.ok) {
-      throw new Response("Référence non trouvée", { status: 404 });
+      // Only a genuine 404 from the backend means "this reference does not
+      // exist". Anything else (429 from the app's own rate limiter, 5xx,
+      // gateway fault) is TRANSIENT and must not be reported as 404 on an
+      // indexed URL — that invites deindexing.
+      throw res.status === 404
+        ? new Response("Référence non trouvée", { status: 404 })
+        : transientlyUnavailable();
     }
 
     const reference = await res.json();
@@ -368,9 +374,25 @@ export async function loader({ params }: LoaderFunctionArgs) {
       },
     );
   } catch (error) {
+    // Deliberate throws above (404 / 503) travel untouched — without this the
+    // catch swallowed them and re-threw a 404, logging a spurious error and
+    // flattening every outcome to "not found".
+    if (error instanceof Response) throw error;
     logger.error("Erreur chargement référence:", error);
-    throw new Response("Référence non trouvée", { status: 404 });
+    throw transientlyUnavailable();
   }
+}
+
+/**
+ * Transient fault → 503: retryable, and the URL stays indexable.
+ * Cache-Control is intentionally omitted — `headers` (buildCacheHeaders) is the
+ * single owner and stamps the canonical no-store on a thrown error.
+ */
+function transientlyUnavailable(): Response {
+  return new Response("Référence temporairement indisponible", {
+    status: 503,
+    headers: { "Retry-After": "60" },
+  });
 }
 
 // Single owner of this route's Cache-Control at the edge (Caddy no longer

--- a/frontend/app/utils/internal-api.server.ts
+++ b/frontend/app/utils/internal-api.server.ts
@@ -1,26 +1,60 @@
 /**
- * Internal API URL utility for server-side Remix loaders/actions
- * Used to construct URLs for backend API calls from Remix server-side code
+ * Internal API URL utility for server-side React Router loaders/actions.
  *
- * IMPORTANT: Prefer getInternalApiUrlFromRequest() in loaders/actions
- * to avoid creating outbound HTTP connections to localhost (causes port exhaustion).
+ * The SSR bundle runs INSIDE the NestJS process (`backend/src/remix/remix.controller.ts`
+ * façade, `app.listen(process.env.PORT || 3000)`), so a loader calling the API is
+ * calling its own process. These URLs MUST therefore stay on the loopback interface.
+ *
+ * ⚠️ NEVER derive the API host from the incoming request's public origin. In PROD the
+ * request origin is `https://www.automecanik.com`, so the server would egress to
+ * Cloudflare and route back into itself for every loader call. Measured on PROD
+ * (2026-08-15) for `/blog-pieces-auto/conseils/*`, which used the request origin:
+ *   - TTFB 1.78-2.27 s for a 221 KB document
+ *   - `/` (same process, same renderer, 279 KB — bigger) served in 0.29 s, because it
+ *     already resolved the API internally via `getInternalApiUrl`
+ *   - `/api/r3-guide/capteur-abs` answered in 227 ms on its own
+ * The ~1.5 s delta was pure CDN round-trip, and it capped mobile LCP at 4.6 s (CrUX,
+ * GSC "LCP > 4 s" group of 46 URLs). Egressing also made the loopback traffic subject
+ * to the app's own global rate limiter with `Cf-Connecting-Ip` set to the ORIGIN's
+ * public IP (`backend/src/common/guards/cloudflare-throttler.guard.ts`), so bursts
+ * self-throttled into 429s.
  */
 
+/** Port the NestJS process listens on — mirrors `backend/src/main.ts`. */
+const DEFAULT_INTERNAL_PORT = "3000";
+
+/** Hosts that are already internal: reuse them verbatim (DEV, tests, probes). */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
 /**
- * Construct API URL from the incoming request's origin.
- * This is the PREFERRED method in loaders/actions as it avoids creating
- * outbound HTTP connections to localhost, which can cause EADDRNOTAVAIL.
+ * Resolve the internal base URL, without any request-derived host.
+ * `INTERNAL_API_BASE_URL` wins when provisioned (container topologies where the API
+ * is not on loopback); otherwise the process's own port on 127.0.0.1.
+ */
+function getInternalBaseUrl(): string {
+  const configured = process.env.INTERNAL_API_BASE_URL?.trim();
+  if (configured) return configured.replace(/\/+$/, "");
+  return `http://127.0.0.1:${process.env.PORT || DEFAULT_INTERNAL_PORT}`;
+}
+
+/**
+ * Construct an API URL for use inside a loader/action.
  *
- * @param path - API path (e.g., "/api/catalog/homepage-rpc")
- * @param request - The Remix Request object
- * @returns Full URL using the request's origin
+ * The `request` is used ONLY to detect a request that already arrived over an
+ * internal address (DEV `npm run dev`, integration tests, container health probes),
+ * in which case its origin is reused so those environments behave exactly as before.
+ * Any public origin is deliberately ignored — see the file header.
+ *
+ * @param path - API path (e.g. "/api/catalog/homepage-rpc")
+ * @param request - The incoming Request object
+ * @returns Full URL on the internal interface
  *
  * @example
  * ```ts
  * export async function loader({ request }: LoaderFunctionArgs) {
  *   const url = getInternalApiUrlFromRequest("/api/catalog/data", request);
  *   const response = await fetch(url);
- *   return json(await response.json());
+ *   return await response.json();
  * }
  * ```
  */
@@ -28,19 +62,30 @@ export function getInternalApiUrlFromRequest(
   path: string,
   request: Request,
 ): string {
-  const url = new URL(request.url);
-  return `${url.origin}${path}`;
+  const origin = getInternalRequestOrigin(request);
+  return `${origin ?? getInternalBaseUrl()}${path}`;
 }
 
 /**
- * Construct API URL from environment variable.
- * Use this ONLY when request object is not available (e.g., background jobs).
- * In loaders/actions, prefer getInternalApiUrlFromRequest().
+ * Origin of the incoming request when it is already internal, else `null`.
+ * Malformed URLs fall back to `null` (→ the resolved internal base), never throw.
+ */
+function getInternalRequestOrigin(request: Request): string | null {
+  try {
+    const url = new URL(request.url);
+    return LOOPBACK_HOSTNAMES.has(url.hostname) ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Construct an API URL when no request object is available (background jobs,
+ * deferred work). Same resolution as `getInternalApiUrlFromRequest`.
  *
- * @param path - API path (e.g., "/api/catalog/homepage-rpc")
- * @returns Full URL using INTERNAL_API_BASE_URL or localhost fallback
+ * @param path - API path (e.g. "/api/catalog/homepage-rpc")
+ * @returns Full URL using INTERNAL_API_BASE_URL or the loopback fallback
  */
 export function getInternalApiUrl(path: string): string {
-  const baseUrl = process.env.INTERNAL_API_BASE_URL || "http://localhost:3000";
-  return `${baseUrl}${path}`;
+  return `${getInternalBaseUrl()}${path}`;
 }

--- a/frontend/tests/unit/internal-api-loopback.test.ts
+++ b/frontend/tests/unit/internal-api-loopback.test.ts
@@ -1,0 +1,100 @@
+/**
+ * SSR→API transport MUST stay on the loopback interface.
+ *
+ * The SSR bundle runs inside the NestJS process, so deriving the API host from the
+ * incoming request's PUBLIC origin makes the server egress to Cloudflare and route
+ * back into itself on every loader call. Measured on PROD 2026-08-15:
+ * `/blog-pieces-auto/conseils/*` (public origin) TTFB 1.78-2.27 s vs `/` (loopback,
+ * bigger document) 0.29 s — the delta capped mobile LCP at 4.6 s in CrUX.
+ *
+ * These tests are the anti-regression guard: if someone reintroduces
+ * `new URL(request.url).origin` as the API host, the first test fails.
+ */
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+
+import {
+  getInternalApiUrl,
+  getInternalApiUrlFromRequest,
+} from "~/utils/internal-api.server";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.INTERNAL_API_BASE_URL;
+  delete process.env.PORT;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("getInternalApiUrlFromRequest", () => {
+  it("never egresses to the public origin (the LCP regression)", () => {
+    const request = new Request(
+      "https://www.automecanik.com/blog-pieces-auto/conseils/capteur-abs",
+    );
+
+    const url = getInternalApiUrlFromRequest("/api/r3-guide/capteur-abs", request);
+
+    expect(url).toBe("http://127.0.0.1:3000/api/r3-guide/capteur-abs");
+    expect(url).not.toContain("automecanik.com");
+  });
+
+  it("ignores the public origin even behind a different public host", () => {
+    const request = new Request("https://preview.example.com/whatever");
+
+    expect(getInternalApiUrlFromRequest("/api/x", request)).toBe(
+      "http://127.0.0.1:3000/api/x",
+    );
+  });
+
+  it("honours PORT so it follows the process it lives in", () => {
+    process.env.PORT = "4001";
+    const request = new Request("https://www.automecanik.com/page");
+
+    expect(getInternalApiUrlFromRequest("/api/x", request)).toBe(
+      "http://127.0.0.1:4001/api/x",
+    );
+  });
+
+  it("prefers INTERNAL_API_BASE_URL and strips its trailing slash", () => {
+    process.env.INTERNAL_API_BASE_URL = "http://api.internal:8080/";
+    const request = new Request("https://www.automecanik.com/page");
+
+    expect(getInternalApiUrlFromRequest("/api/x", request)).toBe(
+      "http://api.internal:8080/api/x",
+    );
+  });
+
+  it("reuses an already-internal request origin (DEV / tests / probes)", () => {
+    for (const origin of [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:5173",
+    ]) {
+      const request = new Request(`${origin}/page`);
+      expect(getInternalApiUrlFromRequest("/api/x", request)).toBe(
+        `${origin}/api/x`,
+      );
+    }
+  });
+
+  it("falls back to the internal base on a malformed request url", () => {
+    const request = { url: "not a url" } as Request;
+
+    expect(getInternalApiUrlFromRequest("/api/x", request)).toBe(
+      "http://127.0.0.1:3000/api/x",
+    );
+  });
+});
+
+describe("getInternalApiUrl", () => {
+  it("resolves identically to the request-based helper", () => {
+    expect(getInternalApiUrl("/api/x")).toBe("http://127.0.0.1:3000/api/x");
+  });
+
+  it("prefers INTERNAL_API_BASE_URL", () => {
+    process.env.INTERNAL_API_BASE_URL = "http://api.internal:8080";
+    expect(getInternalApiUrl("/api/x")).toBe("http://api.internal:8080/api/x");
+  });
+});

--- a/frontend/tests/unit/reference-auto-loader-parallel.test.ts
+++ b/frontend/tests/unit/reference-auto-loader-parallel.test.ts
@@ -3,7 +3,13 @@
  * le fetch principal PUIS le fetch `/related` en SÉQUENTIEL, malgré le commentaire
  * "non-blocking" : les deux ne dépendent que de `slug`. Ce test épingle :
  *   1. le parallélisme (les 2 fetch partent avant que le principal ne résolve) ;
- *   2. la préservation du 404 (principal !ok) et du silent-[] (related en erreur).
+ *   2. le silent-[] (related en erreur).
+ *
+ * Mise à jour 2026-08-15 : le contrat d'erreur épinglé ici était « principal !ok
+ * → 404 », ce qui écrasait AUSSI les pannes transitoires (429 du rate limiter de
+ * l'app, 5xx, coupure réseau) en 404 sur une URL indexée — risque de
+ * désindexation. Le contrat est désormais explicite par statut : 404 = absence
+ * réelle, tout le reste = 503 + Retry-After.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -81,19 +87,49 @@ describe("reference-auto.$slug loader — parallélise le fetch principal + /rel
     expect(body.relatedRefs).toEqual([{ slug: "a", title: "A" }]);
   });
 
-  it("principal !ok → 404", async () => {
+  /** Runs the loader against a main-fetch outcome and returns what it threw. */
+  const throwsFor = async (main: unknown): Promise<Response | undefined> => {
     fetchMock.mockImplementation((url: string) =>
       url.endsWith("/related")
         ? Promise.resolve(okJson({ related: [] }))
-        : Promise.resolve({ ok: false, json: async () => ({}) }),
+        : (main as Promise<unknown>) instanceof Promise
+          ? (main as Promise<unknown>)
+          : Promise.resolve(main),
     );
-
-    let thrown: Response | undefined;
     try {
       await call();
     } catch (e) {
-      thrown = e as Response;
+      return e as Response;
     }
+    return undefined;
+  };
+
+  it("principal 404 → 404 (absence réelle)", async () => {
+    const thrown = await throwsFor({ ok: false, status: 404, json: async () => ({}) });
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(404);
+  });
+
+  // Un 429 (rate limiter de l'app) ou un 5xx est TRANSITOIRE. Le rendre en 404
+  // sur une URL indexée invite à la désindexation — d'où le 503 retryable.
+  it.each([429, 500, 502, 503])(
+    "principal %i → 503 + Retry-After (transitoire, jamais 404)",
+    async (status) => {
+      const thrown = await throwsFor({ ok: false, status, json: async () => ({}) });
+      expect(thrown).toBeInstanceOf(Response);
+      expect(thrown?.status).toBe(503);
+      expect(thrown?.headers.get("Retry-After")).toBe("60");
+    },
+  );
+
+  it("panne réseau du principal → 503, pas 404", async () => {
+    const thrown = await throwsFor(Promise.reject(new Error("ECONNRESET")));
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(503);
+  });
+
+  it("payload vide malgré un 200 → 404 (absence réelle)", async () => {
+    const thrown = await throwsFor(okJson({}));
     expect(thrown).toBeInstanceOf(Response);
     expect(thrown?.status).toBe(404);
   });


### PR DESCRIPTION
## Problème

GSC signale **LCP > 4 s (mobile), 4,6 s** sur un groupe de **46 URLs** `/blog-pieces-auto/conseils/*` (CrUX au 14/08/2026).

Diagnostic mesuré sur PROD le 15/08/2026 (`curl`, UA mobile) — **ce n'est ni l'image, ni le CSS, ni le cache R3** :

| Route | TTFB | Poids |
|---|---|---|
| `/` | **0,29 s** | 279 KB |
| `/blog-pieces-auto/guide-achat/capteur-abs` (R6) | 0,72 s | 129 KB |
| **`/blog-pieces-auto/conseils/capteur-abs` (R3)** | **1,78 – 2,90 s** | 221 KB |
| `/api/r3-guide/capteur-abs` | 227 ms | 57 KB |
| `/health` | 197 ms | — |

La home rend **un document plus gros 6× plus vite**, dans le même processus et le même moteur de rendu. Suspects écartés par la mesure : image héros = **15 KB WebP** déjà `preload` + `fetchpriority=high` ; cache Redis R3 (24 h, #1270) **fonctionne** (227 ms).

## Cause racine

`getInternalApiUrlFromRequest()` dérivait l'hôte de l'API de **l'origine publique de la requête**. Or le bundle SSR tourne **à l'intérieur du processus NestJS** (façade `remix.controller.ts`, `app.listen(PORT)`). En PROD chaque appel de loader sortait donc vers Cloudflare pour **revenir dans le même conteneur**.

L'expérience naturelle est décisive : la home utilise déjà `getInternalApiUrl()` (loopback) → 0,29 s ; R3 utilisait l'origine publique → 1,8 s. **~1,5 s de pur aller-retour CDN**, ce qui plafonne mécaniquement le LCP mobile à 4,6 s.

Effet de bord : le trafic SSR devenait justiciable du **rate limiter global de l'app** avec `Cf-Connecting-Ip` = IP de l'origine — les rafales s'auto-throttlaient en 429.

## Correctifs

**1. Transport SSR→API en loopback** — `frontend/app/utils/internal-api.server.ts`

Convergence sur le pattern **déjà utilisé par la home**, pas de nouvelle abstraction : `INTERNAL_API_BASE_URL` si provisionné, sinon `127.0.0.1:$PORT`. Une requête déjà arrivée par une adresse interne (DEV, tests, sondes) garde son origine → **comportement hors-PROD inchangé**.

Changement **en un seul point** : les 24 autres fichiers de routes utilisant ce helper sont corrigés sans être édités.

**2. Fin du masquage des pannes en 404** — R3 `conseils/$pg_alias`, R4 `reference-auto/$slug`

Les deux routes rendaient **404 pour toute panne** (429 du rate limiter, 5xx, abort, coupure réseau). Sur des URLs indexées, c'est un risque de désindexation. **Reproduit** : ~10 requêtes rapprochées ont fait basculer 6 URLs en 404, toutes revenues en 200 après une pause.

Désormais : 404 **uniquement** pour une absence réelle, **503 + Retry-After** pour tout ce qui est transitoire. Sur R4, le `catch` avalait aussi ses propres `throw new Response(404)` délibérés et en re-jetait un autre — corrigé.

`Cache-Control` volontairement **non posé** sur les 503 : `buildCacheHeaders` est le propriétaire unique et applique le `no-cache, no-store, must-revalidate` canonique sur une erreur jetée, mais **honore verbatim** un Cache-Control explicite — le poser à la main l'aurait *affaibli* (`cache-control.test.ts:74-86`).

## Vérification

- `tsc --noEmit` exit 0 · `eslint` exit 0
- **522/522** tests unitaires frontend (67 fichiers), contre 516 avant
- 8 nouveaux tests anti-régression `internal-api-loopback.test.ts` : si quelqu'un réintroduit `new URL(request.url).origin` comme hôte d'API, le premier test casse
- Contrat de test gouverné `reference-auto-loader-parallel.test.ts` **mis à jour dans ce commit** (pas contourné) : explicite par statut
- Endpoints dépendants du `Host` vérifiés **non atteints** par ce helper

**Non vérifié : l'effet runtime.** Le TTFB post-correctif n'est pas mesuré — cela demande un déploiement. La cause mesurée est supprimée par construction, mais le verdict n'est pas « réglé » tant que PREPROD ne l'a pas confirmé. CrUX mettra ~28 jours à refléter le changement.

## Hors périmètre (constats à traiter séparément)

1. **Cloudflare ne cache aucun HTML** (`cf-cache-status: DYNAMIC`). Vérifié empiriquement : R4 émet déjà `s-maxage=3600` et reste `DYNAMIC` → **ajouter `s-maxage` ne sert à rien**, il faut une *Cache Rule* Cloudflare (hors dépôt).
2. **Bucket de throttling partagé en loopback** — préexistant ; une exemption exige de vérifier la topologie réseau (si Caddy atteignait l'origine via loopback, ce serait un bypass total du rate-limit). Non touché ici volontairement.
3. `/blog-pieces-auto/conseils` (index) sert **1,37 MB de HTML**.
4. `feat/lcp-r3-pr2-imgproxy-hero` est **à abandonner** : son garde exclut les chemins `/img/`, précisément le format servi (`/img/uploads/articles/...`) — elle serait un no-op, et sa base est périmée (`meta({ data })` vs `({ loaderData })`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
