### PR TITLE
perf(rm): cache R2 soft-404 — classification + limit canonique + TTL alt 24h (A2)

### DIFF
--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,16 +2,16 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-07-02'
+last_scan: '2026-09-02'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/dto/alternatives-v2.dto.ts
 - backend/src/modules/rm/rm.module.ts
 - backend/src/modules/rm/rm.types.ts
 - backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
+- backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts
 - backend/src/modules/rm/services/__tests__/rm-builder-seo-shadow.test.ts
 - backend/src/modules/rm/services/__tests__/rm-soft404-tracker.service.test.ts
-- backend/src/modules/rm/services/gamme-clusters.const.ts
 depends_on:
 - DatabaseModule
 - CatalogModule

--- a/backend/src/config/cache-ttl.config.ts
+++ b/backend/src/config/cache-ttl.config.ts
@@ -353,6 +353,37 @@ export const CACHE_STRATEGIES = {
       description: 'Promotional data',
     },
   },
+
+  // ═══════════════════════════════════════════════════════════════
+  // RM (page R2 gamme × véhicule) — A2 2026-09-02
+  // Toute entrée est stockée au `limit` canonique, jamais par limit.
+  // ═══════════════════════════════════════════════════════════════
+  RM: {
+    PAGE_V2: {
+      ttl: CacheTTL.ONE_HOUR,
+      prefix: 'rm:page-v2:',
+      description:
+        'rm_get_page_complete_v2 — résultat plein (classification ok)',
+    },
+    PAGE_V2_EMPTY: {
+      ttl: CacheTTL.FIFTEEN_MINUTES,
+      prefix: 'rm:page-v2:',
+      description:
+        'rm_get_page_complete_v2 — 0 produit (classification empty) : population soft-404, TTL court',
+    },
+    ALTERNATIVES: {
+      ttl: CacheTTL.ONE_DAY,
+      prefix: 'alt:',
+      description:
+        'get_soft_404_alternatives — dérivé de compatibilité TecDoc, stable entre imports catalogue',
+    },
+    ALTERNATIVES_ERROR: {
+      ttl: 30,
+      prefix: 'alt:',
+      description:
+        'get_soft_404_alternatives — échec RPC : réponse vide à TTL court, anti-poisoning (incident 2026-05-19)',
+    },
+  },
 } as const;
 
 /**

--- a/backend/src/modules/rm/controllers/rm.controller.ts
+++ b/backend/src/modules/rm/controllers/rm.controller.ts
@@ -18,7 +18,10 @@ import {
   OperationFailedException,
   DomainNotFoundException,
 } from '@common/exceptions';
-import { RmBuilderService } from '../services/rm-builder.service';
+import {
+  RmBuilderService,
+  PAGE_V2_CANONICAL_LIMIT,
+} from '../services/rm-builder.service';
 import { RmAlternativesService } from '../services/rm-alternatives.service';
 import { RmSoft404TrackerService } from '../services/rm-soft404-tracker.service';
 import { TrackSoft404BodySchema } from '../dto/alternatives-v2.dto';
@@ -147,7 +150,10 @@ export class RmController {
   async getPageV2(
     @Query('gamme_id', ParseIntPipe) gamme_id: number,
     @Query('vehicle_id', ParseIntPipe) vehicle_id: number,
-    @Query('limit', new DefaultValuePipe(200), ParseIntPipe) limit: number,
+    // Défaut = limit canonique du cache rm:page-v2 (tout autre limit contourne
+    // le cache). Partagé avec RmBuilderService pour ne pas dériver.
+    @Query('limit', new DefaultValuePipe(PAGE_V2_CANONICAL_LIMIT), ParseIntPipe)
+    limit: number,
   ) {
     const startTime = performance.now();
     const clampedLimit = Math.min(Math.max(limit, 1), 500);

--- a/backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
@@ -10,12 +10,46 @@ process.env.SUPABASE_SERVICE_ROLE_KEY =
 
 import { RmAlternativesService } from '../rm-alternatives.service';
 import type { CacheService } from '@cache/cache.service';
+import { CACHE_STRATEGIES } from '../../../../config/cache-ttl.config';
 
 /**
  * Pattern test : instanciation directe + mock `callRpc` (méthode héritée).
  * Service refactor canon : 1 appel RPC `get_soft_404_alternatives`, le
  * ranking vit dans Postgres SECURITY DEFINER (bypass RLS, ADR-076).
+ *
+ * Contrat de cache (A2, 2026-09-02) :
+ *   - clé `alt:{type_id}:{pg_id}:v4` — SANS `limit` (cardinalité = type×pg)
+ *   - la RPC est toujours appelée au `limit` canonique maximal (24) ; la
+ *     réponse est tranchée côté application au `limit` demandé
+ *   - le cache stocke le payload RPC brut ; etag recalculé sur la tranche
+ *   - TTL succès = CACHE_STRATEGIES.RM.ALTERNATIVES (24 h), erreur = 30 s
  */
+const KEY = 'alt:11836:3859:v4';
+const CANONICAL_LIMIT = 24;
+
+const vehicle = (id: number) => ({
+  type_id: String(id),
+  type_name: `type ${id}`,
+  modele_id: 1,
+  marque_id: 1,
+  tier: 1,
+});
+const gamme = (id: number) => ({
+  pg_id: id,
+  pg_name: `gamme ${id}`,
+  piece_count: 1,
+  tier: 1,
+});
+const model = (id: number) => ({ modele_id: id, modele_name: `m${id}` });
+
+// Payload "plein" tel que la RPC le rend au limit canonique : 6 véhicules,
+// 8 gammes, 4 modèles (bornes internes LEAST(6,p_limit) / LEAST(8,p_limit) / 4).
+const fullPayload = {
+  alternativeVehicles: [1, 2, 3, 4, 5, 6].map(vehicle),
+  alternativeGammes: [1, 2, 3, 4, 5, 6, 7, 8].map(gamme),
+  relatedModels: [1, 2, 3, 4].map(model),
+};
+
 describe('RmAlternativesService (RPC canon)', () => {
   let service: RmAlternativesService;
   let cacheMock: jest.Mocked<Partial<CacheService>>;
@@ -32,64 +66,98 @@ describe('RmAlternativesService (RPC canon)', () => {
     (service as any).callRpc = callRpcMock;
   });
 
-  describe('compute()', () => {
-    it('retourne le payload depuis le cache si présent (cache hit)', async () => {
-      const cached = {
-        success: true as const,
-        version: 'v2' as const,
-        etag: 'sha256-cached',
-        alternativeVehicles: [],
-        alternativeGammes: [],
-        relatedModels: [],
-      };
-      cacheMock.get!.mockResolvedValue(JSON.stringify(cached));
+  describe('compute() — clé et limit canonique', () => {
+    it('la clé de cache ne contient pas le limit (cardinalité type×pg)', async () => {
+      cacheMock.get!.mockResolvedValue(null);
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
 
-      const result = await service.compute(11836, 3859, 12);
+      await service.compute(11836, 3859, 3);
+      await service.compute(11836, 3859, 12);
 
-      expect(cacheMock.get).toHaveBeenCalledWith('alt:11836:3859:v3');
-      expect(callRpcMock).not.toHaveBeenCalled();
-      expect(result).toEqual(cached);
+      expect(cacheMock.get).toHaveBeenNthCalledWith(1, KEY);
+      expect(cacheMock.get).toHaveBeenNthCalledWith(2, KEY);
     });
 
-    it('appelle la RPC get_soft_404_alternatives en cache miss avec params nommés', async () => {
+    it('appelle la RPC au limit canonique (24), quel que soit le limit demandé', async () => {
       cacheMock.get!.mockResolvedValue(null);
-      callRpcMock.mockResolvedValue({
-        data: {
-          alternativeVehicles: [],
-          alternativeGammes: [],
-          relatedModels: [],
-        },
-        error: null,
-      });
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
 
-      await service.compute(11836, 3859, 12);
+      await service.compute(11836, 3859, 3);
 
       expect(callRpcMock).toHaveBeenCalledWith(
         'get_soft_404_alternatives',
-        { p_type_id: 11836, p_pg_id: 3859, p_limit: 12 },
+        { p_type_id: 11836, p_pg_id: 3859, p_limit: CANONICAL_LIMIT },
         { source: 'api' },
       );
     });
 
-    it('produit un etag sha256-stable et écrit dans le cache (cache miss)', async () => {
+    it('écrit le payload RPC brut dans le cache avec le TTL RM.ALTERNATIVES', async () => {
       cacheMock.get!.mockResolvedValue(null);
-      callRpcMock.mockResolvedValue({
-        data: {
-          alternativeVehicles: [],
-          alternativeGammes: [],
-          relatedModels: [],
-        },
-        error: null,
-      });
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
 
-      const r1 = await service.compute(11836, 3859, 12);
-      const r2 = await service.compute(11836, 3859, 12);
+      await service.compute(11836, 3859, 12);
 
-      expect(r1.etag).toMatch(/^sha256-[0-9a-f]{64}$/);
-      expect(r1.etag).toEqual(r2.etag);
-      expect(cacheMock.set).toHaveBeenCalled();
+      expect(cacheMock.set).toHaveBeenCalledWith(
+        KEY,
+        JSON.stringify(fullPayload),
+        CACHE_STRATEGIES.RM.ALTERNATIVES.ttl,
+      );
+      expect(CACHE_STRATEGIES.RM.ALTERNATIVES.ttl).toBe(86400);
+    });
+  });
+
+  describe('compute() — tranche au limit demandé', () => {
+    it('tranche vehicles et gammes au limit demandé, relatedModels inchangé', async () => {
+      cacheMock.get!.mockResolvedValue(null);
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
+
+      const result = await service.compute(11836, 3859, 3);
+
+      expect(result.alternativeVehicles).toHaveLength(3);
+      expect(result.alternativeGammes).toHaveLength(3);
+      expect(result.relatedModels).toHaveLength(4);
+      expect((result.alternativeVehicles[0] as any).type_id).toBe('1');
+      expect((result.alternativeVehicles[2] as any).type_id).toBe('3');
     });
 
+    it('un limit ≥ aux bornes internes (6/8) rend le payload complet', async () => {
+      cacheMock.get!.mockResolvedValue(null);
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
+
+      const result = await service.compute(11836, 3859, 12);
+
+      expect(result.alternativeVehicles).toHaveLength(6);
+      expect(result.alternativeGammes).toHaveLength(8);
+      expect(result.relatedModels).toHaveLength(4);
+    });
+
+    it('sert une tranche correcte depuis une entrée de cache brute (cache hit)', async () => {
+      cacheMock.get!.mockResolvedValue(JSON.stringify(fullPayload));
+
+      const result = await service.compute(11836, 3859, 2);
+
+      expect(callRpcMock).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.version).toBe('v2');
+      expect(result.alternativeVehicles).toHaveLength(2);
+      expect(result.alternativeGammes).toHaveLength(2);
+      expect(result.relatedModels).toHaveLength(4);
+    });
+
+    it("l'etag est calculé sur la tranche : deux limits ≠ deux etags, même entrée", async () => {
+      cacheMock.get!.mockResolvedValue(JSON.stringify(fullPayload));
+
+      const r3 = await service.compute(11836, 3859, 3);
+      const r12 = await service.compute(11836, 3859, 12);
+      const r12bis = await service.compute(11836, 3859, 12);
+
+      expect(r3.etag).toMatch(/^sha256-[0-9a-f]{64}$/);
+      expect(r3.etag).not.toEqual(r12.etag);
+      expect(r12.etag).toEqual(r12bis.etag);
+    });
+  });
+
+  describe('compute() — chemin erreur', () => {
     it('fallback gracieux sur RPC error : payload vide + cache short-TTL (anti-poisoning)', async () => {
       cacheMock.get!.mockResolvedValue(null);
       callRpcMock.mockResolvedValue({
@@ -103,13 +171,9 @@ describe('RmAlternativesService (RPC canon)', () => {
       expect(result.alternativeVehicles).toEqual([]);
       expect(result.alternativeGammes).toEqual([]);
       expect(result.relatedModels).toEqual([]);
-      // Error path uses CACHE_TTL_ERROR_SECONDS=30, not 300, so a transient
-      // failure does not poison the cache for 5 min (regression 2026-05-19).
-      expect(cacheMock.set).toHaveBeenCalledWith(
-        'alt:11836:3859:v3',
-        expect.any(String),
-        30,
-      );
+      // Error path uses CACHE_TTL_ERROR_SECONDS=30, not the 24 h success TTL,
+      // so a transient failure does not poison the cache (regression 2026-05-19).
+      expect(cacheMock.set).toHaveBeenCalledWith(KEY, expect.any(String), 30);
     });
 
     it('auth failure (Invalid API key) is logged at ERROR not WARN', async () => {
@@ -132,6 +196,19 @@ describe('RmAlternativesService (RPC canon)', () => {
       expect(errorSpy.mock.calls[0][0]).toMatch(/Invalid API key/);
     });
 
+    it('une entrée de cache illisible est ignorée et recalculée', async () => {
+      cacheMock.get!.mockResolvedValue('{not-json');
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
+      jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+
+      const result = await service.compute(11836, 3859, 12);
+
+      expect(callRpcMock).toHaveBeenCalledTimes(1);
+      expect(result.alternativeVehicles).toHaveLength(6);
+    });
+  });
+
+  describe('compute() — propagation', () => {
     it('propage le payload RPC (vehicles/gammes/relatedModels)', async () => {
       cacheMock.get!.mockResolvedValue(null);
       callRpcMock.mockResolvedValue({
@@ -163,6 +240,17 @@ describe('RmAlternativesService (RPC canon)', () => {
       expect(result.alternativeVehicles).toHaveLength(1);
       expect((result.alternativeVehicles[0] as any).tier).toBe(1);
       expect(result.alternativeGammes).toHaveLength(1);
+    });
+
+    it('produit un etag sha256-stable pour une même tranche (cache miss)', async () => {
+      cacheMock.get!.mockResolvedValue(null);
+      callRpcMock.mockResolvedValue({ data: fullPayload, error: null });
+
+      const r1 = await service.compute(11836, 3859, 12);
+      const r2 = await service.compute(11836, 3859, 12);
+
+      expect(r1.etag).toMatch(/^sha256-[0-9a-f]{64}$/);
+      expect(r1.etag).toEqual(r2.etag);
     });
   });
 

--- a/backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts
@@ -1,0 +1,199 @@
+// backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_KEY || 'test-service-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key';
+
+import {
+  RmBuilderService,
+  PAGE_V2_CANONICAL_LIMIT,
+} from '../rm-builder.service';
+import type { CacheService } from '@cache/cache.service';
+import { CACHE_STRATEGIES } from '../../../../config/cache-ttl.config';
+
+/**
+ * Contrat de cache de `getPageCompleteV2` (A2, 2026-09-02).
+ *
+ * Défaut corrigé : le cache n'était écrit que si `count > 0`, donc chaque
+ * couple gamme×véhicule sans produit (la population soft-404) rejouait la
+ * RPC `rm_get_page_complete_v2` (~280 ms) à chaque requête, pour toujours.
+ *
+ * Nouveau contrat, aligné sur `classifyPageV2Result` :
+ *   - 'ok'        → cache, TTL RM.PAGE_V2 (1 h)
+ *   - 'empty'     → cache, TTL RM.PAGE_V2_EMPTY (15 min)
+ *   - 'not_found' → jamais mis en cache
+ *   - 'error'     → jamais mis en cache (mettre une erreur RPC en cache
+ *                   comme « vide » = incident 2026-05-19)
+ *   - limit ≠ canonique (200) → contourne le cache (lecture ET écriture) :
+ *     `count`/`filters`/`minPrice` dépendent du limit, on ne tranche pas.
+ */
+const KEY = 'rm:page-v2:402:100413';
+
+function buildService(cache: jest.Mocked<Partial<CacheService>>) {
+  const dummy = {} as never;
+  const service = new RmBuilderService(
+    cache as unknown as CacheService,
+    dummy, // SeoTemplateService — branche SEO non exercée (pas de seo_raw)
+    dummy, // RpcGateService — callRpc est mocké
+    dummy, // SeoShadowObservatory
+  );
+  const callRpc = jest.fn();
+  (service as any).callRpc = callRpc;
+  return { service, callRpc };
+}
+
+const okResult = {
+  success: true,
+  products: [{ id: 1 }],
+  count: 1,
+  minPrice: 10,
+  grouped_pieces: [],
+  vehicleInfo: {},
+  gamme: {},
+  seo: {},
+  oemRefs: [],
+  crossSelling: [],
+  filters: { brands: [], qualities: [], sides: [], price_range: {} },
+  validation: {},
+  duration_ms: 0,
+};
+
+const emptyResult = { ...okResult, success: false, products: [], count: 0 };
+
+describe('RmBuilderService.getPageCompleteV2 — contrat de cache', () => {
+  let cache: jest.Mocked<Partial<CacheService>>;
+
+  beforeEach(() => {
+    cache = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+  });
+
+  it('exporte le limit canonique = 200 (défaut du contrôleur et du loader R2)', () => {
+    expect(PAGE_V2_CANONICAL_LIMIT).toBe(200);
+  });
+
+  it("met en cache un résultat 'ok' avec le TTL RM.PAGE_V2", async () => {
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({ data: okResult, error: null });
+
+    await service.getPageCompleteV2({ gamme_id: 402, vehicle_id: 100413 });
+
+    expect(cache.set).toHaveBeenCalledWith(
+      KEY,
+      expect.objectContaining({ success: true, count: 1 }),
+      CACHE_STRATEGIES.RM.PAGE_V2.ttl,
+    );
+    expect(CACHE_STRATEGIES.RM.PAGE_V2.ttl).toBe(3600);
+  });
+
+  it("met en cache un résultat 'empty' (0 produit) avec le TTL court RM.PAGE_V2_EMPTY", async () => {
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({ data: emptyResult, error: null });
+
+    await service.getPageCompleteV2({ gamme_id: 402, vehicle_id: 100413 });
+
+    expect(cache.set).toHaveBeenCalledWith(
+      KEY,
+      expect.objectContaining({ success: false, count: 0 }),
+      CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl,
+    );
+    expect(CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl).toBe(900);
+  });
+
+  it("ne met JAMAIS en cache un résultat 'error' (échec RPC)", async () => {
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'connection reset' },
+    });
+
+    const result = await service.getPageCompleteV2({
+      gamme_id: 402,
+      vehicle_id: 100413,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('RPC_ERROR');
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("ne met JAMAIS en cache un résultat 'not_found' (VEHICLE_NOT_FOUND)", async () => {
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({
+      data: {
+        ...emptyResult,
+        error: { code: 'VEHICLE_NOT_FOUND', message: 'nope' },
+      },
+      error: null,
+    });
+
+    await service.getPageCompleteV2({ gamme_id: 402, vehicle_id: 100413 });
+
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("sert une entrée 'empty' depuis le cache sans rappeler la RPC", async () => {
+    cache.get = jest
+      .fn()
+      .mockResolvedValue({ ...emptyResult, cacheHit: false });
+    const { service, callRpc } = buildService(cache);
+
+    const result = await service.getPageCompleteV2({
+      gamme_id: 402,
+      vehicle_id: 100413,
+    });
+
+    expect(callRpc).not.toHaveBeenCalled();
+    expect(result.cacheHit).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.count).toBe(0);
+  });
+
+  it("sert une entrée 'ok' depuis le cache sans rappeler la RPC", async () => {
+    cache.get = jest.fn().mockResolvedValue({ ...okResult, cacheHit: false });
+    const { service, callRpc } = buildService(cache);
+
+    const result = await service.getPageCompleteV2({
+      gamme_id: 402,
+      vehicle_id: 100413,
+    });
+
+    expect(callRpc).not.toHaveBeenCalled();
+    expect(result.cacheHit).toBe(true);
+    expect(result.count).toBe(1);
+  });
+
+  it('un limit non canonique contourne le cache en lecture ET en écriture', async () => {
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({ data: okResult, error: null });
+
+    await service.getPageCompleteV2({
+      gamme_id: 402,
+      vehicle_id: 100413,
+      limit: 50,
+    });
+
+    expect(cache.get).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
+    expect(callRpc).toHaveBeenCalledWith(
+      'rm_get_page_complete_v2',
+      { p_gamme_id: 402, p_vehicle_id: 100413, p_limit: 50 },
+      { source: 'api' },
+    );
+  });
+
+  it('le limit canonique explicite (200) utilise le cache comme le défaut', async () => {
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({ data: okResult, error: null });
+
+    await service.getPageCompleteV2({
+      gamme_id: 402,
+      vehicle_id: 100413,
+      limit: PAGE_V2_CANONICAL_LIMIT,
+    });
+
+    expect(cache.get).toHaveBeenCalledWith(KEY);
+    expect(cache.set).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts
@@ -20,9 +20,11 @@ import { CACHE_STRATEGIES } from '../../../../config/cache-ttl.config';
  * couple gamme×véhicule sans produit (la population soft-404) rejouait la
  * RPC `rm_get_page_complete_v2` (~280 ms) à chaque requête, pour toujours.
  *
- * Nouveau contrat, aligné sur `classifyPageV2Result` :
- *   - 'ok'        → cache, TTL RM.PAGE_V2 (1 h)
- *   - 'empty'     → cache, TTL RM.PAGE_V2_EMPTY (15 min)
+ * Nouveau contrat, aligné sur `classifyPageV2Result` × `count` :
+ *   - 'ok' et count > 0 → cache, TTL RM.PAGE_V2 (1 h)
+ *   - 'ok' et count = 0 → cache, TTL RM.PAGE_V2_EMPTY (15 min) — forme réelle
+ *                         d'un couple existant sans produit (RPC success:true)
+ *   - 'empty'           → cache, TTL RM.PAGE_V2_EMPTY (15 min)
  *   - 'not_found' → jamais mis en cache
  *   - 'error'     → jamais mis en cache (mettre une erreur RPC en cache
  *                   comme « vide » = incident 2026-05-19)
@@ -99,6 +101,27 @@ describe('RmBuilderService.getPageCompleteV2 — contrat de cache', () => {
       CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl,
     );
     expect(CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl).toBe(900);
+  });
+
+  it('un couple vide RÉEL (RPC: success true, count 0) prend le TTL court, pas 1 h', async () => {
+    // Forme observée sur DEV:3000 pour 3859×11836 (soft-404 fixture #1) :
+    // rm_get_page_complete_v2 ne rend `success:false` que sur INVALID_PARAMS /
+    // *_NOT_FOUND / INTERNAL_ERROR (toujours avec `error`). Un couple existant
+    // sans produit est donc `success:true, count:0` → classifyPageV2Result dit
+    // 'ok'. Le TTL doit suivre le COUNT, pas le seul drapeau success.
+    const { service, callRpc } = buildService(cache);
+    callRpc.mockResolvedValue({
+      data: { ...okResult, products: [], count: 0 },
+      error: null,
+    });
+
+    await service.getPageCompleteV2({ gamme_id: 3859, vehicle_id: 11836 });
+
+    expect(cache.set).toHaveBeenCalledWith(
+      'rm:page-v2:3859:11836',
+      expect.objectContaining({ success: true, count: 0 }),
+      CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl,
+    );
   });
 
   it("ne met JAMAIS en cache un résultat 'error' (échec RPC)", async () => {

--- a/backend/src/modules/rm/services/rm-alternatives.service.ts
+++ b/backend/src/modules/rm/services/rm-alternatives.service.ts
@@ -3,26 +3,54 @@ import { Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { CacheService } from '@cache/cache.service';
+import { CACHE_STRATEGIES } from '../../../config/cache-ttl.config';
 import type { AlternativesV2Response } from '../dto/alternatives-v2.dto';
 
-const CACHE_TTL_SECONDS = 300;
-// Error-path TTL kept low so a transient RPC failure does not poison the cache
-// for 5 minutes. Long-TTL caching of empty responses was the amplifier behind
-// the soft-404 R2 smoke regression detected 2026-05-19 (stale anon publishable
-// key → 'Invalid API key' on every RPC → 300s cache of [] → 5min false-empty).
-const CACHE_TTL_ERROR_SECONDS = 30;
+// TTLs déclarés dans CACHE_STRATEGIES.RM (A2, 2026-09-02) — plus de littéral local.
+// Succès = 24 h : les alternatives dérivent de la compatibilité TecDoc, qui ne
+// bouge qu'à l'import catalogue. À 300 s sur une cardinalité 54 k × 9 k, le
+// taux de hit était structurellement ~0 (498 k appels RPC, 2 795 blocs/appel).
+const CACHE_TTL_SECONDS = CACHE_STRATEGIES.RM.ALTERNATIVES.ttl;
+// Error-path TTL kept low so a transient RPC failure does not poison the cache.
+// Long-TTL caching of empty responses was the amplifier behind the soft-404 R2
+// smoke regression detected 2026-05-19 (stale anon publishable key → 'Invalid
+// API key' on every RPC → 300s cache of [] → 5min false-empty).
+const CACHE_TTL_ERROR_SECONDS = CACHE_STRATEGIES.RM.ALTERNATIVES_ERROR.ttl;
 const CACHE_KEY_PREFIX = 'alt';
 // v1 → v2 (PR #633) : reset stale empty entries from the .from() RLS-bypass era.
 // v2 → v3 (2026-05-19) : reset stale empty entries from the rotated-publishable-key
 // era (preprod ANON_KEY rotated by Supabase but GitHub secret not synced — every RPC
 // returned 'Invalid API key', cached as empty for 5min). Pair with the short
 // CACHE_TTL_ERROR_SECONDS above to prevent the next rotation from repeating this.
-const CACHE_KEY_VERSION = 'v3';
+// v3 → v4 (2026-09-02, A2) : la valeur cachée change de forme — payload RPC brut
+// au limit canonique (tranché à la lecture) au lieu de la réponse construite.
+const CACHE_KEY_VERSION = 'v4';
+// Limit canonique = borne haute du contrôleur (clamp 1..24). La RPC borne
+// elle-même à LEAST(6, p_limit) véhicules / LEAST(8, p_limit) gammes / 4 modèles :
+// une seule entrée de cache par (type_id, pg_id) sert donc tous les limits par
+// tranche préfixe, sans multiplier la cardinalité (NO-GO 6c du plan massdoc).
+const RPC_CANONICAL_LIMIT = 24;
 
 interface RpcPayload {
   alternativeVehicles: unknown[];
   alternativeGammes: unknown[];
   relatedModels: unknown[];
+}
+
+const EMPTY_PAYLOAD: RpcPayload = {
+  alternativeVehicles: [],
+  alternativeGammes: [],
+  relatedModels: [],
+};
+
+function isRpcPayload(value: unknown): value is RpcPayload {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    Array.isArray(v.alternativeVehicles) &&
+    Array.isArray(v.alternativeGammes) &&
+    Array.isArray(v.relatedModels)
+  );
 }
 
 /**
@@ -37,9 +65,9 @@ interface RpcPayload {
  * bypass RLS — ADR-021 hardening + ADR-028 Option D preprod READ_ONLY).
  *
  * Ce service est un thin wrapper :
- *   1. Cache-aside Redis 5 min
- *   2. Appel RPC unique (1 round-trip)
- *   3. Calcul etag sha256 canonical JSON (replay-safe)
+ *   1. Cache-aside Redis (TTL CACHE_STRATEGIES.RM.ALTERNATIVES), clé sans limit
+ *   2. Appel RPC unique (1 round-trip) au limit canonique
+ *   3. Tranche préfixe au limit demandé + etag sha256 canonical JSON (replay-safe)
  */
 @Injectable()
 export class RmAlternativesService extends SupabaseBaseService {
@@ -58,12 +86,9 @@ export class RmAlternativesService extends SupabaseBaseService {
 
     const cached = await this.cache.get(cacheKey);
     if (cached) {
-      try {
-        return typeof cached === 'string'
-          ? (JSON.parse(cached) as AlternativesV2Response)
-          : (cached as AlternativesV2Response);
-      } catch {
-        this.logger.warn(`Cache parse error for ${cacheKey}, recomputing`);
+      const payload = this.parseCachedPayload(cached, cacheKey);
+      if (payload) {
+        return this.buildResponse(this.sliceToLimit(payload, limit));
       }
     }
 
@@ -72,7 +97,7 @@ export class RmAlternativesService extends SupabaseBaseService {
     // only fail at runtime (incident root cause for run 26101726823).
     const { data, error } = await this.callRpc<RpcPayload>(
       'get_soft_404_alternatives',
-      { p_type_id: type_id, p_pg_id: pg_id, p_limit: limit },
+      { p_type_id: type_id, p_pg_id: pg_id, p_limit: RPC_CANONICAL_LIMIT },
       { source: 'api' as const },
     );
 
@@ -90,25 +115,19 @@ export class RmAlternativesService extends SupabaseBaseService {
           error?.message ?? 'no data'
         }`,
       );
-      const empty = this.buildResponse({
-        alternativeVehicles: [],
-        alternativeGammes: [],
-        relatedModels: [],
-      });
       // Short TTL on error path: thundering-herd protection without long-window
       // cache poisoning. If the underlying issue clears (key re-synced, RLS
       // policy fixed, transient timeout), recovery is bounded to 30s.
       await this.cache.set(
         cacheKey,
-        JSON.stringify(empty),
+        JSON.stringify(EMPTY_PAYLOAD),
         CACHE_TTL_ERROR_SECONDS,
       );
-      return empty;
+      return this.buildResponse(EMPTY_PAYLOAD);
     }
 
-    const response = this.buildResponse(data);
-    await this.cache.set(cacheKey, JSON.stringify(response), CACHE_TTL_SECONDS);
-    return response;
+    await this.cache.set(cacheKey, JSON.stringify(data), CACHE_TTL_SECONDS);
+    return this.buildResponse(this.sliceToLimit(data, limit));
   }
 
   /**
@@ -132,6 +151,34 @@ export class RmAlternativesService extends SupabaseBaseService {
         .join(',') +
       '}'
     );
+  }
+
+  /**
+   * Tranche préfixe : reproduit exactement `LEAST(n, p_limit)` de la RPC sur
+   * le payload calculé au limit canonique. `relatedModels` est borné à 4 par
+   * la RPC indépendamment de `p_limit` — jamais tranché.
+   */
+  private sliceToLimit(payload: RpcPayload, limit: number): RpcPayload {
+    return {
+      alternativeVehicles: payload.alternativeVehicles.slice(0, limit),
+      alternativeGammes: payload.alternativeGammes.slice(0, limit),
+      relatedModels: payload.relatedModels,
+    };
+  }
+
+  private parseCachedPayload(
+    cached: unknown,
+    cacheKey: string,
+  ): RpcPayload | null {
+    try {
+      const parsed: unknown =
+        typeof cached === 'string' ? JSON.parse(cached) : cached;
+      if (isRpcPayload(parsed)) return parsed;
+      this.logger.warn(`Cache shape mismatch for ${cacheKey}, recomputing`);
+    } catch {
+      this.logger.warn(`Cache parse error for ${cacheKey}, recomputing`);
+    }
+    return null;
   }
 
   private buildResponse(payload: RpcPayload): AlternativesV2Response {

--- a/backend/src/modules/rm/services/rm-builder.service.ts
+++ b/backend/src/modules/rm/services/rm-builder.service.ts
@@ -39,23 +39,31 @@ const CACHE_TTL = 3600;
 export const PAGE_V2_CANONICAL_LIMIT = 200;
 
 /**
- * TTL de cache de `getPageCompleteV2` par classification, ou `null` = jamais
- * mis en cache. Unique source de vérité « cette entrée est-elle cacheable /
- * servable » — utilisée à l'écriture ET à la lecture.
+ * TTL de cache de `getPageCompleteV2`, ou `null` = jamais mis en cache.
+ * Unique source de vérité « cette entrée est-elle cacheable / servable » —
+ * utilisée à l'écriture ET à la lecture.
  *
- *   'ok'        → RM.PAGE_V2 (1 h)
- *   'empty'     → RM.PAGE_V2_EMPTY (15 min) — population soft-404, avant A2
- *                 elle rejouait la RPC (~280 ms) à chaque requête, pour toujours
- *   'not_found' → null
- *   'error'     → null (mettre une erreur RPC en cache comme « vide » =
- *                 incident 2026-05-19)
+ * Décision = classification (`classifyPageV2Result`) × `count` :
+ *   'ok'    et count > 0 → RM.PAGE_V2 (1 h)
+ *   'ok'    et count = 0 → RM.PAGE_V2_EMPTY (15 min) — forme RÉELLE d'un couple
+ *                          existant sans produit : rm_get_page_complete_v2 ne
+ *                          rend `success:false` que sur INVALID_PARAMS /
+ *                          *_NOT_FOUND / INTERNAL_ERROR (toujours avec `error`)
+ *   'empty'              → RM.PAGE_V2_EMPTY (15 min) — population soft-404,
+ *                          avant A2 elle rejouait la RPC (~280 ms) à chaque
+ *                          requête, pour toujours
+ *   'not_found'          → null
+ *   'error'              → null (mettre une erreur RPC en cache comme « vide »
+ *                          = incident 2026-05-19)
  */
 function pageV2CacheTtl(
-  classification: ReturnType<typeof classifyPageV2Result>,
+  result: Pick<RmPageCompleteV2Response, 'success' | 'error' | 'count'>,
 ): number | null {
-  switch (classification) {
+  switch (classifyPageV2Result(result)) {
     case 'ok':
-      return CACHE_STRATEGIES.RM.PAGE_V2.ttl;
+      return (result.count ?? 0) > 0
+        ? CACHE_STRATEGIES.RM.PAGE_V2.ttl
+        : CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl;
     case 'empty':
       return CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl;
     default:
@@ -557,7 +565,7 @@ export class RmBuilderService extends SupabaseBaseService {
       try {
         const cached =
           await this.cacheService.get<RmPageCompleteV2Response>(cacheKey);
-        if (cached && pageV2CacheTtl(classifyPageV2Result(cached)) !== null) {
+        if (cached && pageV2CacheTtl(cached) !== null) {
           const cacheDuration = Math.max(
             1,
             Math.round(performance.now() - startTime),
@@ -715,7 +723,7 @@ export class RmBuilderService extends SupabaseBaseService {
       // 2. Store in cache — sur la classification, jamais sur `count > 0`
       //    (voir pageV2CacheTtl). Le limit non canonique n'écrit jamais.
       if (useCache) {
-        const ttl = pageV2CacheTtl(classifyPageV2Result(result));
+        const ttl = pageV2CacheTtl(result);
         if (ttl !== null) {
           try {
             await this.cacheService.set(cacheKey, result, ttl);

--- a/backend/src/modules/rm/services/rm-builder.service.ts
+++ b/backend/src/modules/rm/services/rm-builder.service.ts
@@ -9,6 +9,8 @@ import {
 } from '../../catalog/services/seo-template.service';
 import { pickGammeKeywordModifier } from '../../catalog/services/vehicle-aware-description.composer';
 import { SeoShadowObservatory } from '../../seo-shadow-observatory/seo-shadow-observatory.service';
+import { CACHE_STRATEGIES } from '../../../config/cache-ttl.config';
+import { classifyPageV2Result } from '../utils/page-v2-response';
 import {
   RmProduct,
   RmListing,
@@ -20,8 +22,46 @@ import {
   GetPageV2Params,
 } from '../rm.types';
 
-// Cache TTL: 1 hour (3600 seconds)
+// Cache TTL: 1 hour (3600 seconds) — rm:products / rm:page (v1)
 const CACHE_TTL = 3600;
+
+/**
+ * Limit canonique de `getPageCompleteV2` (A2, 2026-09-02).
+ *
+ * Le cache `rm:page-v2:{gamme}:{vehicle}` ne porte pas le limit dans sa clé
+ * et ne tranche pas : `count`, `filters` et `minPrice` sont calculés par la
+ * RPC sur les N premières lignes. Seules les requêtes à ce limit lisent et
+ * écrivent le cache ; tout autre limit contourne le cache (lecture + écriture).
+ * Partagé avec le contrôleur (`DefaultValuePipe`) pour qu'un changement de
+ * défaut ne désactive pas silencieusement le cache. Le loader R2 envoie la
+ * même valeur (`INITIAL_PRODUCTS_LIMIT`, frontend).
+ */
+export const PAGE_V2_CANONICAL_LIMIT = 200;
+
+/**
+ * TTL de cache de `getPageCompleteV2` par classification, ou `null` = jamais
+ * mis en cache. Unique source de vérité « cette entrée est-elle cacheable /
+ * servable » — utilisée à l'écriture ET à la lecture.
+ *
+ *   'ok'        → RM.PAGE_V2 (1 h)
+ *   'empty'     → RM.PAGE_V2_EMPTY (15 min) — population soft-404, avant A2
+ *                 elle rejouait la RPC (~280 ms) à chaque requête, pour toujours
+ *   'not_found' → null
+ *   'error'     → null (mettre une erreur RPC en cache comme « vide » =
+ *                 incident 2026-05-19)
+ */
+function pageV2CacheTtl(
+  classification: ReturnType<typeof classifyPageV2Result>,
+): number | null {
+  switch (classification) {
+    case 'ok':
+      return CACHE_STRATEGIES.RM.PAGE_V2.ttl;
+    case 'empty':
+      return CACHE_STRATEGIES.RM.PAGE_V2_EMPTY.ttl;
+    default:
+      return null;
+  }
+}
 
 /**
  * 🏗️ RM Builder Service
@@ -505,25 +545,31 @@ export class RmBuilderService extends SupabaseBaseService {
     params: GetPageV2Params,
   ): Promise<RmPageCompleteV2Response> {
     const startTime = performance.now();
-    const { gamme_id, vehicle_id, limit = 200 } = params;
+    const { gamme_id, vehicle_id, limit = PAGE_V2_CANONICAL_LIMIT } = params;
     const cacheKey = `rm:page-v2:${gamme_id}:${vehicle_id}`;
+    // La clé ne porte pas le limit et l'entrée n'est pas tranchable
+    // (count/filters/minPrice dépendent du limit) : seul le limit canonique
+    // lit et écrit le cache. Voir PAGE_V2_CANONICAL_LIMIT.
+    const useCache = limit === PAGE_V2_CANONICAL_LIMIT;
 
     // 1. Try cache first
-    try {
-      const cached =
-        await this.cacheService.get<RmPageCompleteV2Response>(cacheKey);
-      if (cached && cached.success) {
-        const cacheDuration = Math.max(
-          1,
-          Math.round(performance.now() - startTime),
-        );
-        this.logger.debug(
-          `Cache HIT for ${cacheKey} (${cached.count} products) in ${cacheDuration}ms`,
-        );
-        return { ...cached, cacheHit: true, duration_ms: cacheDuration };
+    if (useCache) {
+      try {
+        const cached =
+          await this.cacheService.get<RmPageCompleteV2Response>(cacheKey);
+        if (cached && pageV2CacheTtl(classifyPageV2Result(cached)) !== null) {
+          const cacheDuration = Math.max(
+            1,
+            Math.round(performance.now() - startTime),
+          );
+          this.logger.debug(
+            `Cache HIT for ${cacheKey} (${cached.count} products) in ${cacheDuration}ms`,
+          );
+          return { ...cached, cacheHit: true, duration_ms: cacheDuration };
+        }
+      } catch {
+        // Cache error - continue to RPC
       }
-    } catch {
-      // Cache error - continue to RPC
     }
 
     this.logger.debug(
@@ -662,18 +708,22 @@ export class RmBuilderService extends SupabaseBaseService {
           `Page v2 complete: ${result.count} products, ${result.grouped_pieces?.length || 0} groups, ` +
             `${result.oemRefs?.length || 0} OEM refs in ${result.duration_ms}ms`,
         );
+      } else {
+        result.duration_ms = duration_ms;
+      }
 
-        // 2. Store in cache (TTL: 1h)
-        if (result.count && result.count > 0) {
+      // 2. Store in cache — sur la classification, jamais sur `count > 0`
+      //    (voir pageV2CacheTtl). Le limit non canonique n'écrit jamais.
+      if (useCache) {
+        const ttl = pageV2CacheTtl(classifyPageV2Result(result));
+        if (ttl !== null) {
           try {
-            await this.cacheService.set(cacheKey, result, CACHE_TTL);
-            this.logger.debug(`Cached ${cacheKey} for ${CACHE_TTL}s`);
+            await this.cacheService.set(cacheKey, result, ttl);
+            this.logger.debug(`Cached ${cacheKey} for ${ttl}s`);
           } catch {
             // Cache error - continue without caching
           }
         }
-      } else {
-        result.duration_ms = duration_ms;
       }
 
       return result;


### PR DESCRIPTION
## Contexte

Slice **A2** du plan massdoc (remédiation DB structurelle avant toute décision de Compute). Deux défauts de cache Redis sur le **même** chemin de requête R2 : le loader `pieces-vehicle` appelle `fetchRmPageV2` puis, si la page est inutilisable, `/api/rm/alternatives`. Chaque couple gamme × véhicule sans produit payait donc **280 ms + 935 ms** à chaque passage de crawler :

| Chemin | Défaut | Mesure PROD (`pg_stat_statements`, snapshot 2026-09-02) |
|---|---|---|
| `rm:page-v2:*` | `set` conditionné à `count > 0` → toute page 0-produit rejouait la RPC, pour toujours | `rm_get_page_complete_v2` : 8,3 M appels @ 279 ms |
| `alt:*` | TTL **300 s codé en dur** sur une cardinalité 54 k × 9 k → hit ~0 ; `limit` non normalisé | `get_soft_404_alternatives` : 498 k appels @ 935 ms, **2 795 blocs lus/appel** |

## Changements

**`rm-builder.service.getPageCompleteV2`**
- Écriture sur la **classification** (`classifyPageV2Result`, utilitaire existant) **× `count`**, plus jamais sur `count > 0` seul : `ok` avec produits → 1 h ; `ok` avec `count = 0` **ou** `empty` → 15 min ; `not_found` / `error` → **jamais** (mettre une erreur RPC en cache comme « vide » = incident 2026-05-19). Un seul helper `pageV2CacheTtl` gouverne lecture **et** écriture.
- **Pourquoi `count` compte** (vérifié sur DEV:3000, fixture soft-404 3859×11836) : `rm_get_page_complete_v2` ne rend `success:false` que sur `INVALID_PARAMS` / `*_NOT_FOUND` / `INTERNAL_ERROR`, toujours avec `error`. Un couple existant sans produit est `success:true, count:0` → classé `ok` par l'utilitaire. Sans le `count`, la population soft-404 aurait pris le TTL 1 h au lieu de 15 min (test dédié ajouté, RED observé avant correction).
- `PAGE_V2_CANONICAL_LIMIT = 200` exporté et partagé avec le `DefaultValuePipe` du contrôleur. Tout autre `limit` **contourne** le cache (lecture + écriture) : `count`/`filters`/`minPrice` dépendent du limit, on ne tranche pas. Clé `rm:page-v2:{g}:{v}` inchangée.

**`rm-alternatives.service`**
- RPC appelée au limit canonique maximal (24 = borne du contrôleur ; la RPC borne elle-même à `LEAST(6|8, p_limit)`), **payload brut** mis en cache, réponse **tranchée** côté application au limit demandé, etag recalculé sur la tranche. Cardinalité inchangée `{type}:{pg}` — **jamais de `limit` dans la clé** (NO-GO 6c : ça corrige la justesse en multipliant la cardinalité).
- TTL 300 s → `CACHE_STRATEGIES.RM.ALTERNATIVES` (**24 h**) ; erreur → 30 s inchangé ; `CACHE_KEY_VERSION` v3 → v4 (la forme de la valeur cachée change).

**`cache-ttl.config`** — nouveau domaine `RM` (`PAGE_V2`, `PAGE_V2_EMPTY`, `ALTERNATIVES`, `ALTERNATIVES_ERROR`). Plus aucun TTL littéral dans ces services.

## Tests (TDD — RED observé avant GREEN)

- `rm-alternatives.service.test.ts` réécrit sur le nouveau contrat (14 tests) : clé sans limit, RPC au limit canonique, payload brut en cache, tranche correcte pour deux limits sur la **même** entrée, etag ≠ par limit, erreur non poisonnante (TTL 30), entrée illisible recalculée.
- `rm-builder-page-v2-cache.test.ts` nouveau (9 tests) : `empty` mis en cache 15 min, `error` **jamais**, `not_found` **jamais**, `ok` 1 h, entrée `empty` servie depuis le cache, limit non canonique = bypass lecture + écriture.
- Suites `rm` + `config` : **206/206**. `tsc --noEmit` propre.

## Vérification à venir (pré-enregistrée, plan §Vérification)

- PREPROD : `redis-cli --scan --pattern 'rm:page-v2:*' | wc -l` avant/après ; puis fenêtres **appariées** ≥ 24 h, `n ≥ 1 200`.
- **Falsifieur nommé** : Δcall-rate de `get_soft_404_alternatives` et `rm_get_page_complete_v2` doit **baisser** ; si elle monte, la normalisation de `limit` est fausse quelque part.
- Aucune comparaison post-fix ↔ cumulé 265 j (NO-GO 7).

## À lire à sa juste échelle (plan §A0)

Ce slice réduit le **coût par miss**. Le levier d'un ordre de grandeur supérieur sur le **nombre** de miss reste le cache CDN des pages R2 (PR C Cloudflare, owner-gated, NO-GO à ce jour) : le HTML R2 est en `BYPASS` parce que le middleware d'attribution matérialise une session sur chaque GET humain. Ce n'est pas la résolution du sujet R2, c'est une des briques cumulatives.

## Runtime-awareness

- Merge `main` → **PREPROD** uniquement (tag `v*` = PROD, GO owner).
- Impact cache : bump `v3 → v4` sur `alt:*` = cold start propre, aucune entrée v3 relue. `rm:page-v2:*` : les entrées existantes (toutes `success: true`) restent servables sous le nouveau garde.
- Rollback : revert PR (main branch-protected).
- Aucun changement DB, aucun changement d'URL, aucun changement de meta/H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
