### PR TITLE
ci(r2): golden gate relations pièces + critères — préalable mécanique à B4/B7 (R2-GOLDEN)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -102,6 +102,18 @@ jobs:
         # may be re-run once, and when both occur the wrong status dominates.
         run: npm run test:preprod-response-suite
 
+      - name: 🧬 R2 golden gate — relations + critères, behavioural proof (BLOCKING)
+        # Owner guarantee (plan massdoc R2-GOLDEN): pieces relations + criteria on
+        # the R2 page must survive the DB slices that touch pieces_relation_type /
+        # pieces_criteria structure (B4, B7). The gate in ci.yml compares a frozen
+        # projection of /api/rm/page-v2 + /api/rm/alternatives against
+        # scripts/ci/r2-golden.json. These tests drive the real script against a
+        # stub server and pin: volatile-only changes (price/stock/score/order/image)
+        # never trip it; a lost relation, a moved side or a changed alternatives set
+        # always do; 404 = divergence never retried; transport retried once → exit 2;
+        # a golden that evaluates nothing fails; --update is the only re-baseline.
+        run: npm run test:r2-golden
+
       - name: 🗂️ EDITORIAL_AUTHORITY_SINKS registry invariants (BLOCKING)
         # Pins the exact P0 sink set (audit §6): 2 served-tracked + 15 ratchet-blind,
         # each evidence-linked, no rN wildcard. The blind rows justify the registry.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,6 +1006,23 @@ jobs:
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: 🧬 R2 golden — relations pièces + critères (BLOCKING)
+        # Owner guarantee (plan massdoc, R2-GOLDEN, 2026-09-02): the pieces relations
+        # and criteria served on the R2 page must keep working across the DB slices
+        # that touch pieces_relation_type / pieces_criteria STRUCTURE (index study
+        # B4, hash-partitioning B7) — neither may start before this is green, and both
+        # must leave it green (plan NO-GO 17). Compares a frozen projection of
+        # /api/rm/page-v2 (limit 200 = loader) + /api/rm/alternatives (limit 12) with
+        # scripts/ci/r2-golden.json: relations + criteria ONLY (piece ids, brands,
+        # sides/positions, groups, OEM refs, alternatives sets) — prices, stock,
+        # ranking, images, SEO text are out, so a price import never trips it.
+        # Verdict: divergence / 404 = exit 1, never retried; transport (5xx, refused,
+        # timeout — cold RPC on a fresh container) retried once, then exit 2.
+        # Re-baseline = `node scripts/ci/assert-r2-golden.mjs --base <url> --update`,
+        # reviewed in a PR diff — a catalog import that legitimately changes relations
+        # is re-baselined explicitly, never absorbed. Unit-tested: npm run test:r2-golden.
+        run: node scripts/ci/assert-r2-golden.mjs --base http://localhost:3200
+
       - name: ⏱️ Response Time Baseline (status-asserting, BLOCKING on wrong status)
         # The inline check_timing this replaces measured `%{time_total}` and asserted
         # NOTHING: a page answering 500 in 20ms scored a green ✅ row. Found while

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:prod-ssr-probe": "node --test scripts/ci/prod-ssr-probe.test.mjs",
     "test:preprod-response-probe": "node --test scripts/ci/preprod-response-probe.test.mjs",
     "test:preprod-response-suite": "node --test scripts/ci/preprod-response-suite.test.mjs",
+    "test:r2-golden": "node --test scripts/ci/assert-r2-golden.test.mjs",
     "audit:rag-authority-rule:test": "ast-grep test --test-dir scripts/audit/__fixtures__/rag-authority --skip-snapshot-tests",
     "audit:rag-authority-read-ratchet": "tsx scripts/audit/check-rag-authority-read-ratchet.ts",
     "audit:rag-authority-read-ratchet:json": "tsx scripts/audit/check-rag-authority-read-ratchet.ts --json",

--- a/scripts/ci/assert-r2-golden.mjs
+++ b/scripts/ci/assert-r2-golden.mjs
@@ -1,0 +1,471 @@
+#!/usr/bin/env node
+/**
+ * assert-r2-golden.mjs — R2 golden gate: relations pièces + critères.
+ *
+ * WHY
+ * ---
+ * Owner requirement (plan massdoc, R2-GOLDEN, 2026-09-02): "les relations
+ * pièces et les critères doivent continuer de fonctionner sur la page R2".
+ * Two DB slices touch the STRUCTURE of the tables behind that page —
+ * `pieces_relation_type` (hash-partitioning B7) and `pieces_criteria` (index
+ * study B4). Neither may start before this gate is green in CI, and both must
+ * leave it green (plan NO-GO 17).
+ *
+ * WHAT IT COMPARES
+ * ----------------
+ * A frozen PROJECTION of two endpoints the R2 loader actually calls
+ * (`pieces-vehicle.loader.server.ts`): `/api/rm/page-v2` at the canonical
+ * limit (200) and `/api/rm/alternatives` at the loader limit (12), against a
+ * committed golden (`scripts/ci/r2-golden.json`).
+ *
+ * The projection keeps ONLY what relations + criteria determine:
+ *   page-v2      : classification (ok/empty), count, relationsCount,
+ *                  products {piece_id, pm_id, quality, piece_position,
+ *                  filtre_gamme, is_accessory} sorted by piece_id,
+ *                  groups {filtre_gamme, filtre_side, piece_ids, oemRefs},
+ *                  filters {sides, brands (pm_id), qualities} with counts,
+ *                  oemRefs, crossSelling.
+ *   alternatives : vehicles (type_id), gammes (pg_id), models (modele_id) as
+ *                  sorted sets — the RANKING is not under contract here.
+ * Everything volatile by design is OUT: prices, stock, ranking score, images,
+ * names, SEO text, timings, cache flags, etag. A price import never trips the
+ * gate; a lost relation, a moved side or a changed alternatives set always does.
+ *
+ * VERDICT RULES (same discipline as preprod-response-suite.sh)
+ * ------------------------------------------------------------
+ *   * Every fixture is evaluated even after a failure — full picture, never
+ *     truncated at the first defect.
+ *   * A DIVERGENCE (projection ≠ expected), a 404 (not_found) or any other
+ *     wrong status is definitive and NEVER retried → exit 1.
+ *   * A TRANSPORT failure (5xx, connection refused/reset, timeout, non-JSON)
+ *     MAY be retried ONCE (cold RPC on a fresh PREPROD container) → still
+ *     failing → exit 2. Divergence dominates transport when both occur.
+ *   * A golden that evaluates NOTHING fails (vacuous green forbidden).
+ *   * A fixture without `expected` fails unless --update: a missing golden is
+ *     a missing guarantee, not a pass.
+ *
+ * RE-BASELINE (--update)
+ * ----------------------
+ * `--update` rewrites `expected` for every fixture from the live target and
+ * stamps provenance (captured_at / captured_from / git_sha). It is the ONLY way
+ * the golden changes, and the diff is reviewed in the PR: a catalog import that
+ * legitimately changes relations is re-baselined explicitly, never absorbed.
+ * The update is atomic — any fixture failing to fetch leaves the file untouched.
+ *
+ * Usage:
+ *   node scripts/ci/assert-r2-golden.mjs --base http://localhost:3200
+ *   node scripts/ci/assert-r2-golden.mjs --base http://localhost:3000 --update
+ * Options:
+ *   --golden <path>        golden file (default: scripts/ci/r2-golden.json)
+ *   --timeout-ms <n>       per-request timeout (default 60000 — cold RPC path)
+ *   --retry-delay-ms <n>   wait before the single transport retry (default 3000)
+ * Env:
+ *   GITHUB_STEP_SUMMARY    markdown summary sink (optional)
+ *   GITHUB_SHA             stamped into the golden on --update (optional)
+ * Exit: 0 = all fixtures match · 1 = divergence / wrong status / missing
+ *       expected / empty golden · 2 = transport failures only
+ */
+import { readFileSync, writeFileSync, appendFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_GOLDEN = join(SCRIPT_DIR, "r2-golden.json");
+const GOLDEN_SCHEMA = "r2-golden/v1";
+// Mirrors the loader: PAGE_V2_CANONICAL_LIMIT (backend) / INITIAL_PRODUCTS_LIMIT
+// (frontend) = 200 ; alternatives fetch limit = 12.
+const PAGE_V2_LIMIT = 200;
+const ALTERNATIVES_LIMIT = 12;
+const ATTEMPTS = 2; // one retry, transport failures only
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const out = {
+    base: null,
+    golden: DEFAULT_GOLDEN,
+    update: false,
+    timeoutMs: 60000,
+    retryDelayMs: 3000,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => {
+      const v = argv[++i];
+      if (v === undefined) throw new Error(`missing value for ${a}`);
+      return v;
+    };
+    if (a === "--base") out.base = next();
+    else if (a === "--golden") out.golden = resolve(next());
+    else if (a === "--update") out.update = true;
+    else if (a === "--timeout-ms") out.timeoutMs = Number(next());
+    else if (a === "--retry-delay-ms") out.retryDelayMs = Number(next());
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (!out.base) throw new Error("--base <url> is required");
+  out.base = out.base.replace(/\/+$/, "");
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures → URLs
+// ---------------------------------------------------------------------------
+function urlFor(fixture, base) {
+  switch (fixture.kind) {
+    case "page-v2":
+      return `${base}/api/rm/page-v2?gamme_id=${fixture.gamme_id}&vehicle_id=${fixture.vehicle_id}&limit=${PAGE_V2_LIMIT}`;
+    case "alternatives":
+      return `${base}/api/rm/alternatives?gamme_id=${fixture.gamme_id}&type_id=${fixture.type_id}&limit=${ALTERNATIVES_LIMIT}`;
+    default:
+      throw new Error(`fixture ${fixture.id}: unknown kind ${fixture.kind}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP — one attempt, classified
+// ---------------------------------------------------------------------------
+async function fetchOnce(url, timeoutMs) {
+  let res;
+  try {
+    res = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { accept: "application/json" },
+    });
+  } catch (err) {
+    return {
+      kind: "transport",
+      reason: `${err?.cause?.code ?? err?.name ?? "fetch"}: ${err?.message ?? err}`,
+    };
+  }
+  if (res.status === 404) return { kind: "not_found", reason: "HTTP 404" };
+  if (res.status >= 500 || res.status === 429)
+    return { kind: "transport", reason: `HTTP ${res.status}` };
+  if (res.status !== 200)
+    return { kind: "wrong_status", reason: `HTTP ${res.status}` };
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return {
+      kind: "transport",
+      reason: `non-JSON body: ${err?.message ?? err}`,
+    };
+  }
+  return { kind: "ok", body };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function fetchFixture(url, { timeoutMs, retryDelayMs }) {
+  let last;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    last = await fetchOnce(url, timeoutMs);
+    if (last.kind !== "transport") return { ...last, attempts: attempt };
+    if (attempt < ATTEMPTS) await sleep(retryDelayMs);
+  }
+  return { ...last, attempts: ATTEMPTS };
+}
+
+// ---------------------------------------------------------------------------
+// Projections — relations + criteria only
+// ---------------------------------------------------------------------------
+const num = (v) => (v === null || v === undefined ? NaN : Number(v));
+const byNumber = (a, b) => num(a) - num(b);
+const byString = (a, b) => String(a).localeCompare(String(b), "fr");
+const sortedUnique = (arr, cmp) => [...new Set(arr)].sort(cmp);
+const idOf = (item) =>
+  item && typeof item === "object"
+    ? (item.pg_id ?? item.id ?? item.piece_id ?? null)
+    : item;
+
+function projectPageV2(body) {
+  const products = Array.isArray(body.products) ? body.products : [];
+  const count = Number(body.count ?? products.length);
+  return {
+    classification: count > 0 ? "ok" : "empty",
+    success: body.success === true,
+    count,
+    relationsCount: body.validation?.relationsCount ?? null,
+    products: products
+      .map((p) => ({
+        piece_id: p.piece_id,
+        pm_id: p.pm_id ?? null,
+        quality: p.quality ?? null,
+        piece_position: p.piece_position ?? null,
+        filtre_gamme: p.filtre_gamme ?? null,
+        is_accessory: p.is_accessory ?? null,
+      }))
+      .sort((a, b) => byNumber(a.piece_id, b.piece_id)),
+    groups: (Array.isArray(body.grouped_pieces) ? body.grouped_pieces : [])
+      .map((g) => ({
+        filtre_gamme: g.filtre_gamme ?? null,
+        filtre_side: g.filtre_side ?? null,
+        piece_ids: sortedUnique(
+          (g.pieces ?? []).map((p) => p.id ?? p.piece_id),
+          byNumber,
+        ),
+        oemRefs: sortedUnique((g.oemRefs ?? []).map(String), byString),
+      }))
+      .sort(
+        (a, b) =>
+          byString(a.filtre_gamme, b.filtre_gamme) ||
+          byString(a.filtre_side, b.filtre_side),
+      ),
+    filters: {
+      sides: (body.filters?.sides ?? [])
+        .map((s) => ({ value: s.value ?? null, count: s.count ?? null }))
+        .sort((a, b) => byString(a.value, b.value)),
+      brands: (body.filters?.brands ?? [])
+        .map((b) => ({ pm_id: b.pm_id ?? null, count: b.count ?? null }))
+        .sort((a, b) => byNumber(a.pm_id, b.pm_id)),
+      qualities: (body.filters?.qualities ?? [])
+        .map((q) => ({ value: q.value ?? null, count: q.count ?? null }))
+        .sort((a, b) => byString(a.value, b.value)),
+    },
+    oemRefs: sortedUnique((body.oemRefs ?? []).map(String), byString),
+    crossSelling: sortedUnique((body.crossSelling ?? []).map(idOf), byNumber),
+  };
+}
+
+function projectAlternatives(body) {
+  return {
+    vehicles: sortedUnique(
+      (body.alternativeVehicles ?? []).map((v) => String(v.type_id)),
+      byNumber,
+    ),
+    gammes: sortedUnique(
+      (body.alternativeGammes ?? []).map((g) => Number(g.pg_id)),
+      byNumber,
+    ),
+    models: sortedUnique(
+      (body.relatedModels ?? []).map((m) => Number(m.modele_id)),
+      byNumber,
+    ),
+  };
+}
+
+function project(fixture, body) {
+  return fixture.kind === "page-v2"
+    ? projectPageV2(body)
+    : projectAlternatives(body);
+}
+
+// ---------------------------------------------------------------------------
+// Diff — readable paths, never truncated
+// ---------------------------------------------------------------------------
+const KEY_FIELDS = [
+  "piece_id",
+  "pm_id",
+  "value",
+  "modele_id",
+  "pg_id",
+  "type_id",
+  "filtre_side",
+];
+const isPrimitive = (v) => v === null || typeof v !== "object";
+const show = (v) => JSON.stringify(v);
+
+function keyOf(item) {
+  for (const k of KEY_FIELDS)
+    if (item && item[k] !== undefined && item[k] !== null)
+      return `${k}=${item[k]}`;
+  return JSON.stringify(item);
+}
+
+function diff(expected, actual, path, out) {
+  if (Array.isArray(expected) && Array.isArray(actual)) {
+    if (expected.every(isPrimitive) && actual.every(isPrimitive)) {
+      const e = new Set(expected.map(String));
+      const a = new Set(actual.map(String));
+      const missing = expected.filter((v) => !a.has(String(v)));
+      const extra = actual.filter((v) => !e.has(String(v)));
+      if (missing.length) out.push(`${path}: missing ${show(missing)}`);
+      if (extra.length) out.push(`${path}: extra ${show(extra)}`);
+      return;
+    }
+    const eMap = new Map(expected.map((it) => [keyOf(it), it]));
+    const aMap = new Map(actual.map((it) => [keyOf(it), it]));
+    for (const [k, it] of eMap) {
+      if (!aMap.has(k)) out.push(`${path}: missing ${k}`);
+      else diff(it, aMap.get(k), `${path}[${k}]`, out);
+    }
+    for (const k of aMap.keys())
+      if (!eMap.has(k)) out.push(`${path}: extra ${k}`);
+    return;
+  }
+  if (!isPrimitive(expected) && !isPrimitive(actual)) {
+    for (const k of new Set([
+      ...Object.keys(expected),
+      ...Object.keys(actual),
+    ])) {
+      diff(expected[k], actual[k], path ? `${path}.${k}` : k, out);
+    }
+    return;
+  }
+  if (!Object.is(expected, actual))
+    out.push(`${path}: ${show(expected)} → ${show(actual)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function loadGolden(path) {
+  let golden;
+  try {
+    golden = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new Error(`cannot read golden ${path}: ${err.message}`);
+  }
+  if (golden.schema !== GOLDEN_SCHEMA)
+    throw new Error(
+      `golden ${path}: schema ${golden.schema} ≠ ${GOLDEN_SCHEMA}`,
+    );
+  if (!Array.isArray(golden.fixtures) || golden.fixtures.length === 0) {
+    throw new Error(
+      `golden ${path}: no fixture to evaluate (vacuous green forbidden)`,
+    );
+  }
+  const ids = new Set();
+  for (const f of golden.fixtures) {
+    if (!f.id || !f.kind)
+      throw new Error(`golden ${path}: fixture without id/kind`);
+    if (ids.has(f.id))
+      throw new Error(`golden ${path}: duplicate fixture id ${f.id}`);
+    ids.add(f.id);
+  }
+  return golden;
+}
+
+function summaryRow(sink, cells) {
+  if (!sink) return;
+  appendFileSync(sink, `| ${cells.join(" | ")} |\n`);
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const golden = loadGolden(opts.golden);
+  const sink =
+    process.env.GITHUB_STEP_SUMMARY &&
+    process.env.GITHUB_STEP_SUMMARY !== "/dev/null"
+      ? process.env.GITHUB_STEP_SUMMARY
+      : null;
+
+  console.log(
+    `🧬 R2 golden — relations pièces + critères — ${golden.fixtures.length} fixture(s) against ${opts.base}${opts.update ? " [UPDATE]" : ""}`,
+  );
+  if (sink) {
+    appendFileSync(
+      sink,
+      `## 🧬 R2 golden — relations pièces + critères${opts.update ? " (update)" : ""}\n\n| Fixture | Kind | Verdict | Detail |\n|---|---|---|---|\n`,
+    );
+  }
+
+  let divergences = 0;
+  let transport = 0;
+  const updated = [];
+
+  for (const fixture of golden.fixtures) {
+    const url = urlFor(fixture, opts.base);
+    const res = await fetchFixture(url, opts);
+
+    if (res.kind === "transport") {
+      transport++;
+      console.log(
+        `  ⚠️  ${fixture.id} — transport failure after ${res.attempts} attempt(s): ${res.reason}`,
+      );
+      summaryRow(sink, [fixture.id, fixture.kind, "⚠️ transport", res.reason]);
+      continue;
+    }
+    if (res.kind === "not_found" || res.kind === "wrong_status") {
+      divergences++;
+      console.log(
+        `  ❌ ${fixture.id} — ${res.kind} (${res.reason}) — never retried`,
+      );
+      summaryRow(sink, [
+        fixture.id,
+        fixture.kind,
+        `❌ ${res.kind}`,
+        res.reason,
+      ]);
+      continue;
+    }
+
+    const actual = project(fixture, res.body);
+
+    if (opts.update) {
+      updated.push({ ...fixture, expected: actual });
+      console.log(`  📸 ${fixture.id} — captured`);
+      summaryRow(sink, [fixture.id, fixture.kind, "📸 captured", ""]);
+      continue;
+    }
+
+    if (fixture.expected === undefined || fixture.expected === null) {
+      divergences++;
+      console.log(
+        `  ❌ ${fixture.id} — no expected projection in golden (run with --update to baseline)`,
+      );
+      summaryRow(sink, [
+        fixture.id,
+        fixture.kind,
+        "❌ no expected",
+        "baseline missing",
+      ]);
+      continue;
+    }
+
+    const lines = [];
+    diff(fixture.expected, actual, "", lines);
+    if (lines.length === 0) {
+      console.log(`  ✅ ${fixture.id}`);
+      summaryRow(sink, [fixture.id, fixture.kind, "✅", ""]);
+    } else {
+      divergences++;
+      console.log(`  ❌ ${fixture.id} — ${lines.length} divergence(s):`);
+      for (const l of lines) console.log(`       ${l}`);
+      summaryRow(sink, [
+        fixture.id,
+        fixture.kind,
+        `❌ ${lines.length} divergence(s)`,
+        lines.map((l) => `\`${l}\``).join("<br>"),
+      ]);
+    }
+  }
+
+  if (opts.update) {
+    if (divergences > 0 || transport > 0) {
+      console.log(
+        `✖ update aborted — ${divergences + transport} fixture(s) could not be captured; golden left untouched`,
+      );
+      process.exit(divergences > 0 ? 1 : 2);
+    }
+    const next = {
+      ...golden,
+      captured_at: new Date().toISOString(),
+      captured_from: opts.base,
+      git_sha: process.env.GITHUB_SHA ?? golden.git_sha ?? null,
+      fixtures: updated,
+    };
+    writeFileSync(opts.golden, JSON.stringify(next, null, 2) + "\n");
+    console.log(`📸 ${updated.length} fixture(s) captured → ${opts.golden}`);
+    process.exit(0);
+  }
+
+  const evaluated = golden.fixtures.length;
+  console.log(
+    `${divergences === 0 && transport === 0 ? "✅" : "✖"} ${evaluated} fixture(s) evaluated, ${divergences} divergence(s), ${transport} transport failure(s)`,
+  );
+  if (sink)
+    appendFileSync(
+      sink,
+      `\n**${evaluated} fixture(s) evaluated, ${divergences} divergence(s), ${transport} transport failure(s)**\n`,
+    );
+  if (divergences > 0) process.exit(1);
+  if (transport > 0) process.exit(2);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`✖ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/ci/assert-r2-golden.mjs
+++ b/scripts/ci/assert-r2-golden.mjs
@@ -111,12 +111,41 @@ function parseArgs(argv) {
 // ---------------------------------------------------------------------------
 // Fixtures → URLs
 // ---------------------------------------------------------------------------
+// Identifiants du golden : entiers positifs sûrs, sinon échec bruyant.
+// Barrière unique — pas de coercition silencieuse ('7' ≠ 7, 7.5 et 1e21 rejetés).
+const ID_FIELDS = {
+  "page-v2": ["gamme_id", "vehicle_id"],
+  alternatives: ["gamme_id", "type_id"],
+};
+
+function assertId(fixture, field) {
+  const v = fixture[field];
+  if (typeof v !== "number" || !Number.isSafeInteger(v) || v <= 0) {
+    throw new Error(
+      `fixture ${fixture.id}: ${field} must be a positive safe integer, got ${JSON.stringify(v)}`,
+    );
+  }
+  return v;
+}
+
 function urlFor(fixture, base) {
+  // Les identifiants viennent du golden (fichier). loadGolden() les a déjà validés
+  // comme entiers positifs sûrs (fail-loud) ; URLSearchParams les encode ensuite —
+  // aucune valeur de fichier n'atteint l'URL sans être passée par ces deux barrières.
+  const qs = (params) => new URLSearchParams(params).toString();
   switch (fixture.kind) {
     case "page-v2":
-      return `${base}/api/rm/page-v2?gamme_id=${fixture.gamme_id}&vehicle_id=${fixture.vehicle_id}&limit=${PAGE_V2_LIMIT}`;
+      return `${base}/api/rm/page-v2?${qs({
+        gamme_id: String(assertId(fixture, "gamme_id")),
+        vehicle_id: String(assertId(fixture, "vehicle_id")),
+        limit: String(PAGE_V2_LIMIT),
+      })}`;
     case "alternatives":
-      return `${base}/api/rm/alternatives?gamme_id=${fixture.gamme_id}&type_id=${fixture.type_id}&limit=${ALTERNATIVES_LIMIT}`;
+      return `${base}/api/rm/alternatives?${qs({
+        gamme_id: String(assertId(fixture, "gamme_id")),
+        type_id: String(assertId(fixture, "type_id")),
+        limit: String(ALTERNATIVES_LIMIT),
+      })}`;
     default:
       throw new Error(`fixture ${fixture.id}: unknown kind ${fixture.kind}`);
   }
@@ -333,6 +362,12 @@ function loadGolden(path) {
     if (ids.has(f.id))
       throw new Error(`golden ${path}: duplicate fixture id ${f.id}`);
     ids.add(f.id);
+    const fields = ID_FIELDS[f.kind];
+    if (!fields)
+      throw new Error(
+        `golden ${path}: fixture ${f.id}: unknown kind ${f.kind}`,
+      );
+    for (const field of fields) assertId(f, field);
   }
   return golden;
 }

--- a/scripts/ci/assert-r2-golden.test.mjs
+++ b/scripts/ci/assert-r2-golden.test.mjs
@@ -1,0 +1,572 @@
+/**
+ * Behavioural proof of the R2 golden gate (assert-r2-golden.mjs).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Owner requirement (plan massdoc, R2-GOLDEN): "les relations pièces et les
+ * critères doivent continuer de fonctionner sur la page R2" across the DB
+ * slices that touch `pieces_relation_type` / `pieces_criteria` structure
+ * (index study B4, hash-partitioning B7). A declarative promise is not a
+ * guarantee; this gate turns it into a CI failure.
+ *
+ * The gate compares a frozen PROJECTION of `/api/rm/page-v2` and
+ * `/api/rm/alternatives` (relations + criteria only) against a committed
+ * golden file. Everything volatile by design — prices, stock, ranking score,
+ * images, SEO text, timings — is OUT of the projection, so a legitimate price
+ * import never trips it, while a lost relation, a changed side/criteria or a
+ * different alternatives set always does.
+ *
+ * These tests drive the real script against a real local HTTP server and pin:
+ *   - volatile-only changes → exit 0 (the gate must not cry wolf);
+ *   - a lost relation / changed criteria / changed alternatives → exit 1 with
+ *     a readable diff naming the fixture and the field;
+ *   - transport failures (503, refused) → retried once, then exit 2 (never a
+ *     silent green, never confused with a divergence);
+ *   - a 404 (not_found) on a fixture is a divergence, not a transport blip;
+ *   - --update rewrites `expected` for every fixture (explicit re-baseline);
+ *   - a golden file that evaluates NOTHING fails (vacuous green forbidden);
+ *   - a fixture without `expected` fails unless --update.
+ *
+ * Run: npm run test:r2-golden
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(SCRIPT_DIR, "assert-r2-golden.mjs");
+
+// ---------------------------------------------------------------------------
+// Canned upstream responses (shape = real /api/rm/page-v2 + /api/rm/alternatives)
+// ---------------------------------------------------------------------------
+const product = (piece_id, pm_id, quality, piece_position, extra = {}) => ({
+  piece_id,
+  pm_id,
+  pm_name: `BRAND-${pm_id}`,
+  quality,
+  piece_name: "Jeu de 4 plaquettes de frein",
+  piece_reference: `REF-${piece_id}`,
+  piece_position,
+  filtre_gamme: "Plaquettes de frein",
+  is_accessory: false,
+  score: 115,
+  has_image: true,
+  image: `https://example.invalid/${piece_id}.jpg`,
+  price_ttc: 52,
+  stock_status: "IN_STOCK",
+  ...extra,
+});
+
+function pageV2Body(overrides = {}) {
+  const products = overrides.products ?? [
+    product(70707, 730, "OE", "Avant"),
+    product(7736200, 810, "OE", "Avant"),
+    product(3747952, 4120, "EQUIV", "Arrière"),
+  ];
+  return {
+    success: true,
+    count: products.length,
+    minPrice: 33,
+    products,
+    grouped_pieces: overrides.grouped_pieces ?? [
+      {
+        filtre_gamme: "Plaquettes de frein",
+        filtre_side: "Avant",
+        title_h2: "Plaquettes de frein - Avant",
+        oemRefs: ["13301234", "22799077"],
+        oemRefsCount: 2,
+        pieces: [
+          { id: 70707, prix_ttc: 52, stock_status: "IN_STOCK" },
+          { id: 7736200, prix_ttc: 62, stock_status: "IN_STOCK" },
+        ],
+      },
+      {
+        filtre_gamme: "Plaquettes de frein",
+        filtre_side: "Arrière",
+        title_h2: "Plaquettes de frein - Arrière",
+        oemRefs: ["42570931"],
+        oemRefsCount: 1,
+        pieces: [{ id: 3747952, prix_ttc: 33, stock_status: "IN_STOCK" }],
+      },
+    ],
+    vehicleInfo: { type_id: 57414 },
+    gamme: { pg_id: 402, pg_name: "Plaquettes de frein" },
+    seo: { h1: "volatile", title: "volatile" },
+    oemRefs: overrides.oemRefs ?? ["13301234", "22799077", "42570931"],
+    crossSelling: overrides.crossSelling ?? [],
+    filters: overrides.filters ?? {
+      sides: [
+        { count: 2, value: "Avant" },
+        { count: 1, value: "Arrière" },
+      ],
+      brands: [
+        { count: 1, pm_id: 730, pm_name: "BOSCH" },
+        { count: 1, pm_id: 810, pm_name: "BREMBO" },
+        { count: 1, pm_id: 4120, pm_name: "SASIC" },
+      ],
+      qualities: [
+        { count: 2, value: "OE" },
+        { count: 1, value: "EQUIV" },
+      ],
+      price_range: { min: 33, max: 62 },
+    },
+    validation: {
+      valid: true,
+      relationsCount: overrides.relationsCount ?? products.length,
+      dataQuality: { quality: 96 },
+    },
+    duration_ms: 123,
+    cacheHit: false,
+  };
+}
+
+function emptyPageV2Body() {
+  return {
+    success: true,
+    count: 0,
+    minPrice: null,
+    products: [],
+    grouped_pieces: [],
+    vehicleInfo: {},
+    gamme: { pg_id: 3859 },
+    seo: {},
+    oemRefs: [],
+    crossSelling: [],
+    filters: {
+      sides: [],
+      brands: [],
+      qualities: [],
+      price_range: { min: null, max: null },
+    },
+    validation: { valid: false, relationsCount: 0 },
+    duration_ms: 50,
+    cacheHit: false,
+  };
+}
+
+function alternativesBody(overrides = {}) {
+  return {
+    success: true,
+    version: "v2",
+    etag: "sha256-volatile",
+    alternativeVehicles: (overrides.vehicles ?? ["32177", "4650", "3825"]).map(
+      (type_id, i) => ({
+        type_id,
+        type_name: `v${i}`,
+        modele_id: 1,
+        marque_id: 1,
+        tier: 1,
+      }),
+    ),
+    alternativeGammes: (overrides.gammes ?? [2234, 4, 273]).map((pg_id) => ({
+      pg_id,
+      pg_name: `g${pg_id}`,
+      piece_count: 1,
+      tier: 1,
+    })),
+    relatedModels: (overrides.models ?? [33021, 33026]).map((modele_id) => ({
+      modele_id,
+      modele_name: `m${modele_id}`,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stub upstream. `routes` maps "<path>?<sorted query>" → handler(res, hitIndex).
+// Map (not object) so attacker-controlled req.url can never reach prototype
+// members (CodeQL js/unvalidated-dynamic-method-call).
+// ---------------------------------------------------------------------------
+async function startServer(routes) {
+  const table = new Map(Object.entries(routes));
+  const hits = new Map();
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, "http://stub");
+    const key = `${url.pathname}?${[...url.searchParams.entries()]
+      .map(([k, v]) => `${k}=${v}`)
+      .sort()
+      .join("&")}`;
+    const n = hits.get(key) ?? 0;
+    hits.set(key, n + 1);
+    const handler = table.get(key);
+    if (!handler) {
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end(`stub: no route for ${key}`);
+      return;
+    }
+    handler(res, n);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    base: `http://127.0.0.1:${port}`,
+    hits,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+const json =
+  (body, status = 200) =>
+  (res) => {
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify(body));
+  };
+
+const PAGE_KEY = "/api/rm/page-v2?gamme_id=402&limit=200&vehicle_id=57414";
+const EMPTY_KEY = "/api/rm/page-v2?gamme_id=3859&limit=200&vehicle_id=11836";
+const ALT_KEY = "/api/rm/alternatives?gamme_id=3859&limit=12&type_id=11836";
+
+function fixturesFile(dir, { withExpected = true } = {}) {
+  const path = join(dir, "r2-golden.json");
+  const golden = {
+    schema: "r2-golden/v1",
+    captured_at: null,
+    captured_from: null,
+    fixtures: [
+      {
+        id: "plaquettes-402-x-57414",
+        kind: "page-v2",
+        gamme_id: 402,
+        vehicle_id: 57414,
+        why: "populated, sides",
+      },
+      {
+        id: "kit-freins-3859-x-11836",
+        kind: "page-v2",
+        gamme_id: 3859,
+        vehicle_id: 11836,
+        why: "empty (soft-404)",
+      },
+      {
+        id: "alt-3859-x-11836",
+        kind: "alternatives",
+        gamme_id: 3859,
+        type_id: 11836,
+        why: "alternatives set",
+      },
+    ],
+  };
+  writeFileSync(path, JSON.stringify(golden, null, 2));
+  return path;
+}
+
+async function run(args, env = {}) {
+  try {
+    const { stdout, stderr } = await execFileAsync("node", [SCRIPT, ...args], {
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: env.summary ?? "/dev/null",
+        ...env,
+      },
+    });
+    return { code: 0, stdout, stderr };
+  } catch (err) {
+    return {
+      code: err.code,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+/** Capture a golden from a healthy stub, then return {dir, path}. */
+async function baseline() {
+  const dir = mkdtempSync(join(tmpdir(), "r2-golden-"));
+  const path = fixturesFile(dir);
+  const srv = await startServer({
+    [PAGE_KEY]: json(pageV2Body()),
+    [EMPTY_KEY]: json(emptyPageV2Body()),
+    [ALT_KEY]: json(alternativesBody()),
+  });
+  const res = await run(["--base", srv.base, "--golden", path, "--update"]);
+  await srv.close();
+  assert.equal(
+    res.code,
+    0,
+    `baseline --update must succeed:\n${res.stdout}\n${res.stderr}`,
+  );
+  return { dir, path };
+}
+
+describe("assert-r2-golden.mjs — R2 relations + criteria golden gate", () => {
+  test("--update captures expected projections for every fixture and stamps provenance", async () => {
+    const { path } = await baseline();
+    const golden = JSON.parse(readFileSync(path, "utf8"));
+    assert.equal(golden.fixtures.length, 3);
+    for (const f of golden.fixtures)
+      assert.ok(f.expected, `fixture ${f.id} has expected`);
+    assert.ok(golden.captured_at, "captured_at stamped");
+    assert.ok(golden.captured_from, "captured_from stamped");
+
+    const page = golden.fixtures[0].expected;
+    assert.equal(page.classification, "ok");
+    assert.equal(page.count, 3);
+    assert.deepEqual(
+      page.products.map((p) => p.piece_id),
+      [70707, 3747952, 7736200].sort((a, b) => a - b),
+      "products projected sorted by piece_id (ranking/price order is volatile)",
+    );
+    assert.deepEqual(
+      Object.keys(page.products[0]).sort(),
+      [
+        "filtre_gamme",
+        "is_accessory",
+        "piece_id",
+        "piece_position",
+        "pm_id",
+        "quality",
+      ],
+      "projection carries relations + criteria fields only",
+    );
+    assert.equal(golden.fixtures[1].expected.classification, "empty");
+    assert.deepEqual(golden.fixtures[2].expected, {
+      vehicles: ["3825", "4650", "32177"],
+      gammes: [4, 273, 2234],
+      models: [33021, 33026],
+    });
+  });
+
+  test("volatile-only changes (price, stock, score, order, image, seo, etag) → exit 0", async () => {
+    const { path } = await baseline();
+    const shuffled = pageV2Body({
+      products: [
+        product(3747952, 4120, "EQUIV", "Arrière", {
+          price_ttc: 99,
+          stock_status: "OUT",
+          score: 1,
+          has_image: false,
+          image: null,
+        }),
+        product(7736200, 810, "OE", "Avant", { price_ttc: 1 }),
+        product(70707, 730, "OE", "Avant", {
+          piece_name: "renamed",
+          pm_name: "RENAMED",
+        }),
+      ],
+    });
+    shuffled.minPrice = 1;
+    shuffled.filters.price_range = { min: 1, max: 99 };
+    shuffled.seo = { h1: "changed" };
+    shuffled.duration_ms = 9999;
+    shuffled.cacheHit = true;
+    const srv = await startServer({
+      [PAGE_KEY]: json(shuffled),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json({
+        ...alternativesBody({ vehicles: ["4650", "32177", "3825"] }),
+        etag: "sha256-other",
+      }),
+    });
+    const res = await run(["--base", srv.base, "--golden", path]);
+    await srv.close();
+    assert.equal(res.code, 0, res.stdout + res.stderr);
+    assert.match(res.stdout, /3 fixture\(s\) evaluated, 0 divergence/);
+  });
+
+  test("a lost relation (piece missing) → exit 1 naming the fixture and the piece", async () => {
+    const { path } = await baseline();
+    const lost = pageV2Body({
+      products: [
+        product(70707, 730, "OE", "Avant"),
+        product(7736200, 810, "OE", "Avant"),
+      ],
+    });
+    const srv = await startServer({
+      [PAGE_KEY]: json(lost),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run(["--base", srv.base, "--golden", path]);
+    await srv.close();
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /plaquettes-402-x-57414/);
+    assert.match(res.stdout, /3747952/);
+    assert.match(res.stdout, /count/);
+  });
+
+  test("a changed criteria (side moves Avant→Arrière) → exit 1 naming piece_position / sides", async () => {
+    const { path } = await baseline();
+    const moved = pageV2Body({
+      products: [
+        product(70707, 730, "OE", "Arrière"),
+        product(7736200, 810, "OE", "Avant"),
+        product(3747952, 4120, "EQUIV", "Arrière"),
+      ],
+    });
+    moved.filters.sides = [
+      { count: 1, value: "Avant" },
+      { count: 2, value: "Arrière" },
+    ];
+    const srv = await startServer({
+      [PAGE_KEY]: json(moved),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run(["--base", srv.base, "--golden", path]);
+    await srv.close();
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /piece_position/);
+    assert.match(res.stdout, /sides/);
+  });
+
+  test("a changed alternatives set → exit 1; an empty page becoming populated → exit 1", async () => {
+    const { path } = await baseline();
+    const srv = await startServer({
+      [PAGE_KEY]: json(pageV2Body()),
+      [EMPTY_KEY]: json(pageV2Body()),
+      [ALT_KEY]: json(alternativesBody({ gammes: [2234, 4] })),
+    });
+    const res = await run(["--base", srv.base, "--golden", path]);
+    await srv.close();
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /alt-3859-x-11836/);
+    assert.match(res.stdout, /gammes/);
+    assert.match(res.stdout, /kit-freins-3859-x-11836/);
+    assert.match(res.stdout, /classification/);
+    assert.match(res.stdout, /3 fixture\(s\) evaluated, 2 divergence/);
+  });
+
+  test("503 on first attempt then 200 → retried once → exit 0", async () => {
+    const { path } = await baseline();
+    const srv = await startServer({
+      [PAGE_KEY]: (res, n) =>
+        n === 0 ? json({ statusCode: 503 }, 503)(res) : json(pageV2Body())(res),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run([
+      "--base",
+      srv.base,
+      "--golden",
+      path,
+      "--retry-delay-ms",
+      "10",
+    ]);
+    await srv.close();
+    assert.equal(res.code, 0, res.stdout + res.stderr);
+    assert.equal(srv.hits.get(PAGE_KEY), 2, "exactly one retry");
+  });
+
+  test("persistent transport failure → exit 2, other fixtures still evaluated", async () => {
+    const { path } = await baseline();
+    const srv = await startServer({
+      [PAGE_KEY]: json({ statusCode: 503 }, 503),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run([
+      "--base",
+      srv.base,
+      "--golden",
+      path,
+      "--retry-delay-ms",
+      "10",
+    ]);
+    await srv.close();
+    assert.equal(res.code, 2, res.stdout + res.stderr);
+    assert.equal(srv.hits.get(PAGE_KEY), 2, "one retry, never more");
+    assert.equal(srv.hits.get(ALT_KEY), 1, "later fixtures still evaluated");
+    assert.match(res.stdout, /transport/i);
+  });
+
+  test("connection refused (no server) → exit 2", async () => {
+    const { path } = await baseline();
+    const res = await run([
+      "--base",
+      "http://127.0.0.1:1",
+      "--golden",
+      path,
+      "--retry-delay-ms",
+      "10",
+    ]);
+    assert.equal(res.code, 2, res.stdout + res.stderr);
+  });
+
+  test("404 not_found on a page-v2 fixture is a divergence (exit 1), never retried", async () => {
+    const { path } = await baseline();
+    const srv = await startServer({
+      [PAGE_KEY]: json({ statusCode: 404, code: "RESOURCE.NOT_FOUND" }, 404),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run([
+      "--base",
+      srv.base,
+      "--golden",
+      path,
+      "--retry-delay-ms",
+      "10",
+    ]);
+    await srv.close();
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.equal(srv.hits.get(PAGE_KEY), 1, "a wrong status is never retried");
+    assert.match(res.stdout, /not_found/);
+  });
+
+  test("divergence dominates transport failure when both occur", async () => {
+    const { path } = await baseline();
+    const srv = await startServer({
+      [PAGE_KEY]: json({ statusCode: 503 }, 503),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody({ models: [1] })),
+    });
+    const res = await run([
+      "--base",
+      srv.base,
+      "--golden",
+      path,
+      "--retry-delay-ms",
+      "10",
+    ]);
+    await srv.close();
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+  });
+
+  test("fixture without expected → exit 1 unless --update", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "r2-golden-"));
+    const path = fixturesFile(dir);
+    const srv = await startServer({
+      [PAGE_KEY]: json(pageV2Body()),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run(["--base", srv.base, "--golden", path]);
+    await srv.close();
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /no expected/i);
+  });
+
+  test("a golden file with zero fixtures fails (vacuous green forbidden)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "r2-golden-"));
+    const path = join(dir, "r2-golden.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ schema: "r2-golden/v1", fixtures: [] }),
+    );
+    const res = await run(["--base", "http://127.0.0.1:1", "--golden", path]);
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.match(res.stdout + res.stderr, /no fixture/i);
+  });
+
+  test("writes a markdown summary row per fixture to GITHUB_STEP_SUMMARY", async () => {
+    const { dir, path } = await baseline();
+    const summary = join(dir, "summary.md");
+    const srv = await startServer({
+      [PAGE_KEY]: json(pageV2Body()),
+      [EMPTY_KEY]: json(emptyPageV2Body()),
+      [ALT_KEY]: json(alternativesBody()),
+    });
+    const res = await run(["--base", srv.base, "--golden", path], { summary });
+    await srv.close();
+    assert.equal(res.code, 0);
+    const md = readFileSync(summary, "utf8");
+    assert.match(md, /plaquettes-402-x-57414/);
+    assert.match(md, /alt-3859-x-11836/);
+  });
+});

--- a/scripts/ci/assert-r2-golden.test.mjs
+++ b/scripts/ci/assert-r2-golden.test.mjs
@@ -542,6 +542,65 @@ describe("assert-r2-golden.mjs — R2 relations + criteria golden gate", () => {
     assert.match(res.stdout, /no expected/i);
   });
 
+  // Barrière d'identifiants : aucune valeur du fichier golden n'atteint une requête
+  // sortante sans avoir été validée comme entier positif sûr. Le refus est bruyant
+  // et se produit AVANT tout appel réseau (--base pointe sur un port fermé : si une
+  // requête partait malgré tout, l'erreur serait « transport », pas « safe integer »).
+  for (const [label, bad] of [
+    ["chaîne", "402"],
+    ["décimal", 402.5],
+    ["négatif", -402],
+    ["zéro", 0],
+    ["hors safe-integer", 1e21],
+    ["absent", undefined],
+    ["objet", { toString: () => "402" }],
+  ]) {
+    test(`un identifiant ${label} dans le golden échoue avant toute requête`, async () => {
+      const dir = mkdtempSync(join(tmpdir(), "r2-golden-"));
+      const path = join(dir, "r2-golden.json");
+      writeFileSync(
+        path,
+        JSON.stringify({
+          schema: "r2-golden/v1",
+          fixtures: [
+            { id: "bad", kind: "page-v2", gamme_id: bad, vehicle_id: 57414 },
+          ],
+        }),
+      );
+      const res = await run(["--base", "http://127.0.0.1:1", "--golden", path]);
+      assert.equal(res.code, 1, res.stdout + res.stderr);
+      assert.match(
+        res.stdout + res.stderr,
+        /gamme_id must be a positive safe integer/i,
+      );
+    });
+  }
+
+  test("un identifiant qui tenterait d'injecter des paramètres est rejeté, pas encodé", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "r2-golden-"));
+    const path = join(dir, "r2-golden.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        schema: "r2-golden/v1",
+        fixtures: [
+          {
+            id: "inject",
+            kind: "alternatives",
+            gamme_id: "1&limit=999",
+            type_id: 11836,
+          },
+        ],
+      }),
+    );
+    const res = await run(["--base", "http://127.0.0.1:1", "--golden", path]);
+    assert.equal(res.code, 1, res.stdout + res.stderr);
+    assert.match(
+      res.stdout + res.stderr,
+      /gamme_id must be a positive safe integer/i,
+    );
+  });
+
   test("a golden file with zero fixtures fails (vacuous green forbidden)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "r2-golden-"));
     const path = join(dir, "r2-golden.json");

--- a/scripts/ci/r2-golden.json
+++ b/scripts/ci/r2-golden.json
@@ -1,0 +1,1755 @@
+{
+  "schema": "r2-golden/v1",
+  "captured_at": "2026-09-02T00:50:13.509Z",
+  "captured_from": "http://localhost:3000",
+  "git_sha": "b9bffc494f7816b165e39ab2d903f55124142d72",
+  "fixtures": [
+    {
+      "id": "plaquettes-402-x-57414",
+      "kind": "page-v2",
+      "gamme_id": 402,
+      "vehicle_id": 57414,
+      "why": "gamme populaire peuplée (plaquettes) : 2 côtés (critères Avant/Arrière), 5 groupes, 16 marques, 21 OEM ; contient des pièces sans image et des piece_position null",
+      "expected": {
+        "classification": "ok",
+        "success": true,
+        "count": 56,
+        "relationsCount": 56,
+        "products": [
+          {
+            "piece_id": 70707,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 70892,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 70902,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 70915,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 618990,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 1091574,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1091575,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1091576,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1349864,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1356255,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1821091,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1821096,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1821098,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1957088,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1960005,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1960834,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2006174,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2006352,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2006896,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2007140,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2012668,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2012675,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 3747891,
+            "pm_id": 4120,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 3747952,
+            "pm_id": 4120,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 4383187,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 4383592,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 5086265,
+            "pm_id": 3130,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 5088843,
+            "pm_id": 3130,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 5192414,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5192415,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5979533,
+            "pm_id": 3420,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5979597,
+            "pm_id": 3420,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6476530,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6476534,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6672973,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6672974,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6672975,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7305602,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7305628,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7305631,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7305632,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7357890,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 7357897,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 7481987,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7481988,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7482064,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7736200,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7736201,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7736202,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7736203,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7736206,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Plaquettes de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7877469,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 7877473,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Accessoires de plaquette",
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12176990,
+            "pm_id": 2910,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12483085,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12483090,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          }
+        ],
+        "groups": [
+          {
+            "filtre_gamme": "Accessoires de plaquette",
+            "filtre_side": "Arrière",
+            "piece_ids": [
+              618990,
+              4383592,
+              5088843,
+              7357897,
+              7877473
+            ],
+            "oemRefs": []
+          },
+          {
+            "filtre_gamme": "Accessoires de plaquette",
+            "filtre_side": "Avant",
+            "piece_ids": [
+              4383187,
+              5086265,
+              7357890,
+              7877469
+            ],
+            "oemRefs": []
+          },
+          {
+            "filtre_gamme": null,
+            "filtre_side": null,
+            "piece_ids": [
+              12176990,
+              12483085,
+              12483090
+            ],
+            "oemRefs": []
+          },
+          {
+            "filtre_gamme": "Plaquettes de frein",
+            "filtre_side": "Arrière",
+            "piece_ids": [
+              70892,
+              1091576,
+              1356255,
+              1821098,
+              1960005,
+              2012668,
+              2012675,
+              3747891,
+              5192415,
+              5979597,
+              6476534,
+              6672974,
+              7305628,
+              7482064,
+              7736206
+            ],
+            "oemRefs": [
+              "13300867",
+              "13300868",
+              "133192294",
+              "13319293",
+              "13404405",
+              "13411380",
+              "13473427",
+              "1680880080",
+              "42793718",
+              "95516192"
+            ]
+          },
+          {
+            "filtre_gamme": "Plaquettes de frein",
+            "filtre_side": "Avant",
+            "piece_ids": [
+              70707,
+              70902,
+              70915,
+              1091574,
+              1091575,
+              1349864,
+              1821091,
+              1821096,
+              1957088,
+              1960834,
+              2006174,
+              2006352,
+              2006896,
+              2007140,
+              3747952,
+              5192414,
+              5979533,
+              6476530,
+              6672973,
+              6672975,
+              7305602,
+              7305631,
+              7305632,
+              7481987,
+              7481988,
+              7736200,
+              7736201,
+              7736202,
+              7736203
+            ],
+            "oemRefs": [
+              "13301234",
+              "13356286",
+              "13374966",
+              "13412807",
+              "22799077",
+              "23242201",
+              "39126138",
+              "42570931",
+              "42589333",
+              "95516193",
+              "D13301207"
+            ]
+          }
+        ],
+        "filters": {
+          "sides": [
+            {
+              "value": "Arrière",
+              "count": 20
+            },
+            {
+              "value": "Avant",
+              "count": 33
+            }
+          ],
+          "brands": [
+            {
+              "pm_id": 380,
+              "count": 3
+            },
+            {
+              "pm_id": 670,
+              "count": 2
+            },
+            {
+              "pm_id": 730,
+              "count": 5
+            },
+            {
+              "pm_id": 810,
+              "count": 5
+            },
+            {
+              "pm_id": 1270,
+              "count": 6
+            },
+            {
+              "pm_id": 1780,
+              "count": 2
+            },
+            {
+              "pm_id": 1810,
+              "count": 2
+            },
+            {
+              "pm_id": 2590,
+              "count": 3
+            },
+            {
+              "pm_id": 2910,
+              "count": 1
+            },
+            {
+              "pm_id": 3130,
+              "count": 2
+            },
+            {
+              "pm_id": 3140,
+              "count": 3
+            },
+            {
+              "pm_id": 3410,
+              "count": 3
+            },
+            {
+              "pm_id": 3420,
+              "count": 2
+            },
+            {
+              "pm_id": 4120,
+              "count": 2
+            },
+            {
+              "pm_id": 4540,
+              "count": 10
+            },
+            {
+              "pm_id": 4670,
+              "count": 5
+            }
+          ],
+          "qualities": [
+            {
+              "value": "EQUIV",
+              "count": 43
+            },
+            {
+              "value": "OE",
+              "count": 13
+            }
+          ]
+        },
+        "oemRefs": [
+          "13300867",
+          "13300868",
+          "13301234",
+          "133192294",
+          "13319293",
+          "13356286",
+          "13374966",
+          "13404405",
+          "13411380",
+          "13412807",
+          "13473427",
+          "1680880080",
+          "22799077",
+          "23242201",
+          "39126138",
+          "42570931",
+          "42589333",
+          "42793718",
+          "95516192",
+          "95516193",
+          "D13301207"
+        ],
+        "crossSelling": []
+      }
+    },
+    {
+      "id": "disques-82-x-57414",
+      "kind": "page-v2",
+      "gamme_id": 82,
+      "vehicle_id": 57414,
+      "why": "seconde gamme freinage peuplée sur le même véhicule : 2 côtés, 3 groupes, 17 marques, 18 OEM",
+      "expected": {
+        "classification": "ok",
+        "success": true,
+        "count": 61,
+        "relationsCount": 61,
+        "products": [
+          {
+            "piece_id": 67153,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 67154,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 67155,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 67156,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 516335,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 516338,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 552189,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 552191,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 552192,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 552194,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 552196,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1641751,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1641769,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1641789,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1641807,
+            "pm_id": 3410,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1940812,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1940813,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1941647,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 1941648,
+            "pm_id": 380,
+            "quality": "OE",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2016691,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2029807,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2029850,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2029906,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2726140,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2726178,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2726292,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2726573,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 3688313,
+            "pm_id": 4120,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 3688314,
+            "pm_id": 4120,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 3688383,
+            "pm_id": 4120,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 4828696,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 4829125,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 4829130,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 4829134,
+            "pm_id": 4540,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5192628,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5192629,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5192631,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5216316,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5504660,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5504768,
+            "pm_id": 1270,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5979012,
+            "pm_id": 3420,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5979048,
+            "pm_id": 3420,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6059574,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6059575,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6059578,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6059582,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6059585,
+            "pm_id": 1810,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6069905,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6069919,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6070749,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6071045,
+            "pm_id": 4670,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7484113,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7484114,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7484115,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Avant",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7484117,
+            "pm_id": 3140,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 8559944,
+            "pm_id": 3420,
+            "quality": "EQUIV",
+            "piece_position": "Arrière",
+            "filtre_gamme": "Disque de frein",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 12172050,
+            "pm_id": 2910,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12185557,
+            "pm_id": 4820,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12185723,
+            "pm_id": 4820,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12218327,
+            "pm_id": 810,
+            "quality": "OE",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          },
+          {
+            "piece_id": 12489145,
+            "pm_id": 4290,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          }
+        ],
+        "groups": [
+          {
+            "filtre_gamme": "Disque de frein",
+            "filtre_side": "Arrière",
+            "piece_ids": [
+              67155,
+              67156,
+              516335,
+              516338,
+              1641769,
+              1641807,
+              1940812,
+              1940813,
+              2029850,
+              2029906,
+              2726140,
+              2726292,
+              3688313,
+              3688383,
+              4829125,
+              4829134,
+              5192628,
+              5216316,
+              5504660,
+              5504768,
+              5979048,
+              6059582,
+              6059585,
+              6069905,
+              6069919,
+              7484114,
+              7484117,
+              8559944
+            ],
+            "oemRefs": [
+              "13 502 136",
+              "13 502 139",
+              "13 502 864",
+              "13502134",
+              "13502135",
+              "13505759",
+              "23118282",
+              "23118283"
+            ]
+          },
+          {
+            "filtre_gamme": "Disque de frein",
+            "filtre_side": "Avant",
+            "piece_ids": [
+              67153,
+              67154,
+              552189,
+              552191,
+              552192,
+              552194,
+              552196,
+              1641751,
+              1641789,
+              1941647,
+              1941648,
+              2016691,
+              2029807,
+              2726178,
+              2726573,
+              3688314,
+              4828696,
+              4829130,
+              5192629,
+              5192631,
+              5979012,
+              6059574,
+              6059575,
+              6059578,
+              6070749,
+              6071045,
+              7484113,
+              7484115
+            ],
+            "oemRefs": [
+              "13 502 824",
+              "13502044",
+              "13502045",
+              "13502051",
+              "13502052",
+              "13502053",
+              "13503988",
+              "23118060",
+              "23118274",
+              "23118275"
+            ]
+          },
+          {
+            "filtre_gamme": null,
+            "filtre_side": null,
+            "piece_ids": [
+              12172050,
+              12185557,
+              12185723,
+              12218327,
+              12489145
+            ],
+            "oemRefs": []
+          }
+        ],
+        "filters": {
+          "sides": [
+            {
+              "value": "Arrière",
+              "count": 28
+            },
+            {
+              "value": "Avant",
+              "count": 28
+            }
+          ],
+          "brands": [
+            {
+              "pm_id": 380,
+              "count": 4
+            },
+            {
+              "pm_id": 670,
+              "count": 4
+            },
+            {
+              "pm_id": 730,
+              "count": 4
+            },
+            {
+              "pm_id": 810,
+              "count": 8
+            },
+            {
+              "pm_id": 1270,
+              "count": 2
+            },
+            {
+              "pm_id": 1780,
+              "count": 4
+            },
+            {
+              "pm_id": 1810,
+              "count": 5
+            },
+            {
+              "pm_id": 2590,
+              "count": 4
+            },
+            {
+              "pm_id": 2910,
+              "count": 1
+            },
+            {
+              "pm_id": 3140,
+              "count": 4
+            },
+            {
+              "pm_id": 3410,
+              "count": 4
+            },
+            {
+              "pm_id": 3420,
+              "count": 3
+            },
+            {
+              "pm_id": 4120,
+              "count": 3
+            },
+            {
+              "pm_id": 4290,
+              "count": 1
+            },
+            {
+              "pm_id": 4540,
+              "count": 4
+            },
+            {
+              "pm_id": 4670,
+              "count": 4
+            },
+            {
+              "pm_id": 4820,
+              "count": 2
+            }
+          ],
+          "qualities": [
+            {
+              "value": "EQUIV",
+              "count": 45
+            },
+            {
+              "value": "OE",
+              "count": 16
+            }
+          ]
+        },
+        "oemRefs": [
+          "13 502 136",
+          "13 502 139",
+          "13 502 824",
+          "13 502 864",
+          "13502044",
+          "13502045",
+          "13502051",
+          "13502052",
+          "13502053",
+          "13502134",
+          "13502135",
+          "13503988",
+          "13505759",
+          "23118060",
+          "23118274",
+          "23118275",
+          "23118282",
+          "23118283"
+        ],
+        "crossSelling": []
+      }
+    },
+    {
+      "id": "filtre-huile-7-x-57414",
+      "kind": "page-v2",
+      "gamme_id": 7,
+      "vehicle_id": 57414,
+      "why": "gamme peuplée sans critère de côté (13 pièces, 2 groupes, 0 side) — couvre le chemin criteria-less",
+      "expected": {
+        "classification": "ok",
+        "success": true,
+        "count": 13,
+        "relationsCount": 13,
+        "products": [
+          {
+            "piece_id": 830645,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 2674168,
+            "pm_id": 1780,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5191397,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5191419,
+            "pm_id": 670,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5858769,
+            "pm_id": 1090,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 5969831,
+            "pm_id": 3420,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6381971,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6382215,
+            "pm_id": 730,
+            "quality": "OE",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6442773,
+            "pm_id": 1180,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6494376,
+            "pm_id": 2590,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 6494560,
+            "pm_id": 3130,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 7256504,
+            "pm_id": 3820,
+            "quality": "EQUIV",
+            "piece_position": null,
+            "filtre_gamme": "Filtre à huile",
+            "is_accessory": false
+          },
+          {
+            "piece_id": 12475034,
+            "pm_id": 700,
+            "quality": "ECO",
+            "piece_position": null,
+            "filtre_gamme": null,
+            "is_accessory": true
+          }
+        ],
+        "groups": [
+          {
+            "filtre_gamme": "Filtre à huile",
+            "filtre_side": null,
+            "piece_ids": [
+              830645,
+              2674168,
+              5191397,
+              5191419,
+              5858769,
+              5969831,
+              6381971,
+              6382215,
+              6442773,
+              6494376,
+              6494560,
+              7256504
+            ],
+            "oemRefs": [
+              "25 195 775",
+              "55560748",
+              "93190129"
+            ]
+          },
+          {
+            "filtre_gamme": null,
+            "filtre_side": null,
+            "piece_ids": [
+              12475034
+            ],
+            "oemRefs": []
+          }
+        ],
+        "filters": {
+          "sides": [],
+          "brands": [
+            {
+              "pm_id": 670,
+              "count": 2
+            },
+            {
+              "pm_id": 700,
+              "count": 1
+            },
+            {
+              "pm_id": 730,
+              "count": 2
+            },
+            {
+              "pm_id": 1090,
+              "count": 1
+            },
+            {
+              "pm_id": 1180,
+              "count": 1
+            },
+            {
+              "pm_id": 1780,
+              "count": 2
+            },
+            {
+              "pm_id": 2590,
+              "count": 1
+            },
+            {
+              "pm_id": 3130,
+              "count": 1
+            },
+            {
+              "pm_id": 3420,
+              "count": 1
+            },
+            {
+              "pm_id": 3820,
+              "count": 1
+            }
+          ],
+          "qualities": [
+            {
+              "value": "ECO",
+              "count": 1
+            },
+            {
+              "value": "EQUIV",
+              "count": 10
+            },
+            {
+              "value": "OE",
+              "count": 2
+            }
+          ]
+        },
+        "oemRefs": [
+          "25 195 775",
+          "55560748",
+          "93190129"
+        ],
+        "crossSelling": []
+      }
+    },
+    {
+      "id": "kit-freins-3859-x-11836",
+      "kind": "page-v2",
+      "gamme_id": 3859,
+      "vehicle_id": 11836,
+      "why": "couple vide (soft-404 fixture #1, BMW 525d F10) : classification empty, 0 relation",
+      "expected": {
+        "classification": "empty",
+        "success": true,
+        "count": 0,
+        "relationsCount": 0,
+        "products": [],
+        "groups": [],
+        "filters": {
+          "sides": [],
+          "brands": [],
+          "qualities": []
+        },
+        "oemRefs": [],
+        "crossSelling": []
+      }
+    },
+    {
+      "id": "alt-3859-x-11836",
+      "kind": "alternatives",
+      "gamme_id": 3859,
+      "type_id": 11836,
+      "why": "alternatives soft-404 dérivées de pieces_relation_type (rtp_pg_id ×5 dans la RPC) — chemin mené par pg_id, dégradé par B7",
+      "expected": {
+        "vehicles": [
+          "3726",
+          "3825",
+          "4650",
+          "32177"
+        ],
+        "gammes": [
+          2,
+          4,
+          82,
+          273,
+          402,
+          470,
+          479,
+          2234
+        ],
+        "models": [
+          33021,
+          33026,
+          33030,
+          33032
+        ]
+      }
+    },
+    {
+      "id": "alt-4-x-16023",
+      "kind": "alternatives",
+      "gamme_id": 4,
+      "type_id": 16023,
+      "why": "véhicule à forte fratrie (BMW E60 alternateur, 800+ siblings) — fixture la plus lourde du smoke soft-404",
+      "expected": {
+        "vehicles": [
+          "14802",
+          "14924",
+          "15271",
+          "16828",
+          "17176",
+          "17291"
+        ],
+        "gammes": [
+          8,
+          82,
+          107,
+          188,
+          273,
+          402,
+          424,
+          854
+        ],
+        "models": [
+          33017,
+          33018,
+          33019,
+          33020
+        ]
+      }
+    },
+    {
+      "id": "alt-7-x-11688",
+      "kind": "alternatives",
+      "gamme_id": 7,
+      "type_id": 11688,
+      "why": "alternatives sur un couple vide hors freinage (filtre à huile, Sandero Stepway)",
+      "expected": {
+        "vehicles": [
+          "2049",
+          "2114",
+          "12523",
+          "14048",
+          "23487",
+          "32992"
+        ],
+        "gammes": [
+          70,
+          82,
+          107,
+          298,
+          318,
+          402,
+          560,
+          2462
+        ],
+        "models": [
+          140000,
+          140001,
+          140002,
+          140003
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Objet

Slice **R2-GOLDEN** du plan massdoc. Exigence owner : *« garantir que les relations pièces et critères vont continuer de fonctionner sur page R2 »*. Deux slices DB à venir touchent la **structure** des tables derrière la page R2 — `pieces_relation_type` (partitionnement par hachage, B7) et `pieces_criteria` (étude d'index, B4). Une promesse déclarative n'est pas une garantie : ce gate la rend **mécanique** (CI rouge), et le plan interdit de toucher B4/B7 tant qu'il n'est pas en place et vert (NO-GO 17).

## Ce que le gate compare

[`scripts/ci/assert-r2-golden.mjs`](scripts/ci/assert-r2-golden.mjs) compare une **projection figée** des deux endpoints que le loader R2 appelle réellement (`/api/rm/page-v2` au limit canonique 200, `/api/rm/alternatives` au limit 12) au golden commité [`scripts/ci/r2-golden.json`](scripts/ci/r2-golden.json).

| Gardé (relations + critères) | Exclu (volatil par conception) |
|---|---|
| `piece_id`, `pm_id`, `quality`, **`piece_position`** (critère côté), `filtre_gamme`, `is_accessory` — triés par `piece_id` | prix, stock, `score` de ranking, ordre d'affichage |
| groupes : `filtre_side`, `filtre_gamme`, pièces, OEM refs | images / `has_image`, libellés, `piece_reference` |
| `filters.sides` / `brands` / `qualities` **avec comptes**, `oemRefs`, `crossSelling`, `relationsCount` | SEO (`seo.*`), `vehicleInfo`, `duration_ms`, `cacheHit`, `etag` |
| alternatives : ensembles triés de `type_id` / `pg_id` / `modele_id` | le **ranking** des alternatives (hors contrat ici) |

Un import tarifaire ne déclenche jamais le gate. Une relation perdue, un côté déplacé (`Avant → Arrière`) ou un ensemble d'alternatives changé le déclenchent toujours, avec un diff lisible nommant la fixture et le champ.

## Règles de verdict (même discipline que `preprod-response-suite.sh`)

- Chaque fixture est évaluée même après un échec — tableau complet, jamais tronqué.
- **Divergence / 404 / statut inattendu = définitif, jamais rejoué → exit 1.**
- Transport (5xx, refus, timeout — RPC froide sur container neuf) rejoué **une** fois, puis exit 2. La divergence domine le transport.
- Un golden qui n'évalue rien échoue (vert vide interdit). Une fixture sans `expected` échoue hors `--update`.
- `--update` est le **seul** chemin de re-baseline : atomique, provenance stampée (`captured_at`, `captured_from`, `git_sha`), relu en diff de PR. Un import catalogue qui change légitimement les relations est re-baseliné explicitement, jamais absorbé.

## Fixtures (7) — capturées depuis DEV:3000 (`main` `b9bffc494`, DB PROD), 0 divergence sur un second passage

| Fixture | Couvre |
|---|---|
| `plaquettes-402-x-57414` | gamme populaire peuplée : 56 pièces, 2 côtés, 5 groupes, 16 marques, 21 OEM, pièces sans image, `piece_position` null |
| `disques-82-x-57414` | seconde gamme freinage, 61 pièces, 2 côtés |
| `filtre-huile-7-x-57414` | gamme peuplée **sans** critère de côté (chemin criteria-less) |
| `kit-freins-3859-x-11836` | couple vide (soft-404 fixture #1) : classification `empty`, 0 relation |
| `alt-3859-x-11836` | alternatives dérivées de `pieces_relation_type` menées par `rtp_pg_id` — le chemin dégradé par B7 |
| `alt-4-x-16023` | BMW E60 alternateur, 800+ siblings — fixture la plus lourde du smoke |
| `alt-7-x-11688` | alternatives sur un couple vide hors freinage |

## Câblage

- `ci.yml` : step **🧬 R2 golden — relations pièces + critères (BLOCKING)** après le smoke soft-404, contre PREPROD `localhost:3200`.
- `audit.yml` + `npm run test:r2-golden` : preuve comportementale [`assert-r2-golden.test.mjs`](scripts/ci/assert-r2-golden.test.mjs) — **13 tests** node:test contre un serveur HTTP local (TDD, RED observé avant GREEN) : volatil-seulement → 0 ; relation perdue / côté déplacé / alternatives changées → 1 avec diff ; 503 puis 200 → 1 retry → 0 ; transport persistant → 2 (autres fixtures évaluées) ; 404 → 1 sans retry ; divergence domine transport ; sans `expected` → 1 ; golden vide → 1 ; résumé markdown par fixture.

## Vérification

- Local : `npm run test:r2-golden` → 13/13 ; `node scripts/ci/assert-r2-golden.mjs --base http://localhost:3000` → 7/7, 0 divergence, 0 transport.
- **Ce que cette PR prouve** : la preuve comportementale (13 tests, job audit) tourne sur la PR. **Ce qu'elle ne prouve pas encore** : le step « 🧬 R2 golden » vit dans le job deploy de `ci.yml`, qui ne s'exécute que sur push `main` (comme le smoke soft-404 qu'il suit). Sa **première exécution réelle contre PREPROD** (rôle anon, `READ_ONLY`) aura lieu sur le run `main` post-merge. Le golden a été capturé avec le rôle service (DEV:3000) : si anon voit des relations différentes (RLS), le gate sera rouge sur `main` — c'est exactement ce qu'il doit dire ; instruction = revert ou re-baseline motivée, jamais contournement. **Aucun GO B4/B7 avant d'avoir lu ce premier run vert.**
- Aucun changement de runtime, de DB, d'URL, de meta/H1. Nouveaux fichiers sous `scripts/ci/**` (glob D13 existant, gate Block-new satisfait).

## Sur B7 spécifiquement (à ajouter dans la PR B7, pas ici)

Le plan exige en plus, pour B7 : assertion que l'élagage de partitions **fonctionne** (`Partitions removed:` dans l'`EXPLAIN` d'un prédicat mené par `rtp_type_id`) **et** que le chemin mené par `rtp_pg_id` (les 3 fixtures `alt-*`) reste sous son seuil de latence. Ce gate fournit l'égalité de contenu ; la latence relève de l'API Timing Gate existante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
