### PR TITLE
perf(seo-monitor): sonde bornée sur rtp_pg_id au lieu d'un count exact sur rtp_ga_id (A1)

### DIFF
--- a/backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts
+++ b/backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts
@@ -1,0 +1,138 @@
+// backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_KEY || 'test-service-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key';
+
+import { SeoMonitorProcessor } from '../seo-monitor.processor';
+
+/**
+ * Contrat de la sonde `checkUrl` (A1, plan massdoc 2026-09-02).
+ *
+ * Avant : `.select('rtp_piece_id', { count: 'exact', head: true })` filtré sur
+ * `rtp_type_id` + `rtp_ga_id`. Mesuré en PROD (pg_stat_statements) : 110 663
+ * appels, 1 167 ms de moyenne, 2 705 blocs lus par appel ≈ 2,3 To de churn du
+ * buffer pool — comptage complet sur 368 M lignes, et `rtp_ga_id` n'est pas
+ * indexé.
+ *
+ * Et la colonne était la mauvaise : `rtp_ga_id` est la gamme ARTICLE (sous-
+ * gamme TecDoc : « Accessoires de plaquette », « Tête de cardan »…), pas la
+ * gamme de la page. Toutes les RPC de la page R2 filtrent `rtp_pg_id`, et sur
+ * les 8 couples critiques le comptage via `rtp_ga_id` sous-compte de 1 à 12 %
+ * (ex. 893 contre 1 010 pour disques 82 × 29991) — preuve SQL dans la PR.
+ *
+ * Après : sonde BORNÉE — au plus `WARNING_THRESHOLD` (5) lignes lues via
+ * l'index composite `(rtp_type_id, rtp_pg_id)`, sans comptage. La frontière
+ * de décision est intacte : 0 → error, 1..4 → warning avec le compte exact,
+ * ≥ 5 → ok (piecesCount rapporté = 5, borne de la sonde).
+ */
+
+type QueryResult = {
+  data?: unknown[] | null;
+  error?: { message: string } | null;
+  count?: number | null;
+};
+
+function supabaseMock(result: QueryResult) {
+  const builder: Record<string, jest.Mock> & { then?: unknown } = {};
+  for (const m of ['select', 'eq', 'limit']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  // Les query builders Supabase sont des thenables : `await builder` résout.
+  builder.then = (
+    resolve: (v: QueryResult) => unknown,
+    reject: (e: unknown) => unknown,
+  ) => Promise.resolve(result).then(resolve, reject);
+  const from = jest.fn(() => builder);
+  return { client: { from }, from, builder };
+}
+
+function buildProcessor(result: QueryResult) {
+  const configService = { get: (k: string) => process.env[k] } as never;
+  const rpcGate = {} as never;
+  const jobHealth = { recordSuccess: jest.fn().mockResolvedValue(undefined) };
+  const processor = new SeoMonitorProcessor(
+    configService,
+    rpcGate,
+    jobHealth as never,
+  );
+  const mock = supabaseMock(result);
+  (processor as unknown as { supabase: unknown }).supabase = mock.client;
+  type CheckResult = {
+    status: 'ok' | 'warning' | 'error';
+    piecesCount: number;
+    message?: string;
+  };
+  const checkUrl = (url: string, typeId: number, gammeId: number) =>
+    (
+      processor as unknown as {
+        checkUrl: (u: string, t: number, g: number) => Promise<CheckResult>;
+      }
+    ).checkUrl(url, typeId, gammeId);
+  return { processor, mock, checkUrl };
+}
+
+const rows = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ rtp_piece_id: i + 1 }));
+
+describe('SeoMonitorProcessor.checkUrl — sonde de présence bornée (A1)', () => {
+  it('filtre rtp_type_id + rtp_pg_id (jamais rtp_ga_id), sans count exact, borné à 5 lignes', async () => {
+    const { mock, checkUrl } = buildProcessor({ data: rows(5), error: null });
+
+    await checkUrl('/pieces/filtre-a-huile-7/x/y/z-8217.html', 8217, 7);
+
+    expect(mock.from).toHaveBeenCalledWith('pieces_relation_type');
+    // Sélection plate : ni `{ count: 'exact' }` ni `head: true`.
+    expect(mock.builder.select).toHaveBeenCalledWith('rtp_piece_id');
+    expect(mock.builder.eq).toHaveBeenCalledWith('rtp_type_id', 8217);
+    expect(mock.builder.eq).toHaveBeenCalledWith('rtp_pg_id', 7);
+    expect(mock.builder.eq).not.toHaveBeenCalledWith(
+      'rtp_ga_id',
+      expect.anything(),
+    );
+    expect(mock.builder.limit).toHaveBeenCalledWith(5);
+  });
+
+  it('0 ligne → status error (risque désindexation), piecesCount 0', async () => {
+    const { checkUrl } = buildProcessor({ data: [], error: null });
+
+    const result = await checkUrl('/pieces/x', 8217, 7);
+
+    expect(result.status).toBe('error');
+    expect(result.piecesCount).toBe(0);
+    expect(result.message).toMatch(/0 pièce/);
+  });
+
+  it('1..4 lignes → status warning avec le compte exact', async () => {
+    const { checkUrl } = buildProcessor({ data: rows(3), error: null });
+
+    const result = await checkUrl('/pieces/x', 8217, 7);
+
+    expect(result.status).toBe('warning');
+    expect(result.piecesCount).toBe(3);
+  });
+
+  it('5 lignes (borne de la sonde) → status ok, piecesCount = 5 (≥ 5)', async () => {
+    const { checkUrl } = buildProcessor({ data: rows(5), error: null });
+
+    const result = await checkUrl('/pieces/x', 8217, 7);
+
+    expect(result.status).toBe('ok');
+    expect(result.piecesCount).toBe(5);
+  });
+
+  it('erreur DB → status error, piecesCount -1, message explicite', async () => {
+    const { checkUrl } = buildProcessor({
+      data: null,
+      error: { message: 'connection reset' },
+    });
+
+    const result = await checkUrl('/pieces/x', 8217, 7);
+
+    expect(result.status).toBe('error');
+    expect(result.piecesCount).toBe(-1);
+    expect(result.message).toMatch(/Erreur DB: connection reset/);
+  });
+});

--- a/backend/src/workers/processors/seo-monitor.processor.ts
+++ b/backend/src/workers/processors/seo-monitor.processor.ts
@@ -17,6 +17,12 @@ import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { getErrorMessage } from '@common/utils/error.utils';
 import { AdminJobHealthService } from '../../modules/admin/services/admin-job-health.service';
 
+/**
+ * Seuil « peu de pièces » (warning). C'est aussi la borne de lecture de la
+ * sonde `checkUrl` : au-delà, le compte exact n'a aucune valeur de décision.
+ */
+const WARNING_THRESHOLD = 5;
+
 interface SeoMonitorJobData {
   taskType: 'check-critical-urls' | 'check-random-sample';
   triggeredBy: 'scheduler' | 'api' | 'alert';
@@ -231,12 +237,24 @@ export class SeoMonitorProcessor extends SupabaseBaseService {
     gammeId: number,
   ): Promise<UrlCheckResult> {
     try {
-      // Source de verite: pieces_relation_type (meme table que la RPC get_pieces_for_type_gamme_v4)
-      const { count, error } = await this.supabase
+      // Source de vérité : pieces_relation_type, MÊME colonne que les RPC de la
+      // page R2 (rm_get_page_complete_v2 / get_listing_products_extended /
+      // get_soft_404_alternatives) = `rtp_pg_id` (gamme de la page). `rtp_ga_id`
+      // est la gamme ARTICLE TecDoc (sous-gamme), non indexée : l'ancien filtre
+      // sous-comptait de 1 à 12 % sur les couples critiques et coûtait
+      // 2 705 blocs lus par appel (comptage exact sur 368 M lignes, A1 plan
+      // massdoc 2026-09-02).
+      //
+      // Sonde BORNÉE : la décision ne dépend que de « 0 / moins de
+      // WARNING_THRESHOLD / au moins WARNING_THRESHOLD » — on lit au plus
+      // WARNING_THRESHOLD lignes via l'index composite (rtp_type_id, rtp_pg_id),
+      // jamais un COUNT complet.
+      const { data, error } = await this.supabase
         .from('pieces_relation_type')
-        .select('rtp_piece_id', { count: 'exact', head: true })
+        .select('rtp_piece_id')
         .eq('rtp_type_id', typeId)
-        .eq('rtp_ga_id', gammeId);
+        .eq('rtp_pg_id', gammeId)
+        .limit(WARNING_THRESHOLD);
 
       if (error) {
         return {
@@ -250,7 +268,9 @@ export class SeoMonitorProcessor extends SupabaseBaseService {
         };
       }
 
-      const piecesCount = count ?? 0;
+      // = min(nombre réel, WARNING_THRESHOLD) : exact sous le seuil (ce qui
+      // alimente les alertes), « ≥ WARNING_THRESHOLD » au-dessus.
+      const piecesCount = data?.length ?? 0;
 
       // Analyse du résultat
       if (piecesCount === 0) {
@@ -268,7 +288,7 @@ export class SeoMonitorProcessor extends SupabaseBaseService {
         };
       }
 
-      if (piecesCount < 5) {
+      if (piecesCount < WARNING_THRESHOLD) {
         this.logger.warn(
           `⚠️ WARNING: Seulement ${piecesCount} pièce(s) pour ${url}`,
         );


### PR DESCRIPTION
## Contexte

Slice **A1** du plan massdoc. Rang 8 du snapshot `pg_stat_statements` (PR #1377) : la requête émise par [`seo-monitor.processor.ts`](backend/src/workers/processors/seo-monitor.processor.ts) — `SELECT rtp_piece_id FROM pieces_relation_type WHERE rtp_type_id=$1 AND rtp_ga_id=$2` en `{ count: 'exact', head: true }`.

| Mesure PROD (cumulé depuis 2026-03-15) | Valeur |
|---|---|
| Appels | 110 663 |
| Moyenne | 1 167 ms |
| Blocs lus / appel | **2 705** (≈ 2,3 To de churn du buffer pool sur la fenêtre) |
| Émetteur | worker cron 30 min, 8 URLs critiques + 20 aléatoires, décision « 0 / < 5 / ≥ 5 » |

## Deux défauts sur la même ligne

1. **Colonne non indexée** : `rtp_ga_id` n'a pas d'index. Le plan descend l'index composite sur `rtp_type_id` puis filtre `rtp_ga_id` ligne à ligne, et compte tout.
2. **Mauvaise colonne** : `rtp_ga_id` est la **gamme article** TecDoc (sous-gamme), pas la gamme de la page. Toutes les RPC de la page R2 (`rm_get_page_complete_v2`, `get_listing_products_extended`, `get_soft_404_alternatives`) filtrent `rtp_pg_id`.

Preuve SQL (lecture seule, PROD) :

```sql
-- Échantillon 36 201 lignes : 12,3 % ont rtp_ga_id ≠ rtp_pg_id (0 NULL des deux côtés)
SELECT count(*) FILTER (WHERE rtp_ga_id = rtp_pg_id), count(*) FILTER (WHERE rtp_ga_id IS DISTINCT FROM rtp_pg_id)
FROM pieces_relation_type TABLESAMPLE SYSTEM (0.01);
--> 31762 | 4439

-- Ce qu'est rtp_ga_id (top écarts, avec pieces_gamme.pg_name) :
-- pg 107 "Ampoule feu avant"        → ga 106 "Ampoule projecteur longue portée"
-- pg 273 "Bras de suspension"       → ga 251 "Silentbloc de bras de suspension"
-- pg 13  "Cardan"                   → ga 5   "Tête de cardan"
-- pg 402 "Plaquettes de frein"      → (accessoires de plaquette, cf. page-v2 filtre_gamme)
```

| Couple critique (type × gamme) | via `rtp_pg_id` (page) | via `rtp_ga_id` (ancien worker) |
|---|---|---|
| 7977 × 7 | 259 | 257 |
| 8217 × 7 | 268 | 266 |
| 29991 × 82 | **1 010** | **893** |
| 30971 × 82 | 995 | 905 |
| 6318 × 402 | 1 512 | 1 452 |
| 8773 × 402 | 1 519 | 1 454 |
| 11042 × 854 | 583 | 576 |
| 15452 × 854 | 599 | 590 |

Sur ces 8 couples le seuil n'était pas franchi. Mais l'échantillon aléatoire (20 couples par run) pouvait produire de **fausses alertes « 0 pièce — risque désindexation »** sur toute gamme dont les articles portent une autre gamme article.

## Changement

`.select('rtp_piece_id').eq('rtp_type_id').eq('rtp_pg_id').limit(WARNING_THRESHOLD)` — **au plus 5 lignes lues** via l'index composite `(rtp_type_id, rtp_pg_id)`, jamais de `COUNT`. La frontière de décision est intacte : 0 → error, 1..4 → warning avec le compte exact (ce qui alimente les alertes), ≥ 5 → ok avec `piecesCount = 5` (borne de la sonde, documentée dans le code).

## Evidence-after (PROD, `EXPLAIN (ANALYZE, BUFFERS)`, cache chaud, couple 82 × 29991)

| | Plan | Blocs | Temps |
|---|---|---|---|
| Ancien | Index Scan `rtp_type_id` + Filter `rtp_ga_id` (23 742 lignes retirées) + Aggregate | **7 982** | 24,9 ms |
| Nouveau | Index Scan `(rtp_type_id, rtp_pg_id)` + Limit 5 | **5** | 0,18 ms |

Les 2 705 blocs/appel du cumulé sont des lectures (cache froid) ; le rapport ×1 600 sur les blocs touchés vaut à froid comme à chaud.

## Tests (TDD, RED observé avant GREEN)

[`seo-monitor.processor.test.ts`](backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts) — 5 cas : contrat de requête (`select('rtp_piece_id')` plat, `eq('rtp_pg_id')`, jamais `rtp_ga_id`, `limit(5)`), 0 ligne → error, 3 → warning exact, 5 → ok, erreur DB → error -1. `tsc --noEmit` propre.

## Vérification à venir (pré-enregistrée)

- Après merge : la ligne `queryid 2936327735217431600` (rank 8 du snapshot) doit cesser de croître ; une nouvelle ligne `… rtp_pg_id = $2 LIMIT $3` apparaît avec `shared_blks_read/calls` de l'ordre de l'unité. Fenêtre ≥ 48 h (≥ 96 runs cron). **Falsifieur** : si `mean_exec_time` de la nouvelle ligne dépasse 10 ms à chaud, le planner n'utilise pas l'index composite.
- Aucune comparaison avec le cumulé 265 j (NO-GO 7).

## Runtime-awareness

- Worker BullMQ `seo-monitor` ; PREPROD court-circuite (`isReadOnlyMode`) donc aucune exécution avant PROD (tag `v*`, GO owner).
- Pas de changement DB, d'URL, de meta/H1. Rollback = revert.
- Rappel plan §A0 : ceci réduit le coût d'une requête de monitoring ; le levier dominant sur la charge R2 reste le cache CDN (PR C, owner-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
