### PR TITLE
perf(admin): batch R1 keyword-plan — RPC gouvernée via callRpc + cache par gamme (A4 massdoc)

### DIFF
--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 183,
+  "total": 185,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -478,6 +478,11 @@
       "name": "get_all_seo_references",
       "volatility": "STABLE",
       "reason": "SELECT only — liste R4 /reference-auto (231 refs publiées) ; absent de l'allowlist → RpcBlockedError en PROD enforce P2 → index vide (fix 2026-06-10)"
+    },
+    {
+      "name": "get_alternative_vehicles_for_gamme",
+      "volatility": "STABLE",
+      "reason": "Top véhicules par gamme pour le batch R1 keyword-plan (admin, 0-LLM). LANGUAGE sql STABLE (ADR-017, 395 ms), résultat dépend de p_gamme_id seul — mis en cache côté NestJS (r1kp:top-vehicles:{pgId}). Called by R1KeywordPlanBatchService.getTopVehicles via callRpc source admin (A4, plan massdoc 2026-09-02)."
     },
     {
       "name": "get_r5_redirect_target",

--- a/backend/src/config/cache-ttl.config.ts
+++ b/backend/src/config/cache-ttl.config.ts
@@ -353,6 +353,18 @@ export const CACHE_STRATEGIES = {
       description: 'Promotional data',
     },
   },
+
+  // ═══════════════════════════════════════════════════════════════
+  // KEYWORD PLAN (admin batch R1, 0-LLM)
+  // ═══════════════════════════════════════════════════════════════
+  KEYWORD_PLAN: {
+    R1_TOP_VEHICLES: {
+      ttl: CacheTTL.ONE_DAY,
+      prefix: 'r1kp:top-vehicles:',
+      description:
+        'Top véhicules par gamme (RPC get_alternative_vehicles_for_gamme, clé = pgId seul) — compatibilité TecDoc, stable entre imports',
+    },
+  },
 } as const;
 
 /**

--- a/backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts
+++ b/backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts
@@ -1,0 +1,175 @@
+// backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts
+
+// SupabaseBaseService vérifie les env vars dans son constructor — stub minimal
+// (canon, cf. rm-alternatives.service.test.ts).
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_KEY || 'test-service-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key';
+
+import { R1KeywordPlanBatchService } from './r1-keyword-plan-batch.service';
+import { CACHE_STRATEGIES } from '../../../config/cache-ttl.config';
+
+/**
+ * Contrat de `getTopVehicles(pgId)` (A4, plan massdoc 2026-09-02).
+ *
+ * Avant : `this.client.rpc('get_alternative_vehicles_for_gamme' as never,
+ * {...} as never)` — le double cast défait le typage ET le parseur d'allowlist
+ * (`scripts/ci/check-rpc-allowlist-coverage.sh` ne voit que `callRpc(...)`),
+ * et le fichier est dans la liste de contournement du RPC-gate (ci.yml), d'où
+ * l'invisibilité. Un appel séquentiel par gamme, jusqu'à 200 par requête
+ * `POST /api/admin/keyword-planner/batch-r1`, sans aucun cache — alors que le
+ * résultat ne dépend que de `pgId` (compatibilité TecDoc, stable entre imports).
+ *
+ * Après : `callRpc()` gouverné (nom littéral, `source: 'admin'`), résultat mis
+ * en cache sous `CACHE_STRATEGIES.KEYWORD_PLAN.R1_TOP_VEHICLES` (clé = pgId
+ * seul), erreur RPC observable (warn) et JAMAIS mise en cache.
+ */
+
+type TopVehicle = { marque_name: string; modele_name: string; cnt: number };
+
+const STRATEGY = CACHE_STRATEGIES.KEYWORD_PLAN.R1_TOP_VEHICLES;
+
+// Constructeur typé lâchement : le test décrit le contrat cible (4e dépendance
+// CacheService) sans dépendre de la signature courante.
+const ServiceCtor = R1KeywordPlanBatchService as unknown as new (
+  ...args: unknown[]
+) => R1KeywordPlanBatchService;
+
+function buildService() {
+  const configService = { get: (k: string) => process.env[k] };
+  const yamlParser = {};
+  const gatesService = {};
+  const cache = {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  };
+  const service = new ServiceCtor(
+    configService,
+    yamlParser,
+    gatesService,
+    cache,
+  );
+  const callRpc = jest.fn();
+  (service as unknown as { callRpc: jest.Mock }).callRpc = callRpc;
+  const getTopVehicles = (pgId: number): Promise<TopVehicle[]> =>
+    (
+      service as unknown as {
+        getTopVehicles: (id: number) => Promise<TopVehicle[]>;
+      }
+    ).getTopVehicles(pgId);
+  return { service, cache, callRpc, getTopVehicles };
+}
+
+const rpcRows = [
+  {
+    type_id: '11836',
+    type_name: '530 d',
+    type_alias: '530-d',
+    modele_name: 'Série 5 (E60)',
+    modele_alias: 'serie-5-e60',
+    modele_id: 33053,
+    marque_name: 'BMW',
+    marque_alias: 'bmw',
+    marque_id: 33,
+  },
+  {
+    type_id: '57414',
+    type_name: '1.9 TDI',
+    type_alias: '1-9-tdi',
+    modele_name: 'Golf V',
+    modele_alias: 'golf-v',
+    modele_id: 1201,
+    marque_name: 'Volkswagen',
+    marque_alias: 'volkswagen',
+    marque_id: 120,
+  },
+];
+
+describe('R1KeywordPlanBatchService.getTopVehicles — RPC gouvernée + cache (A4)', () => {
+  it('cache miss → un seul callRpc gouverné (nom littéral, params nommés, source admin), mappé en TopVehicle', async () => {
+    const { callRpc, getTopVehicles } = buildService();
+    callRpc.mockResolvedValue({ data: rpcRows, error: null });
+
+    const result = await getTopVehicles(402);
+
+    expect(callRpc).toHaveBeenCalledTimes(1);
+    expect(callRpc).toHaveBeenCalledWith(
+      'get_alternative_vehicles_for_gamme',
+      { p_gamme_id: 402, p_exclude_type_id: 0, p_limit: 6 },
+      { source: 'admin' },
+    );
+    expect(result).toEqual([
+      { marque_name: 'BMW', modele_name: 'Série 5 (E60)', cnt: 1 },
+      { marque_name: 'Volkswagen', modele_name: 'Golf V', cnt: 1 },
+    ]);
+  });
+
+  it('cache miss → écrit le résultat mappé sous la clé pgId seul, avec le TTL déclaré dans CACHE_STRATEGIES', async () => {
+    const { cache, callRpc, getTopVehicles } = buildService();
+    callRpc.mockResolvedValue({ data: rpcRows, error: null });
+
+    const result = await getTopVehicles(402);
+
+    expect(cache.get).toHaveBeenCalledWith('r1kp:top-vehicles:402');
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith(
+      'r1kp:top-vehicles:402',
+      result,
+      STRATEGY.ttl,
+    );
+    // La donnée dérive de la compatibilité TecDoc : stable entre imports.
+    expect(STRATEGY.ttl).toBe(86400);
+  });
+
+  it('cache hit → aucun appel RPC, résultat rejoué depuis le cache', async () => {
+    const { cache, callRpc, getTopVehicles } = buildService();
+    const cached: TopVehicle[] = [
+      { marque_name: 'Peugeot', modele_name: '308', cnt: 1 },
+    ];
+    cache.get.mockResolvedValue(cached);
+
+    const result = await getTopVehicles(7);
+
+    expect(callRpc).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
+    expect(result).toEqual(cached);
+  });
+
+  it('erreur RPC → [] observable (warn), et RIEN n’est mis en cache (anti-poisoning)', async () => {
+    const { service, cache, callRpc, getTopVehicles } = buildService();
+    callRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'permission denied', name: 'SupabaseRpcError' },
+    });
+    const warnSpy = jest
+      .spyOn(
+        (service as unknown as { logger: { warn: (m: string) => void } })
+          .logger,
+        'warn',
+      )
+      .mockImplementation(() => {});
+
+    const result = await getTopVehicles(402);
+
+    expect(result).toEqual([]);
+    expect(cache.set).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/permission denied/);
+  });
+
+  it('résultat vide (RPC ok, 0 ligne) → [] mis en cache : c’est un état réel, pas une erreur', async () => {
+    const { cache, callRpc, getTopVehicles } = buildService();
+    callRpc.mockResolvedValue({ data: [], error: null });
+
+    const result = await getTopVehicles(9999);
+
+    expect(result).toEqual([]);
+    expect(cache.set).toHaveBeenCalledWith(
+      'r1kp:top-vehicles:9999',
+      [],
+      STRATEGY.ttl,
+    );
+  });
+});

--- a/backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts
+++ b/backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts
@@ -4,7 +4,8 @@
  * Generates deterministic keyword plans from RAG YAML + DB data:
  * - RAG gamme frontmatter (domain.role, selection, brands, faq)
  * - R3 anti-cannibalization (forbidden terms from validated R3 plan)
- * - Top vehicles from __cross_gamme_car_new
+ * - Top vehicles via RPC get_alternative_vehicles_for_gamme (governed callRpc,
+ *   cached per pgId — A4, plan massdoc 2026-09-02)
  * - Equipementiers from gamme_aggregates
  *
  * Writes to __seo_r1_keyword_plan via R1KeywordPlanGatesService.upsertR1KeywordPlan().
@@ -13,6 +14,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { CacheService } from '@cache/cache.service';
+import {
+  CACHE_STRATEGIES,
+  getCacheKey,
+} from '../../../config/cache-ttl.config';
 import { EnricherYamlParser } from './enricher-yaml-parser.service';
 import {
   R1KeywordPlanGatesService,
@@ -40,6 +46,15 @@ interface TopVehicle {
   cnt: number;
 }
 
+/** Colonnes consommées de la RPC `get_alternative_vehicles_for_gamme`. */
+interface AlternativeVehicleRow {
+  marque_name: string;
+  modele_name: string;
+}
+
+const TOP_VEHICLES_STRATEGY = CACHE_STRATEGIES.KEYWORD_PLAN.R1_TOP_VEHICLES;
+const TOP_VEHICLES_LIMIT = 6;
+
 @Injectable()
 export class R1KeywordPlanBatchService extends SupabaseBaseService {
   protected override readonly logger = new Logger(
@@ -52,6 +67,7 @@ export class R1KeywordPlanBatchService extends SupabaseBaseService {
     configService: ConfigService,
     private readonly yamlParser: EnricherYamlParser,
     private readonly gatesService: R1KeywordPlanGatesService,
+    private readonly cacheService: CacheService,
   ) {
     super(configService);
   }
@@ -214,35 +230,8 @@ export class R1KeywordPlanBatchService extends SupabaseBaseService {
       r3ForbiddenTerms.add(term.toLowerCase());
     }
 
-    // ── P0.4: Top vehicles ──
-    const { data: vehicles } = await this.client.rpc(
-      'get_alternative_vehicles_for_gamme' as never,
-      { p_gamme_id: pgId, p_exclude_type_id: 0, p_limit: 6 } as never,
-    );
-
-    let topVehicles: TopVehicle[] = [];
-    if (vehicles && Array.isArray(vehicles) && vehicles.length > 0) {
-      topVehicles = vehicles.map(
-        (v: { marque_name: string; modele_name: string }) => ({
-          marque_name: v.marque_name,
-          modele_name: v.modele_name,
-          cnt: 1,
-        }),
-      );
-    } else {
-      // Direct query fallback
-      const { data: cgcData } = await this.client
-        .from('__cross_gamme_car_new')
-        .select('cgc_marque_id')
-        .eq('cgc_pg_id', String(pgId))
-        .limit(1);
-
-      if (cgcData && cgcData.length > 0) {
-        // Has cross-gamme data, query with joins via raw SQL
-        // (Supabase SDK can't do GROUP BY + JOIN easily)
-        topVehicles = []; // Will use generic fallback
-      }
-    }
+    // ── P0.4: Top vehicles (RPC gouvernée + cache par pgId, A4) ──
+    const topVehicles = await this.getTopVehicles(pgId);
 
     // ── P0.5: Equipementiers from gamme_aggregates ──
     const { data: aggRow } = await this.client
@@ -387,6 +376,49 @@ export class R1KeywordPlanBatchService extends SupabaseBaseService {
       qualityScore: gateReport.qualityScore,
       r3RiskScore: gateReport.r3RiskScore,
     };
+  }
+
+  /**
+   * Top véhicules d'une gamme (section S5 compat). Le résultat ne dépend que
+   * de `pgId` : cache Redis `r1kp:top-vehicles:{pgId}` (TTL déclaré dans
+   * CACHE_STRATEGIES) — un batch de 200 gammes rejoué (dry-run puis réel)
+   * ne paie la RPC qu'une fois par gamme.
+   *
+   * RPC via `callRpc()` (gate + allowlist, nom littéral pour le parseur de
+   * `scripts/ci/check-rpc-allowlist-coverage.sh`). Erreur RPC : warn
+   * observable, `[]` renvoyé et JAMAIS mis en cache (anti-poisoning).
+   * Résultat vide (0 ligne) : état réel, mis en cache.
+   */
+  private async getTopVehicles(pgId: number): Promise<TopVehicle[]> {
+    const cacheKey = getCacheKey(TOP_VEHICLES_STRATEGY, String(pgId));
+    const cached = await this.cacheService.get<TopVehicle[]>(cacheKey);
+    if (cached) return cached;
+
+    const { data, error } = await this.callRpc<AlternativeVehicleRow[]>(
+      'get_alternative_vehicles_for_gamme',
+      { p_gamme_id: pgId, p_exclude_type_id: 0, p_limit: TOP_VEHICLES_LIMIT },
+      { source: 'admin' },
+    );
+    if (error) {
+      this.logger.warn(
+        `[R1_KP_BATCH pgId=${pgId}] top vehicles RPC failed (not cached): ${error.message}`,
+      );
+      return [];
+    }
+
+    const topVehicles: TopVehicle[] = (Array.isArray(data) ? data : []).map(
+      (v) => ({
+        marque_name: v.marque_name,
+        modele_name: v.modele_name,
+        cnt: 1,
+      }),
+    );
+    await this.cacheService.set(
+      cacheKey,
+      topVehicles,
+      TOP_VEHICLES_STRATEGY.ttl,
+    );
+    return topVehicles;
   }
 
   // ── Term generation (deterministic, 0-LLM) ──


### PR DESCRIPTION
## Contexte

Slice **A4** du plan massdoc. `get_alternative_vehicles_for_gamme` est un fossile du classement `pg_stat_statements` : son appelant SSR a été retiré le 2026-05-18, son corps réécrit le 2026-04-21 (ADR-017, 10,5 s → 395 ms). **Seul survivant** : [`r1-keyword-plan-batch.service.ts`](backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts), le batch admin `POST /api/admin/keyword-planner/batch-r1`.

| Mesure PROD (lecture seule, 2026-09-02, agrégée par `queryid` — S0.4) | Valeur |
|---|---|
| `queryid` | `7590200925601701268` |
| Appels | 423 002 |
| `stats_since` | 2026-03-09 (= ajout de l'appelant SSR, `c3885192c`) |
| Moyenne **cumulée** | 9 006 ms — mélange de l'ancien corps (10,5 s) et du corps ADR-017 (395 ms) : **inutilisable** comme coût courant (NO-GO 7) |
| Blocs lus / appel | 68 744 |

## Trois défauts sur le même appel

1. **Invisible aux gardes** : `this.client.rpc('…' as never, {…} as never)` — le double cast défait le typage **et** le parseur de [`check-rpc-allowlist-coverage.sh`](scripts/ci/check-rpc-allowlist-coverage.sh) (qui ne voit que `callRpc(...)`) ; le fichier est en outre dans la liste de contournement du RPC-gate (`ci.yml`). Aucune garde ne voyait cet appel.
2. **Aucun cache** : un appel séquentiel par gamme, jusqu'à 200 par requête (`limit` borné à 200 par le contrôleur). Le flux admin typique « dry-run puis run réel » paie la RPC **deux fois** par gamme, alors que le résultat ne dépend que de `pgId` (`p_exclude_type_id: 0`, `p_limit: 6` fixes).
3. **Branche morte** : le « Direct query fallback » interrogeait `__cross_gamme_car_new` pour affecter `topVehicles = []` dans les deux cas — une requête payée pour rien.

## Changement

- `getTopVehicles(pgId)` : `callRpc()` gouverné (nom **littéral**, `source: 'admin'`), cache Redis `r1kp:top-vehicles:{pgId}` déclaré dans [`cache-ttl.config.ts`](backend/src/config/cache-ttl.config.ts) (`KEYWORD_PLAN.R1_TOP_VEHICLES`, 24 h — compatibilité TecDoc, stable entre imports ; le jeton de version d'invalidation = slice A3).
  - Erreur RPC → `warn` observable, `[]` renvoyé, **jamais mis en cache** (anti-poisoning, incident 2026-05-19).
  - Résultat vide (0 ligne, RPC ok) → état réel, mis en cache.
- Entrée `get_alternative_vehicles_for_gamme` (`STABLE`, vérifié dans `pg_proc` : `provolatile = s`, `LANGUAGE sql`) dans [`backend/governance/rpc/rpc_allowlist.json`](backend/governance/rpc/rpc_allowlist.json) — la copie lue au runtime (`Dockerfile:88-90` copie `backend/governance` ; `rpc-gate.service.ts` lit `process.cwd()/governance/rpc`) et par la CI. Champ `total` remis au vrai (183 déclaré, 184 réels, 185 après).
- `CacheService` injecté (module `@Global`, déjà injecté par 5 services admin voisins).

**Non touché, volontairement** :
- La liste de contournement RPC-gate de `ci.yml` (territoire `guardrails.md`, 4 passes). Après cette PR le fichier n'a **plus aucun** `.rpc(` direct : l'entrée `r1-keyword-plan-batch` devient vacante, retrait = PR séparée.
- La copie racine `governance/rpc/rpc_allowlist.json` : périmée depuis #969, lue ni par le runtime ni par la CI (grep `scripts/`, `.github/`, `backend/src/`). À traiter séparément (SoT dupliquée, invariant 2).

## Tests (TDD, RED observé avant GREEN)

[`r1-keyword-plan-batch.service.test.ts`](backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts) — 5 cas, RED = `getTopVehicles is not a function` ×5 :

- cache miss → **un** `callRpc('get_alternative_vehicles_for_gamme', { p_gamme_id, p_exclude_type_id: 0, p_limit: 6 }, { source: 'admin' })`, mappé en `TopVehicle` ;
- cache miss → `set('r1kp:top-vehicles:402', …, 86400)` ;
- cache hit → aucun appel RPC ;
- erreur RPC → `[]`, `warn`, `set` jamais appelé ;
- résultat vide → `[]` mis en cache.

`tsc --noEmit` propre · `check-rpc-allowlist-coverage.sh` : 40 appels `callRpc`, tous couverts.

## Vérification à venir (pré-enregistrée)

- Le texte PostgREST de l'appel est inchangé → **même `queryid`** `7590200925601701268`. Sur une fenêtre ≥ 14 j couvrant ≥ 1 exercice du batch (S0.3), `Δcalls` doit être **≤ nombre de gammes distinctes traitées** (le rejeu dry-run → réel ne doit plus doubler). **Falsifieur** : `Δcalls > 2 × gammes distinctes` ⇒ le cache n'est pas effectif (Redis non prêt, ou clé non stable).
- Aucune comparaison avec la moyenne cumulée 9 006 ms (deux corps de fonction mélangés — NO-GO 7).

## Runtime-awareness

- Endpoint admin, écriture `__seo_r1_keyword_plan` : PREPROD est `READ_ONLY=true`, donc aucun exercice avant PROD (tag `v*`, GO owner). La résolution DI (`CacheService`) est exercée au boot PREPROD (E2E Smoke) — c'est la seule surface non couverte par les tests unitaires.
- Pas de changement DB, d'URL, de meta/H1. Rollback = revert.
- Rappel plan §A0 : ceci ferme un appelant invisible d'une RPC de 395 ms ; le levier dominant sur la charge R2 reste le cache CDN (PR C, owner-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
