### PR TITLE
chore(db): B0 — déclare STABLE rm_get_page_complete_v2 et get_pieces_for_type_gamme_v3 (hygiène, 0 gain annoncé)

### DIFF
--- a/.claude/knowledge/REPO_MAP.md
+++ b/.claude/knowledge/REPO_MAP.md
@@ -3,7 +3,7 @@ title: Repository Map
 kind: registry-index
 generated_at: "1970-01-01T00:00:00.000Z"
 source: audit/registry/canonical.json
-source_sha256: 9d9262a3ed7fc70333a390ffbcdecf1676c5a527665c9ebd054c2faca6f05b35
+source_sha256: 801ae6662d718a1400e8594fb55d869bccbb7523650e48c2f3305bb27cc45f58
 schema_version: "1.0.0"
 do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-058 PR-F)
 ---
@@ -18,13 +18,13 @@ do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-
 
 | Layer | Count |
 |---|---|
-| Files (Layer 1) | 2829 |
+| Files (Layer 1) | 2837 |
 | DB tables (Layer 1) | 307 |
 | DB RPC (Layer 1) | 258 |
 | Dependencies (Layer 1) | 237 |
 | Runtime entrypoints (Layer 1) | 515 |
 
-Source sotFingerprint: `9575abc78d8e`.
+Source sotFingerprint: `25854fb52859`.
 
 ## Comment l'utiliser
 
@@ -45,11 +45,11 @@ Source sotFingerprint: `9575abc78d8e`.
 
 ### D2 — Legacy / XTR Migration
 
-- **Files**: 96 (test=82, service=10, config=3, controller=1)
+- **Files**: 98 (test=84, service=10, config=3, controller=1)
 - **Runtime entrypoints**: 1
-- **Top owners**: @ak125 (84), __unassigned__ (12)
+- **Top owners**: @ak125 (85), __unassigned__ (13)
 - **Knowledge prose**: [`rm`](modules/rm.md)
-- **Status**: LEGACY=11, LIVE=1, UNKNOWN=84
+- **Status**: LEGACY=12, LIVE=1, UNKNOWN=85
 
 ### D3 — SEO & Sitemap
 
@@ -93,26 +93,26 @@ Source sotFingerprint: `9575abc78d8e`.
 
 ### D8 — Read Model / Serving (RM)
 
-- **Files**: 941 (config=466, route=246, service=176, controller=38, test=15)
+- **Files**: 942 (config=466, route=246, service=176, controller=38, test=16)
 - **Runtime entrypoints**: 286
-- **Top owners**: @ak125/frontend-team (686), @ak125/admin-team (255)
+- **Top owners**: @ak125/frontend-team (686), @ak125/admin-team (256)
 - **Knowledge prose**: [`admin`](modules/admin.md), [`staff`](modules/staff.md)
-- **Status**: LIVE=498, UNKNOWN=443
+- **Status**: LIVE=498, UNKNOWN=444
 
 ### D9 — Import / ETL / Normalisation
 
-- **Files**: 14 (service=12, test=1, config=1)
+- **Files**: 15 (service=12, test=2, config=1)
 - **Runtime entrypoints**: 2
-- **Top owners**: @ak125 (14)
-- **Status**: LIVE=9, UNKNOWN=5
+- **Top owners**: @ak125 (15)
+- **Status**: LIVE=9, UNKNOWN=6
 
 ### D10 — Quality, Monitoring & Observabilité
 
-- **Files**: 32 (service=20, test=6, controller=6)
+- **Files**: 33 (service=20, test=7, controller=6)
 - **Runtime entrypoints**: 13
-- **Top owners**: @ak125 (32)
+- **Top owners**: @ak125 (33)
 - **Knowledge prose**: [`analytics`](modules/analytics.md), [`dashboard`](modules/dashboard.md), [`errors`](modules/errors.md), [`health`](modules/health.md), [`observability`](modules/observability.md)
-- **Status**: LIVE=27, UNKNOWN=5
+- **Status**: LIVE=27, UNKNOWN=6
 
 ### D11 — Commerce & Users
 
@@ -132,10 +132,10 @@ Source sotFingerprint: `9575abc78d8e`.
 
 ### D13 — Config & System
 
-- **Files**: 187 (service=70, config=52, script=48, test=17)
+- **Files**: 190 (service=70, config=52, script=50, test=18)
 - **Runtime entrypoints**: 5
-- **Top owners**: @ak125 (187)
-- **Status**: LIVE=79, UNKNOWN=108
+- **Top owners**: @ak125 (190)
+- **Status**: LIVE=80, UNKNOWN=110
 
 ### D14 — Gamme Aggregates & V-Level
 

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -143,6 +143,14 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # B0 massdoc — volatilité STABLE des wrappers de rendu R2/R1 (hygiène, 0 gain annoncé).
+  # Glob exact volontaire — les migrations ne sont PAS auto-couvertes.
+  # D15 par précédent 20260614_gov_m7_stable_function_volatility_rpc*.sql (même famille).
+  - glob: backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable*.sql
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: scripts/governance/validate-authority-graph.js
     domain: D15
     owner: '@ak125'

--- a/audit/registry/canonical.json
+++ b/audit/registry/canonical.json
@@ -10110,7 +10110,6 @@
         "status": "LIVE",
         "usedBy": [
           "backend/src/modules/admin/services/gamme-detail-enricher.service.ts",
-          "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
           "backend/src/modules/blog/services/blog-article-relation.service.ts"
         ]
       },
@@ -29188,9 +29187,32 @@
         "manual"
       ],
       "domain": "D10",
+      "id": "backend/src/cache/cache.service.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/cache/cache.service.ts"
+      ],
+      "kind": "test",
+      "loc": 93,
+      "owner": "@ak125",
+      "path": "backend/src/cache/cache.service.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D10",
       "id": "backend/src/cache/cache.service.ts",
       "importedBy": [
         "backend/src/cache/cache.module.ts",
+        "backend/src/cache/cache.service.test.ts",
         "backend/src/modules/admin/services/command-center-reader.service.ts",
         "backend/src/modules/admin/services/registry-reader.service.ts",
         "backend/src/modules/admin/services/seo-control.service.ts",
@@ -29204,7 +29226,7 @@
         "events"
       ],
       "kind": "service",
-      "loc": 454,
+      "loc": 515,
       "owner": "@ak125",
       "path": "backend/src/cache/cache.service.ts",
       "risk": "medium",
@@ -30411,6 +30433,28 @@
       "deletePolicy": "FREE",
       "derivedFrom": [
         "depcruise",
+        "manual"
+      ],
+      "domain": "D13",
+      "id": "backend/src/config/cache-ttl.config.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/config/cache-ttl.config.ts"
+      ],
+      "kind": "test",
+      "loc": 53,
+      "owner": "@ak125",
+      "path": "backend/src/config/cache-ttl.config.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
         "manual",
         "reachability"
       ],
@@ -30419,14 +30463,17 @@
       "importedBy": [
         "backend/src/cache/cache.service.ts",
         "backend/src/config/cache-store.factory.test.ts",
+        "backend/src/config/cache-ttl.config.test.ts",
         "backend/src/config/index.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
         "backend/src/modules/vehicles/services/brand-bestsellers.service.ts",
         "backend/src/modules/vehicles/services/vehicle-motor-codes.service.ts",
         "backend/src/modules/vehicles/services/vehicle-profile.service.ts"
       ],
       "imports": [],
       "kind": "config",
-      "loc": 409,
+      "loc": 510,
       "owner": "@ak125",
       "path": "backend/src/config/cache-ttl.config.ts",
       "risk": "medium",
@@ -36270,13 +36317,39 @@
         "manual"
       ],
       "domain": "D8",
+      "id": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/config/cache-ttl.config.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts"
+      ],
+      "kind": "test",
+      "loc": 176,
+      "owner": "@ak125/admin-team",
+      "path": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D8",
       "id": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
       "importedBy": [
         "backend/src/modules/admin/admin.module.ts",
-        "backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts"
+        "backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts"
       ],
       "imports": [
+        "@cache/cache.service",
         "@database/services/supabase-base.service",
+        "backend/src/config/cache-ttl.config.ts",
         "backend/src/config/r1-keyword-plan.constants.ts",
         "backend/src/config/rag.config.ts",
         "backend/src/modules/admin/services/enricher-yaml-parser.service.ts",
@@ -36285,7 +36358,7 @@
         "path"
       ],
       "kind": "service",
-      "loc": 524,
+      "loc": 556,
       "owner": "@ak125/admin-team",
       "path": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
       "risk": "medium",
@@ -50274,7 +50347,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "controller",
-      "loc": 381,
+      "loc": 387,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/controllers/rm.controller.ts",
       "risk": "medium",
@@ -50354,9 +50427,29 @@
       "importedBy": [],
       "imports": [],
       "kind": "test",
-      "loc": 187,
+      "loc": 305,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "LEGACY"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D2",
+      "id": "backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts",
+      "importedBy": [],
+      "imports": [],
+      "kind": "test",
+      "loc": 274,
+      "owner": "__unassigned__",
+      "path": "backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts",
       "risk": "medium",
       "runtime": false,
       "schemaVersion": "1.0.0",
@@ -50434,7 +50527,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "service",
-      "loc": 151,
+      "loc": 197,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/services/rm-alternatives.service.ts",
       "risk": "medium",
@@ -50454,7 +50547,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "service",
-      "loc": 919,
+      "loc": 991,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/services/rm-builder.service.ts",
       "risk": "medium",
@@ -64490,6 +64583,28 @@
         "manual"
       ],
       "domain": "D9",
+      "id": "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/workers/processors/seo-monitor.processor.ts"
+      ],
+      "kind": "test",
+      "loc": 139,
+      "owner": "@ak125",
+      "path": "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "high",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D9",
       "id": "backend/src/workers/processors/agentic.processor.ts",
       "importedBy": [
         "backend/src/workers/worker.module.ts"
@@ -64594,6 +64709,7 @@
       "domain": "D9",
       "id": "backend/src/workers/processors/seo-monitor.processor.ts",
       "importedBy": [
+        "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
         "backend/src/workers/worker.module.ts"
       ],
       "imports": [
@@ -64603,7 +64719,7 @@
         "backend/src/modules/admin/services/admin-job-health.service.ts"
       ],
       "kind": "service",
-      "loc": 438,
+      "loc": 458,
       "owner": "@ak125",
       "path": "backend/src/workers/processors/seo-monitor.processor.ts",
       "risk": "medium",
@@ -82721,7 +82837,7 @@
         "~/utils/seo/canonical"
       ],
       "kind": "route",
-      "loc": 821,
+      "loc": 836,
       "owner": "@ak125/frontend-team",
       "path": "frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx",
       "risk": "medium",
@@ -84843,7 +84959,7 @@
         "~/utils/page-role.types"
       ],
       "kind": "route",
-      "loc": 1241,
+      "loc": 1263,
       "owner": "@ak125/frontend-team",
       "path": "frontend/app/routes/reference-auto.$slug.tsx",
       "risk": "medium",
@@ -87182,7 +87298,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "config",
-      "loc": 47,
+      "loc": 92,
       "owner": "@ak125/frontend-team",
       "path": "frontend/app/utils/internal-api.server.ts",
       "risk": "medium",
@@ -89299,6 +89415,26 @@
         "manual"
       ],
       "domain": "D2",
+      "id": "frontend/tests/unit/internal-api-loopback.test.ts",
+      "importedBy": [],
+      "imports": [],
+      "kind": "test",
+      "loc": 101,
+      "owner": "@ak125",
+      "path": "frontend/tests/unit/internal-api-loopback.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "high",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D2",
       "id": "frontend/tests/unit/lazy-boundary.test.tsx",
       "importedBy": [],
       "imports": [],
@@ -89863,7 +89999,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "test",
-      "loc": 115,
+      "loc": 151,
       "owner": "@ak125",
       "path": "frontend/tests/unit/reference-auto-loader-parallel.test.ts",
       "risk": "medium",
@@ -95295,6 +95431,46 @@
         "manual"
       ],
       "domain": "D13",
+      "id": "scripts/ci/assert-r2-golden.mjs",
+      "importedBy": [],
+      "imports": [],
+      "kind": "script",
+      "loc": 507,
+      "owner": "@ak125",
+      "path": "scripts/ci/assert-r2-golden.mjs",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "high",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D13",
+      "id": "scripts/ci/assert-r2-golden.test.mjs",
+      "importedBy": [],
+      "imports": [],
+      "kind": "script",
+      "loc": 632,
+      "owner": "@ak125",
+      "path": "scripts/ci/assert-r2-golden.test.mjs",
+      "risk": "medium",
+      "runtime": true,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "high",
+      "status": "LIVE"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D13",
       "id": "scripts/ci/pr-2e-readiness-gate.mjs",
       "importedBy": [],
       "imports": [],
@@ -98036,15 +98212,15 @@
       ".spec/00-canon/repository-registry/automation-reality.yaml": "98f10df3b19858e0d723a5a21218be5e599b0c3f6038a3672b10bbb02baf0e29",
       ".spec/00-canon/repository-registry/delete-policy.yaml": "2e698ddddc3d11c244c710271a02e376ce471812c53290439a55220bf6c7aff6",
       ".spec/00-canon/repository-registry/domains.yaml": "670a81abb20bf96ded77ca329883305243207680f9c05aa66190502dd4f8d2a2",
-      ".spec/00-canon/repository-registry/ownership.yaml": "f6d7717a16309ad0fa9c995ff72f32241d63b9f06ab0d09213f4f305e24a9997",
+      ".spec/00-canon/repository-registry/ownership.yaml": "7c0009630175eeb727b2422e95aa888ab04c04ce1adcd765ac704636b34d86ee",
       ".spec/00-canon/repository-registry/status-overrides.yaml": "6acccd32de6d9c15b47621ab22d9f2d3e34861ea8b6b1a3cd559f68a9fa32e02",
-      "audit/registry/db.json": "5615f6c8f657b5ebdf48b6add1216f66c227b805ae687b1f401c95e8d393fbf9",
+      "audit/registry/db.json": "c874feb59f5d00601c29a139560da9ecd2d63678eea0eddc4bb4fbd8d79672d1",
       "audit/registry/deps.json": "6f667991be593e37b2798c4ca0f0689d89c412731aa2bdf50000248da9f2c5bd",
-      "audit/registry/files.json": "af476ef3b420b209347e626df42fdcdbe6051327fd73a9bfc0ede839330eefc0",
+      "audit/registry/files.json": "c764b429d515654d426bf887ed5cf17ce246c4791b75c1e3862350b91f017ffd",
       "audit/registry/rpc.json": "e7d09287e11bb447da93a48d1a18e4c5ee13ad6667a6e10356a3af95d7463cbd",
       "audit/registry/runtime.json": "314a3bda98e2b9bb87a4b6a88a1efa131a3c12505d9e56b5f60eeebd23e5f70f"
     },
-    "sotFingerprint": "9575abc78d8e"
+    "sotFingerprint": "25854fb52859"
   },
   "runtime": [
     {

--- a/audit/registry/db.json
+++ b/audit/registry/db.json
@@ -1118,7 +1118,6 @@
       "status": "LIVE",
       "usedBy": [
         "backend/src/modules/admin/services/gamme-detail-enricher.service.ts",
-        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
         "backend/src/modules/blog/services/blog-article-relation.service.ts"
       ]
     },

--- a/audit/registry/files.json
+++ b/audit/registry/files.json
@@ -1848,9 +1848,31 @@
         "depcruise"
       ],
       "domain": "UNKNOWN",
+      "id": "backend/src/cache/cache.service.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/cache/cache.service.ts"
+      ],
+      "kind": "test",
+      "loc": 93,
+      "owner": "__unassigned__",
+      "path": "backend/src/cache/cache.service.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
       "id": "backend/src/cache/cache.service.ts",
       "importedBy": [
         "backend/src/cache/cache.module.ts",
+        "backend/src/cache/cache.service.test.ts",
         "backend/src/modules/admin/services/command-center-reader.service.ts",
         "backend/src/modules/admin/services/registry-reader.service.ts",
         "backend/src/modules/admin/services/seo-control.service.ts",
@@ -1864,7 +1886,7 @@
         "events"
       ],
       "kind": "service",
-      "loc": 454,
+      "loc": 515,
       "owner": "__unassigned__",
       "path": "backend/src/cache/cache.service.ts",
       "risk": "low",
@@ -3040,6 +3062,27 @@
     {
       "deletePolicy": "FREE",
       "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
+      "id": "backend/src/config/cache-ttl.config.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/config/cache-ttl.config.ts"
+      ],
+      "kind": "test",
+      "loc": 53,
+      "owner": "__unassigned__",
+      "path": "backend/src/config/cache-ttl.config.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
         "depcruise",
         "reachability"
       ],
@@ -3048,14 +3091,17 @@
       "importedBy": [
         "backend/src/cache/cache.service.ts",
         "backend/src/config/cache-store.factory.test.ts",
+        "backend/src/config/cache-ttl.config.test.ts",
         "backend/src/config/index.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
         "backend/src/modules/vehicles/services/brand-bestsellers.service.ts",
         "backend/src/modules/vehicles/services/vehicle-motor-codes.service.ts",
         "backend/src/modules/vehicles/services/vehicle-profile.service.ts"
       ],
       "imports": [],
       "kind": "config",
-      "loc": 409,
+      "loc": 510,
       "owner": "__unassigned__",
       "path": "backend/src/config/cache-ttl.config.ts",
       "risk": "low",
@@ -8704,13 +8750,38 @@
         "depcruise"
       ],
       "domain": "UNKNOWN",
+      "id": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/config/cache-ttl.config.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts"
+      ],
+      "kind": "test",
+      "loc": 176,
+      "owner": "__unassigned__",
+      "path": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
       "id": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
       "importedBy": [
         "backend/src/modules/admin/admin.module.ts",
-        "backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts"
+        "backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts",
+        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.test.ts"
       ],
       "imports": [
+        "@cache/cache.service",
         "@database/services/supabase-base.service",
+        "backend/src/config/cache-ttl.config.ts",
         "backend/src/config/r1-keyword-plan.constants.ts",
         "backend/src/config/rag.config.ts",
         "backend/src/modules/admin/services/enricher-yaml-parser.service.ts",
@@ -8719,7 +8790,7 @@
         "path"
       ],
       "kind": "service",
-      "loc": 524,
+      "loc": 556,
       "owner": "__unassigned__",
       "path": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
       "risk": "low",
@@ -22244,7 +22315,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "controller",
-      "loc": 381,
+      "loc": 387,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/controllers/rm.controller.ts",
       "risk": "low",
@@ -22320,9 +22391,28 @@
       "importedBy": [],
       "imports": [],
       "kind": "test",
-      "loc": 187,
+      "loc": 305,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
+      "id": "backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts",
+      "importedBy": [],
+      "imports": [],
+      "kind": "test",
+      "loc": 274,
+      "owner": "__unassigned__",
+      "path": "backend/src/modules/rm/services/__tests__/rm-builder-page-v2-cache.test.ts",
       "risk": "low",
       "runtime": false,
       "schemaVersion": "1.0.0",
@@ -22396,7 +22486,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "service",
-      "loc": 151,
+      "loc": 197,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/services/rm-alternatives.service.ts",
       "risk": "low",
@@ -22415,7 +22505,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "service",
-      "loc": 919,
+      "loc": 991,
       "owner": "__unassigned__",
       "path": "backend/src/modules/rm/services/rm-builder.service.ts",
       "risk": "low",
@@ -35977,6 +36067,27 @@
         "depcruise"
       ],
       "domain": "UNKNOWN",
+      "id": "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/workers/processors/seo-monitor.processor.ts"
+      ],
+      "kind": "test",
+      "loc": 139,
+      "owner": "__unassigned__",
+      "path": "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
       "id": "backend/src/workers/processors/agentic.processor.ts",
       "importedBy": [
         "backend/src/workers/worker.module.ts"
@@ -36077,6 +36188,7 @@
       "domain": "UNKNOWN",
       "id": "backend/src/workers/processors/seo-monitor.processor.ts",
       "importedBy": [
+        "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
         "backend/src/workers/worker.module.ts"
       ],
       "imports": [
@@ -36086,7 +36198,7 @@
         "backend/src/modules/admin/services/admin-job-health.service.ts"
       ],
       "kind": "service",
-      "loc": 438,
+      "loc": 458,
       "owner": "__unassigned__",
       "path": "backend/src/workers/processors/seo-monitor.processor.ts",
       "risk": "low",
@@ -53500,7 +53612,7 @@
         "~/utils/seo/canonical"
       ],
       "kind": "route",
-      "loc": 821,
+      "loc": 836,
       "owner": "__unassigned__",
       "path": "frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx",
       "risk": "low",
@@ -55547,7 +55659,7 @@
         "~/utils/page-role.types"
       ],
       "kind": "route",
-      "loc": 1241,
+      "loc": 1263,
       "owner": "__unassigned__",
       "path": "frontend/app/routes/reference-auto.$slug.tsx",
       "risk": "low",
@@ -57841,7 +57953,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "config",
-      "loc": 47,
+      "loc": 92,
       "owner": "__unassigned__",
       "path": "frontend/app/utils/internal-api.server.ts",
       "risk": "low",
@@ -59864,6 +59976,25 @@
         "depcruise"
       ],
       "domain": "UNKNOWN",
+      "id": "frontend/tests/unit/internal-api-loopback.test.ts",
+      "importedBy": [],
+      "imports": [],
+      "kind": "test",
+      "loc": 101,
+      "owner": "__unassigned__",
+      "path": "frontend/tests/unit/internal-api-loopback.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
       "id": "frontend/tests/unit/lazy-boundary.test.tsx",
       "importedBy": [],
       "imports": [],
@@ -60400,7 +60531,7 @@
       "importedBy": [],
       "imports": [],
       "kind": "test",
-      "loc": 115,
+      "loc": 151,
       "owner": "__unassigned__",
       "path": "frontend/tests/unit/reference-auto-loader-parallel.test.ts",
       "risk": "low",
@@ -65557,6 +65688,44 @@
       "schemaVersion": "1.0.0",
       "sourceConfidence": "medium",
       "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
+      "id": "scripts/ci/assert-r2-golden.mjs",
+      "importedBy": [],
+      "imports": [],
+      "kind": "script",
+      "loc": 507,
+      "owner": "__unassigned__",
+      "path": "scripts/ci/assert-r2-golden.mjs",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
+      "id": "scripts/ci/assert-r2-golden.test.mjs",
+      "importedBy": [],
+      "imports": [],
+      "kind": "script",
+      "loc": 632,
+      "owner": "__unassigned__",
+      "path": "scripts/ci/assert-r2-golden.test.mjs",
+      "risk": "low",
+      "runtime": true,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "LIVE"
     },
     {
       "deletePolicy": "FREE",

--- a/backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.down.sql
+++ b/backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.down.sql
@@ -1,0 +1,9 @@
+-- Rollback: 20260902_b0_rm_rpc_volatility_stable
+-- Restaure la volatilité d'origine (VOLATILE par omission). Métadonnée seule,
+-- transactionnel, idempotent.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+ALTER FUNCTION public.rm_get_page_complete_v2(integer, bigint, integer) VOLATILE;
+ALTER FUNCTION public.get_pieces_for_type_gamme_v3(integer, integer) VOLATILE;

--- a/backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.sql
+++ b/backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.sql
@@ -1,0 +1,48 @@
+-- Migration: 20260902_b0_rm_rpc_volatility_stable
+-- Slice B0 du plan massdoc (2026-09-02) — hygiène de métadonnée, SANS promesse
+-- de gain de performance.
+--
+-- Constat (pg_proc, PROD, lecture seule, 2026-09-02) :
+--   rm_get_page_complete_v2(integer, bigint, integer)
+--     plpgsql, SECURITY DEFINER, VOLATILE / PARALLEL UNSAFE, 12 767 caractères,
+--     0 INSERT/UPDATE/DELETE/TRUNCATE ; callee unique :
+--     get_listing_products_extended_filtered (sql, STABLE).
+--   get_pieces_for_type_gamme_v3(integer, integer)
+--     plpgsql, SECURITY DEFINER, VOLATILE / PARALLEL UNSAFE, 18 757 caractères,
+--     0 écriture ; callee unique : process_seo_template (plpgsql, STABLE).
+--   Aucun des deux corps ne contient TEMP / nextval / setval / pg_advisory_* /
+--   NOTIFY (les hazards d'une transaction READ ONLY PostgREST).
+--   Leur moteur interne get_listing_products_extended est déjà STABLE
+--   PARALLEL SAFE : la métadonnée des wrappers est fausse par omission.
+--
+-- Pourquoi STABLE : déclarer la volatilité réelle est un prérequis à tout
+-- inlining / réécriture ultérieure (B6) et rend cohérent le couple wrapper /
+-- moteur. Garde-fou déjà armé : __gov_m7_stable_function_volatility (incident
+-- 2026-05-22, get_vehicle_page_data_cached déclarée STABLE alors qu'elle
+-- écrivait → 5xx sous transaction read-only PostgREST). La condition causale
+-- est ici mesurée absente (0 écriture dans les corps ET dans les callees).
+--
+-- Pourquoi PAS PARALLEL SAFE : plpgsql + `SELECT … INTO` (limite de lignes
+-- SPI) désactive les plans parallèles quelle que soit la déclaration. Aucun
+-- gain à attendre, aucune promesse faite (plan massdoc, NO-GO 6b).
+--
+-- Pourquoi ALTER FUNCTION et non CREATE OR REPLACE : seule la métadonnée
+-- change ; recopier 31 k caractères de corps serait un risque de dérive pour
+-- zéro valeur. Idempotent (ALTER vers la volatilité déjà en place = no-op),
+-- transactionnel, réversible (.down.sql : VOLATILE).
+--
+-- Vérification attendue APRÈS apply (owner) :
+--   1. pg_proc.provolatile = 's' pour les deux fonctions ;
+--   2. SELECT * FROM __gov_m7_stable_function_volatility() → aucune ligne
+--      writes = true pour ces deux noms ;
+--   3. EXPLAIN (ANALYZE, BUFFERS) IDENTIQUE avant/après — référence du
+--      2026-09-02 (un run, cache tiède) : v2(402, 57414, 200) = 277,9 ms,
+--      16 229 hit / 638 read ; v3(57414, 402) = 153,4 ms, 11 552 hit / 171
+--      read. Toute apparition d'un nœud Gather serait une surprise à
+--      documenter, pas un objectif.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+ALTER FUNCTION public.rm_get_page_complete_v2(integer, bigint, integer) STABLE;
+ALTER FUNCTION public.get_pieces_for_type_gamme_v3(integer, integer) STABLE;


### PR DESCRIPTION
## Contexte

Slice **B0** du plan massdoc — **hygiène de métadonnée, sans promesse de gain** (le plan a explicitement rétrogradé B0 : `plpgsql` + `SELECT … INTO` désactive les plans parallèles quelle que soit la déclaration, NO-GO 6b).

## Constat (pg_proc, PROD, lecture seule, 2026-09-02)

| Fonction | Langage | Sécurité | Volatilité déclarée | Corps | Écritures | Callees |
|---|---|---|---|---|---|---|
| `rm_get_page_complete_v2(integer, bigint, integer)` | plpgsql | DEFINER | **VOLATILE / PARALLEL UNSAFE** | 12 767 c. | 0 | `get_listing_products_extended_filtered` (sql, STABLE) |
| `get_pieces_for_type_gamme_v3(integer, integer)` | plpgsql | DEFINER | **VOLATILE / PARALLEL UNSAFE** | 18 757 c. | 0 | `process_seo_template` (plpgsql, STABLE) |
| `get_listing_products_extended` (moteur interne) | sql | — | STABLE PARALLEL SAFE | 11 490 c. | 0 | — |

Contrôle des hazards d'une transaction **READ ONLY** PostgREST (ce qu'impose `STABLE` sur un `POST /rpc/*`) : aucun `TEMP` / `nextval` / `setval` / `pg_advisory_*` / `NOTIFY` / `CREATE TABLE` dans les deux corps **ni** dans leurs callees. La condition causale de l'incident 2026-05-22 (`get_vehicle_page_data_cached` STABLE alors qu'elle écrivait → 5xx silencieux) est **mesurée absente**.

## Changement

[`20260902_b0_rm_rpc_volatility_stable.sql`](backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.sql) : `ALTER FUNCTION … STABLE` sur les deux wrappers.

- **`ALTER FUNCTION`, pas `CREATE OR REPLACE`** : seule la métadonnée change ; recopier 31 k caractères de corps serait un risque de dérive pour zéro valeur. Idempotent, transactionnel, `lock_timeout 5s` / `statement_timeout 30s`.
- **Pas de `PARALLEL SAFE`** : aucun gain à attendre (cf. plan), aucune promesse faite.
- `.down.sql` : retour à `VOLATILE`.

squawk 2.52.1 (binaire CI, `.squawk.toml`) : `Found 0 issues in 1 file`.

## Evidence-before (référence, un run, cache tiède)

```
EXPLAIN (ANALYZE, BUFFERS) SELECT rm_get_page_complete_v2(402, 57414, 200);
  Result … actual time=277.834..277.835   Buffers: shared hit=16229 read=638   Execution Time: 277.875 ms
EXPLAIN (ANALYZE, BUFFERS) SELECT get_pieces_for_type_gamme_v3(57414, 402);
  Result … actual time=153.300..153.301   Buffers: shared hit=11552 read=171   Execution Time: 153.354 ms
```

**Attendu après apply : plans et ordres de grandeur IDENTIQUES** — c'est le résultat recherché, pas un échec. Toute apparition d'un nœud `Gather` serait une surprise à documenter, pas un objectif. `SELECT * FROM __gov_m7_stable_function_volatility()` ne doit lister aucun des deux noms avec `writes = true`.

## Apply (owner-gated, hors de cette PR)

Le merge ne touche pas la base. `apply-supabase-migrations.yml` : `dry_run=true` puis `confirm=APPLY`. Durée : millisecondes (métadonnée). Rollback : `.down.sql` ou `ALTER FUNCTION … VOLATILE`.

**Suite immédiate de l'apply** (une ligne chacune, non incluses ici **volontairement** — l'état réel prime tant que la base dit `VOLATILE`) : basculer `volatility` de `VOLATILE` → `STABLE` pour les deux entrées de [`rpc_allowlist.json`](backend/governance/rpc/rpc_allowlist.json) (champ déclaratif, consommé par aucun gate — vérifié : `pg-stable-write.ts` lit `__gov_m7`, pas l'allowlist).

## Block-new (owner)

Nouvelle migration → glob d'ownership requis (`.spec/00-canon/**` owner-only). Snippet proposé, à la suite des globs exacts existants :

```yaml
  # B0 massdoc — volatilité STABLE des wrappers R2/R1 (hygiène, 0 gain annoncé). Glob exact.
  - glob: backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable*.sql
    domain: D2
    owner: '@ak125'
    sourceConfidence: high
    risk: low
```

## Non touché

- Corps des fonctions, grants (`anon` EXECUTE, 20260621), `search_path` pinné (20260616).
- `PARALLEL` : reste `UNSAFE` (aucune raison mesurée de le changer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
