### PR TITLE
ci(migrations): planifier la garde de fraîcheur du ledger + Signal 7 au digest

### DIFF
--- a/.github/scripts/morning-health-digest.sh
+++ b/.github/scripts/morning-health-digest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Morning health digest — collect 6 signals, classify, write digest body file,
+# Morning health digest — collect 7 signals, classify, write digest body file,
 # emit GitHub Actions outputs.
 #
 # Called by .github/workflows/morning-health-digest.yml. Requires gh CLI with
@@ -104,6 +104,29 @@ if [ -z "$MERGED" ]; then
   echo "_None._" >> "$OUT"
 else
   echo "$MERGED" >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+# ---- Signal 7 — Migration ledger freshness ----
+# Reads only the CONCLUSION of migration-ledger-freshness.yml (04:30 UTC, i.e.
+# before this digest). That workflow is the only holder of DATABASE_URL: this
+# repo is public and this body is pasted verbatim into a GitHub issue, so no
+# database credential and no database content belongs in here.
+echo "## Signal 7 — Migration ledger freshness" >> "$OUT"
+LEDGER=$(gh run list --workflow=migration-ledger-freshness.yml --limit 2 --repo "$REPO" \
+  --json conclusion,createdAt \
+  --jq '.[] | "\(.createdAt[:19]) \(.conclusion // "running")"' 2>/dev/null || echo "")
+if [ -z "$LEDGER" ]; then
+  echo "⚠️ No runs yet" >> "$OUT"
+  [ "$STATUS_OVERALL" = "✅" ] && STATUS_OVERALL="⚠️"
+else
+  echo '```' >> "$OUT"
+  echo "$LEDGER" >> "$OUT"
+  echo '```' >> "$OUT"
+  if echo "$LEDGER" | grep -q failure; then
+    echo "⛔ \`infra.schema_migrations\` no longer describes the database — drift, a stuck apply, or a migration pending past 30 days. The run's job summary lists which." >> "$OUT"
+    STATUS_OVERALL="⛔"
+  fi
 fi
 echo "" >> "$OUT"
 

--- a/.github/workflows/migration-ledger-freshness.yml
+++ b/.github/workflows/migration-ledger-freshness.yml
@@ -1,0 +1,72 @@
+name: 🧾 Migration ledger freshness
+
+# Read-only daily probe over `infra.schema_migrations`.
+#
+# WHY THIS EXISTS
+# ---------------
+# The mini migration engine (scripts/ci/apply-supabase-migration.py) already
+# detects everything that matters — drift, stuck `applying`, `failed`, and a
+# stale pending backlog. It was simply never executed on a schedule: its only
+# workflow (apply-supabase-migrations.yml) is `workflow_dispatch` alone. The
+# result, observed 2026-09-02: the ledger stopped describing the database on
+# 2026-05-24 and nothing said so for three months.
+#
+# So this workflow adds NO new detector and NO second source of truth. It runs
+# the existing engine in its existing read-only `--status` mode, on a cron.
+#
+# WHY 04:30 UTC
+# -------------
+# The morning digest (Signal 7) reports this workflow's conclusion and runs at
+# 05:00 UTC. A probe whose result is read must complete before its reader — a
+# guard executed at the wrong moment produces the same symptoms as a broken one
+# (.claude/rules/guardrails.md).
+#
+# SCOPE CONTRACT — this workflow is read-only, permanently.
+# It must never be given --dry-run, --limit, --baseline or a bare invocation.
+# Applying migrations is a deliberate, owner-confirmed act and stays in
+# apply-supabase-migrations.yml behind its `confirm=APPLY` token.
+
+on:
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-ledger-freshness
+  cancel-in-progress: false
+
+jobs:
+  status:
+    name: 🗄️ Ledger status (read-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 📦 Install psycopg
+        run: pip install --quiet --no-cache-dir 'psycopg[binary]==3.2.*'
+
+      - name: 🧪 Self-test the migration engine
+        run: python3 scripts/ci/apply-supabase-migration.py --self-test
+
+      # Exits non-zero on: drift / applying / failed (engine's existing
+      # blockers), or any migration pending for more than 30 days. See the
+      # "Ledger freshness" section of the engine for why 30 and not a number
+      # picked out of the air.
+      - name: 🚦 Ledger status + freshness
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/apply-supabase-migration.py \
+            --status \
+            --max-pending-age-days 30

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -25,6 +25,7 @@ CLI
 
     python3 apply-supabase-migration.py --self-test
     python3 apply-supabase-migration.py --status
+    python3 apply-supabase-migration.py --status --max-pending-age-days 30
     python3 apply-supabase-migration.py --dry-run
     python3 apply-supabase-migration.py [--limit N]
 
@@ -39,6 +40,7 @@ Env vars consumed
 from __future__ import annotations
 
 import argparse
+import datetime
 import hashlib
 import os
 import re
@@ -535,6 +537,100 @@ def print_status(rows, summary) -> int:
     return 1 if blocker > 0 else 0
 
 
+# ── Ledger freshness ─────────────────────────────────────────────────────────
+#
+# `pending` is deliberately NOT a blocker: between a merge and the apply run a
+# file is legitimately pending for a few days. What is not legitimate is a file
+# that stays pending for months — it means either the apply never happened, or
+# it happened out-of-band and this ledger no longer describes the database.
+# Both are the same operational defect: the ledger stopped being true, and
+# nothing said so. Blockers alone cannot catch it (they stay at zero), which is
+# why a scheduled `--status` without this check would be green-but-wrong.
+#
+# Why 30 days, and not a number picked out of the air:
+#   - the observed cadence of this runner, baseline rows excluded, is
+#     p50 = 1 day, p95 = 3 days, max = 4 days over its genuine applies;
+#   - 30 days is the freshness horizon already governed by
+#     `.spec/00-canon/repository-registry/automation-reality.yaml`, which
+#     requires runtime_evidence ≤30j before an automation may be called ACTIVE.
+# 30 is therefore ~10x the observed p95 *and* this repo's existing definition of
+# "recent enough to still be true". The threshold is passed in by the caller;
+# 0 disables the check, so every pre-existing caller keeps its behaviour.
+
+
+def migration_date(migration_id: str) -> "datetime.date | None":
+    """Calendar date encoded in a migration id, or None if it is not a real day.
+
+    MIGRATION_FILE_RE guarantees the leading digits (`YYYYMMDD` or
+    `YYYYMMDDHHMMSS`); it does not guarantee they form a date that exists.
+    """
+    try:
+        return datetime.date(
+            int(migration_id[0:4]), int(migration_id[4:6]), int(migration_id[6:8])
+        )
+    except ValueError:
+        return None
+
+
+def stale_pending(
+    local_ids, remote_ids, max_age_days: int, today: "datetime.date"
+) -> "list[tuple[str, int | None]]":
+    """Pending ids older than `max_age_days`, oldest first.
+
+    Pure: no database, no wall clock — `today` is injected so the self-tests are
+    deterministic. An id whose date is impossible is reported with age None
+    rather than raising: a malformed filename is a genuine defect, but it must
+    not take the freshness probe down with it and mask the backlog.
+    """
+    if max_age_days <= 0:
+        return []
+    out: "list[tuple[str, int | None]]" = []
+    for mid in local_ids:
+        if mid in remote_ids:
+            continue
+        day = migration_date(mid)
+        if day is None:
+            out.append((mid, None))
+            continue
+        age = (today - day).days
+        if age > max_age_days:
+            out.append((mid, age))
+    # Malformed dates first, then genuinely oldest first.
+    out.sort(key=lambda t: (t[1] is not None, -(t[1] or 0)))
+    return out
+
+
+def report_stale_pending(stale, max_age_days: int) -> int:
+    """Print the stale backlog and mirror it to the step summary. 1 if any."""
+    if not stale:
+        print(
+            f"Ledger freshness : OK — nothing pending for more than "
+            f"{max_age_days} days."
+        )
+        return 0
+    print()
+    print(
+        f"Ledger freshness : {len(stale)} migration(s) pending for more than "
+        f"{max_age_days} days — the ledger no longer describes the database."
+    )
+    lines = [
+        "## Ledger freshness",
+        "",
+        f"{len(stale)} migration(s) pending longer than {max_age_days} days. "
+        "Either the apply never happened, or it happened out-of-band and "
+        "`infra.schema_migrations` is now fiction.",
+        "",
+        "| ID | Pending since |",
+        "| --- | --- |",
+    ]
+    for mid, age in stale:
+        age_txt = f"{age} days" if age is not None else "unparsable date in filename"
+        print(f"  {mid}  {age_txt}")
+        lines.append(f"| `{mid}` | {age_txt} |")
+    write_step_summary(lines)
+    return 1
+
+
 def write_step_summary(lines) -> "None":
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
@@ -712,6 +808,41 @@ def run_self_test() -> int:
     assert split_sql_statements("  ;  ;\n") == []
     assert split_sql_statements("") == []
 
+    # 5. Ledger freshness ------------------------------------------------
+    assert migration_date("20260429_x") == datetime.date(2026, 4, 29)
+    assert migration_date("20260429120000_x") == datetime.date(2026, 4, 29)
+    assert migration_date("20261332_impossible_day") is None
+
+    today = datetime.date(2026, 9, 3)
+    ids = ["20260429_old", "20260801_borderline", "20260901_recent"]
+
+    # Applied files are never reported, however old they are.
+    assert stale_pending(ids, set(ids), 30, today) == []
+    # All pending: only those past the threshold, oldest first.
+    assert stale_pending(ids, set(), 30, today) == [
+        ("20260429_old", 127),
+        ("20260801_borderline", 33),
+    ], stale_pending(ids, set(), 30, today)
+    # A single applied id drops out; the rest still reports.
+    assert stale_pending(ids, {"20260429_old"}, 30, today) == [
+        ("20260801_borderline", 33)
+    ]
+    # Threshold is exclusive — exactly 30 days old is not yet stale.
+    assert stale_pending(["20260804_exact"], set(), 30, today) == []
+    assert stale_pending(["20260803_one_over"], set(), 30, today) == [
+        ("20260803_one_over", 31)
+    ]
+    # 0 disables the check outright, so existing callers are unaffected.
+    assert stale_pending(ids, set(), 0, today) == []
+    # A malformed date surfaces as a finding, first, instead of crashing.
+    assert stale_pending(["20260429_old", "20261332_bad"], set(), 30, today) == [
+        ("20261332_bad", None),
+        ("20260429_old", 127),
+    ]
+    # Reporting contract: empty backlog is success, any backlog is failure.
+    assert report_stale_pending([], 30) == 0
+    assert report_stale_pending([("20260429_old", 127)], 30) == 1
+
     print("OK — all self-tests passed.")
     return 0
 
@@ -828,6 +959,15 @@ def main(argv: list[str]) -> int:
         help="Print the migration state table and exit. Read-only on the data.",
     )
     parser.add_argument(
+        "--max-pending-age-days", type=int, default=0, metavar="N",
+        help=(
+            "With --status: exit non-zero when a migration has been pending "
+            "for more than N days. 0 (default) disables the check and keeps "
+            "the historical behaviour. See the 'Ledger freshness' section in "
+            "this file for why the scheduled probe uses 30."
+        ),
+    )
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Show the apply plan without writing.",
     )
@@ -877,7 +1017,18 @@ def main(argv: list[str]) -> int:
             return run_baseline(conn, local, remote, args.exclude)
 
         if args.status:
-            return print_status(rows, summary)
+            rc = print_status(rows, summary)
+            if args.max_pending_age_days > 0:
+                rc = max(rc, report_stale_pending(
+                    stale_pending(
+                        [m.id for m in local],
+                        remote,
+                        args.max_pending_age_days,
+                        datetime.date.today(),
+                    ),
+                    args.max_pending_age_days,
+                ))
+            return rc
 
         # Refuse to proceed when blockers exist.
         if summary["drift"] or summary["applying"] or summary["failed"]:


### PR DESCRIPTION
## Le défaut

`infra.schema_migrations` a cessé de décrire la base le **2026-05-24**. Au 2026-09-02 : **58 migrations en attente**, la plus ancienne depuis **176 jours**, plus une ligne en drift. Trois mois, **aucun signal**.

## Diagnostic — les 4 passes de `.claude/rules/guardrails.md`

Le réflexe serait « le détecteur est cassé ». Il ne l'est pas.

| Passe | Résultat |
|---|---|
| **1. Lire la garde** | `print_status()` retourne déjà `1` sur `drift + applying + failed`. Complète et correcte. |
| **2. Qui d'autre porte la responsabilité ?** | **Personne.** Les invariants registry sont hors-ligne (projection L1/L2/L3, aucun accès DB) ; le digest matinal n'interroge que l'API GitHub ; `apply-supabase-migration` n'apparaît dans **aucun** autre workflow, script ou npm script. |
| **3. Ordre d'exécution** | Son unique workflow est `workflow_dispatch:` **seul**. La garde ne s'exécute à aucun moment. |
| **4. Contrat de périmètre** | `automation-reality.yaml` déclare lui-même : *« NOT a system to add new automation (it OBSERVES existing reality) »* — il enregistrerait l'écart, il ne le détecte pas. |

**Donc : aucun second détecteur, aucune SoT dupliquée.** On planifie l'existant.

## Le détail qui décide du design

`pending` **n'est pas** un bloqueur — et c'est délibéré : entre un merge et l'apply, un fichier est légitimement en attente quelques jours. Conséquence : planifier `--status` tel quel aurait rendu **VERT** l'état d'aujourd'hui, ses 58 fichiers en attente ne comptant pour rien. Une sonde verte-mais-fausse, exactement l'anti-pattern « mesurer sans assurer ».

D'où l'assertion de fraîcheur, dans le moteur qui possède déjà la vérité du ledger.

## Le seuil est dérivé, pas inventé

| Source | Valeur |
|---|---|
| Cadence réelle du runner, **hors** baseline de masse (22 applications authentiques) | p50 = **1 j**, p95 = **3 j**, max = **4 j** |
| Horizon de fraîcheur déjà gouverné par `automation-reality.yaml` (`runtime_evidence`) | **≤ 30 j** |

**30 jours ≈ 10× le p95 observé** *et* la définition maison de « encore vrai ». Les 244 lignes du ledger donnaient un p50 apparent de 91 j — chiffre contaminé par les 222 lignes du `baseline-2026-05-16`, écartées.

## Le changement

- **`--max-pending-age-days N`** — défaut `0` = désactivé, donc **zéro impact** sur les appelants existants. Logique pure (`stale_pending`), horloge injectée, **12 assertions** ajoutées au `--self-test` déjà lancé en CI (seuil exclusif, id appliqué jamais signalé, `0` désactive, date impossible remontée en constat au lieu de faire tomber la sonde).
- **`migration-ledger-freshness.yml`** — cron **04:30 UTC**, lecture seule, contrat de périmètre inscrit dans l'en-tête (jamais d'argument mutant ; appliquer reste dans `apply-supabase-migrations.yml` derrière son jeton `confirm=APPLY`). 04:30 parce que son lecteur tourne à 05:00 : *une garde lue doit finir avant son lecteur.*
- **Digest Signal 7** — ne lit que la **conclusion** du workflow, exactement comme les Signaux 2 et 5. Le repo est **public** et le corps du digest est collé tel quel dans une issue : `DATABASE_URL` reste donc dans le seul workflow qui en a besoin, et **aucun contenu de base ne transite par l'issue**.

## Preuve

```
$ python3 scripts/ci/apply-supabase-migration.py --self-test
OK — all self-tests passed.
```

Preuve rouge sur données réelles (302 fichiers du repo × les 244 lignes réelles du ledger, sans connexion DB) :

```
fichiers locaux : 302   lignes au ledger : 244   en attente : 58

--> seuil=0j  : 0 signalées,  code de sortie 0
--> seuil=30j : 58 signalées, code de sortie 1
  20260311142250_r8_diversity_system              176 days
  20260513_default_privileges_data_api_post_oct30 113 days
  20260520_supplier_truth_v1                      106 days
  …
```

Digest exécuté de bout en bout : le Signal 7 rend son chemin « aucun run » (l'état qu'il rencontrera au premier digest après merge) sans casser le script.

## À attendre : ce workflow sera ROUGE dès son premier run

Et il le restera jusqu'à la réconciliation du ledger (`baseline_only` + `exclude_ids`). **C'est le comportement correct.** Aucun baseline de complaisance n'a été ajouté pour le verdir — cela masquerait précisément le défaut qu'il ferme.

## Périmètre

CI seule : `.github/workflows/**`, `.github/scripts/**`, `scripts/ci/**` — les trois déjà couverts par `ownership.yaml` (l. 221, 226, 1049), donc **aucun glob owner-gated à attendre**. Aucun rebuild registry : I6 ne hache que les JSON L1 et les overlays L2, et l'inventaire AST n'indexe pas le Python. Aucune migration appliquée, aucun runtime touché. Merge `main` → PREPROD.

## Suite, côté owner

Une entrée `automation-reality.yaml` documenterait proprement cet écart `intended_mode: ACTIVE` / `actual_mode: SCRIPT_ONLY` désormais résolu — le fichier est `.spec/00-canon/**`, donc owner-only. Je fournis le bloc sur demande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
