### PR TITLE
feat(migrations): --reapply — réparer une ligne en drift par exécution, pas par affirmation

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -57,6 +57,14 @@ on:
         description: 'Comma-separated migration ids to keep pending during --baseline (e.g. "20260518_seo_admin_job_table").'
         required: false
         default: ''
+      reapply_id:
+        description: |
+          Re-execute ONE drifted migration and rewrite its ledger row from the run.
+          The engine refuses unless the row is a drifted `applied`, the file is
+          transactional, and nothing in it misbehaves on a second run. Needs
+          confirm=APPLY and dry_run=false. Blank = not this mode.
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -73,14 +81,28 @@ jobs:
     steps:
       - name: 🛑 Confirm token
         if: ${{ !inputs.status_only && !inputs.dry_run && inputs.confirm != 'APPLY' }}
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
-          echo "::error::Mutating step requires confirm=APPLY (got '${{ inputs.confirm }}'). Re-run with confirm=APPLY, dry_run=true, or status_only=true."
+          echo "::error::Mutating step requires confirm=APPLY (got '${CONFIRM}'). Re-run with confirm=APPLY, dry_run=true, or status_only=true."
           exit 1
 
       - name: 🛑 Reject mutually-exclusive modes
         if: ${{ inputs.baseline_only && (inputs.status_only || inputs.dry_run || inputs.limit != '') }}
         run: |
           echo "::error::baseline_only cannot be combined with status_only / dry_run / limit. Pick one mode per run."
+          exit 1
+
+      - name: 🛑 Reject reapply combined with another mode
+        if: ${{ inputs.reapply_id != '' && (inputs.baseline_only || inputs.status_only || inputs.limit != '') }}
+        run: |
+          echo "::error::reapply_id cannot be combined with baseline_only / status_only / limit. Pick one mode per run."
+          exit 1
+
+      - name: 🛑 Reject reapply under dry_run
+        if: ${{ inputs.reapply_id != '' && inputs.dry_run }}
+        run: |
+          echo "::error::reapply_id executes SQL — there is no dry-run for it. Re-run with dry_run=false and confirm=APPLY."
           exit 1
 
       - name: ⬇️ Checkout repo
@@ -102,13 +124,20 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SHA: ${{ github.sha }}
+          # Operator-supplied strings reach the shell as env vars, never as `${{ }}`
+          # interpolation inside `run:` — this runner holds DATABASE_URL.
+          REAPPLY_ID: ${{ inputs.reapply_id }}
+          EXCLUDE_IDS: ${{ inputs.exclude_ids }}
+          LIMIT: ${{ inputs.limit }}
         run: |
           set -euo pipefail
           ARGS=()
-          if [ "${{ inputs.baseline_only }}" = "true" ]; then
+          if [ -n "$REAPPLY_ID" ]; then
+            ARGS+=("--reapply" "$REAPPLY_ID")
+          elif [ "${{ inputs.baseline_only }}" = "true" ]; then
             ARGS+=("--baseline")
-            if [ -n "${{ inputs.exclude_ids }}" ]; then
-              ARGS+=("--exclude" "${{ inputs.exclude_ids }}")
+            if [ -n "$EXCLUDE_IDS" ]; then
+              ARGS+=("--exclude" "$EXCLUDE_IDS")
             fi
           elif [ "${{ inputs.status_only }}" = "true" ]; then
             ARGS+=("--status")
@@ -116,8 +145,8 @@ jobs:
             if [ "${{ inputs.dry_run }}" = "true" ]; then
               ARGS+=("--dry-run")
             fi
-            if [ -n "${{ inputs.limit }}" ]; then
-              ARGS+=("--limit" "${{ inputs.limit }}")
+            if [ -n "$LIMIT" ]; then
+              ARGS+=("--limit" "$LIMIT")
             fi
           fi
           python3 scripts/ci/apply-supabase-migration.py "${ARGS[@]}"

--- a/log.md
+++ b/log.md
@@ -398,3 +398,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix+ledger-probe-truly-readonly`
 - **Décision** : fix(migrations): rendre la sonde de fraîcheur réellement en lecture seule + résumé exploitable
 - **Sortie** : PR #1387 | commits ac9227a4e
+
+## 2026-09-03 — feat+engine-reapply-drifted-migration (auto)
+
+- **Branche** : `feat+engine-reapply-drifted-migration`
+- **Décision** : feat(migrations): --reapply — réparer une ligne en drift par exécution, pas par affirmation
+- **Sortie** : PR #1389 | commits 9601898bf

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -991,21 +991,38 @@ def run_self_test() -> int:
     assert report_stale_pending([], 30) == 0
     assert report_stale_pending([("20260429_old", 127)], 30) == 1
 
-    # 7. Re-apply safety ---------------------------------------------------
-    assert unsafe_to_rerun("INSERT INTO t (a) VALUES (1);") != []
-    assert unsafe_to_rerun("INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING;") == []
-    assert unsafe_to_rerun(
-        "INSERT INTO t (a) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM t);"
+    # 7. Re-apply safety — ALLOW-LIST, not deny-list ----------------------
+    # Proven-idempotent forms pass.
+    assert not_replayable("SET lock_timeout = '5s';") == []
+    assert not_replayable("CREATE TABLE IF NOT EXISTS t (a int);") == []
+    assert not_replayable("CREATE UNIQUE INDEX IF NOT EXISTS i ON t(a);") == []
+    assert not_replayable("CREATE OR REPLACE VIEW v AS SELECT 1;") == []
+    assert not_replayable("COMMENT ON VIEW v IS 'x';") == []
+    assert not_replayable("GRANT SELECT ON t TO r;") == []
+    assert not_replayable("INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING;") == []
+    # Everything else is refused BY NAME, including the forms a deny-list missed.
+    assert not_replayable("INSERT INTO t (a) VALUES (1);") != []
+    assert not_replayable("TRUNCATE t;") != []
+    assert not_replayable("UPDATE t SET a = 1;") != []
+    assert not_replayable("CREATE TABLE t (a int);") != []
+    assert not_replayable("ALTER TABLE t ADD COLUMN b int;") != []
+    # The inverted-polarity bug this replaced: IF EXISTS protects the FIRST run,
+    # not the replay. On a replay the table exists and is full.
+    assert not_replayable("DROP TABLE IF EXISTS t;") != []
+    assert not_replayable("DROP TABLE t;") != []
+    # Transaction control ends our transaction — refused, which also closes the
+    # "the SQL committed but the ledger did not" hole.
+    assert not_replayable("BEGIN; SELECT 1; COMMIT;") != []
+    assert not_replayable("SAVEPOINT s;") != []
+    # DO blocks: assertions replay, writers do not.
+    assert not_replayable(
+        "DO $$ DECLARE n INT; BEGIN SELECT count(*) INTO n FROM t; "
+        "IF n < 1 THEN RAISE EXCEPTION 'empty'; END IF; END $$;"
     ) == []
-    assert unsafe_to_rerun("TRUNCATE t;") != []
-    assert unsafe_to_rerun("DROP TABLE t;") != []
-    assert unsafe_to_rerun("DROP TABLE IF EXISTS t;") == []
-    assert unsafe_to_rerun("DELETE FROM t;") != []
-    assert unsafe_to_rerun("DELETE FROM t WHERE a = 1;") == []
-    # An INSERT parked inside a block comment is dead text, not a hazard. This is
-    # the case a grep-based check gets wrong on 20260429.
-    assert unsafe_to_rerun("/* disabled\nINSERT INTO t (a) VALUES (1);\n*/\nSELECT 1;") == []
-    assert unsafe_to_rerun("SELECT 'INSERT INTO t VALUES (1)';") == []
+    assert not_replayable("DO $$ BEGIN INSERT INTO t VALUES (1); END $$;") != []
+    # Lexer-backed: dead text in a block comment or a string is not a statement.
+    assert not_replayable("/* disabled\nDROP TABLE t;\n*/\nSELECT 1;") == []
+    assert not_replayable("SELECT 'DROP TABLE t';") == []
 
     _lm = LocalMigration(id="x", path=Path("x.sql"), checksum="bbb",
                          non_transactional=False)
@@ -1013,25 +1030,25 @@ def run_self_test() -> int:
                           applied_at="2026-05-16", runner="baseline")
     _ok_sql = "CREATE OR REPLACE VIEW v AS SELECT 1;"
     assert reapply_precheck(_lm, _rm, _ok_sql) is None
-    # Not recorded at all.
     assert "not recorded" in reapply_precheck(_lm, None, _ok_sql)
-    # Wrong status.
     assert "not 'applied'" in reapply_precheck(
         _lm, RemoteMigration("x", "aaa", "failed", None, None), _ok_sql)
-    # No drift.
     assert "not in drift" in reapply_precheck(
         _lm, RemoteMigration("x", "bbb", "applied", None, None), _ok_sql)
-    # Non-transactional is out of scope.
     assert "non_transactional" in reapply_precheck(
         LocalMigration("x", Path("x.sql"), "bbb", True), _rm, _ok_sql)
-    # Non-replayable SQL.
-    assert "not re-runnable" in reapply_precheck(
-        _lm, _rm, "INSERT INTO t (a) VALUES (1);")
-    # The real drifted file, when the checkout has it : must be re-runnable.
-    _real = MIGRATIONS_DIR / "20260429_diag_maintenance_via_kg.sql"
-    if _real.exists():
-        _r = unsafe_to_rerun(_real.read_text(encoding="utf-8"))
-        assert _r == [], _r
+    assert "not replayable" in reapply_precheck(_lm, _rm, "DROP TABLE IF EXISTS t;")
+
+    # The two real files that pin both directions of this gate.
+    _target = MIGRATIONS_DIR / "20260429_diag_maintenance_via_kg.sql"
+    if _target.exists():
+        _r = not_replayable(_target.read_text(encoding="utf-8"))
+        assert _r == [], _r          # must stay repairable
+    _destructive = (MIGRATIONS_DIR
+                    / "20260104_purchase_guide_v2_client_content.sql")
+    if _destructive.exists():
+        _r = not_replayable(_destructive.read_text(encoding="utf-8"))
+        assert any("DROP TABLE IF EXISTS" in x for x in _r), _r
 
     print("OK — all self-tests passed.")
     return 0
@@ -1055,37 +1072,84 @@ def run_self_test() -> int:
 # that can run twice, which is checked mechanically below rather than promised in
 # a header comment.
 
-UNGUARDED_INSERT_RE = re.compile(r"^\s*INSERT\s+INTO\s+([A-Za-z_][\w.\"]*)", re.IGNORECASE)
-INSERT_GUARD_RE = re.compile(r"ON\s+CONFLICT|WHERE\s+NOT\s+EXISTS", re.IGNORECASE)
-DESTRUCTIVE_RE = re.compile(
-    r"^\s*(DROP\s+TABLE(?!\s+IF\s+EXISTS)|TRUNCATE|DELETE\s+FROM(?![\s\S]*\bWHERE\b))",
-    re.IGNORECASE,
+# The gate is an ALLOW-LIST, not a deny-list. A deny-list of a few dangerous
+# forms approved 301 of this repo's 303 migrations — including
+# `20260104_purchase_guide_v2_client_content.sql`, whose line 9 is
+# `DROP TABLE IF EXISTS __seo_gamme_purchase_guide` (241 live rows, 3.7 MB today).
+# `IF EXISTS` protects the FIRST run against a missing table; on a replay months
+# later the table exists and is full, and the DROP would commit inside the very
+# transaction that stamps the ledger row `applied`.
+#
+# So: every top-level statement must be a form that is *proven* to survive a
+# second execution. Anything else is refused by name. Widening this list is a
+# deliberate act, not an oversight.
+
+_ALLOWED = (
+    re.compile(r"^(SET|RESET)\s", re.I),
+    re.compile(r"^SELECT\s", re.I),
+    re.compile(r"^CREATE\b[\s\S]{0,80}?\bIF\s+NOT\s+EXISTS\b", re.I),
+    re.compile(r"^CREATE\s+OR\s+REPLACE\s+(FUNCTION|VIEW|PROCEDURE|TRIGGER|RULE)\b", re.I),
+    re.compile(r"^COMMENT\s+ON\s", re.I),
+    re.compile(r"^(GRANT|REVOKE)\s", re.I),
+)
+_INSERT_RE = re.compile(r"^INSERT\s+INTO\s+([A-Za-z_][\w.\"]*)", re.I)
+_INSERT_GUARD_RE = re.compile(r"ON\s+CONFLICT|WHERE\s+NOT\s+EXISTS", re.I)
+_DO_RE = re.compile(r"^DO\s", re.I)
+_DOLLAR_BODY_RE = re.compile(r"\$([A-Za-z_]*)\$(.*?)\$\1\$", re.S)
+# Verbs that write. `BEGIN`/`END` are PL/pgSQL block delimiters inside a DO and
+# are deliberately absent — only writes disqualify an assertion block.
+_WRITE_VERB_RE = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE|CALL|COPY|MERGE)\b",
+    re.I,
 )
 
 
-def unsafe_to_rerun(sql: str) -> "list[str]":
-    """Reasons this SQL must not be executed a second time. Empty = re-runnable.
+def _do_block_is_read_only(stmt: str) -> bool:
+    """True when a DO block only reads and raises.
 
-    Lexer-backed, so a statement quoted inside a string, a dollar-quoted body or
-    a block comment does not produce a hit. That matters : 20260429 keeps a whole
-    disabled INSERT inside a /* ... */ block for traceability, and a grep-based
-    check reports it as a duplication hazard when it is dead text.
+    20260429 uses two of them as post-conditions (`SELECT COUNT(*) INTO ...`
+    then `RAISE EXCEPTION` when the invariant fails). Those replay safely; a DO
+    that writes does not, and this cannot tell the difference by intent — only
+    by looking for write verbs in the body.
+    """
+    bodies = _DOLLAR_BODY_RE.findall(stmt)
+    if not bodies:
+        return False
+    return not any(_WRITE_VERB_RE.search(body) for _, body in bodies)
+
+
+def not_replayable(sql: str) -> "list[str]":
+    """Statements that are not proven safe to execute a second time.
+
+    Empty list = every statement is on the allow-list. Lexer-backed, so a
+    statement quoted inside a string, a dollar-quoted body or a block comment is
+    not counted — 20260429 keeps a whole disabled INSERT inside a /* ... */ block
+    for traceability, and a grep-based check calls that a duplication hazard when
+    it is dead text.
     """
     reasons = []
     for stmt in split_sql_statements(sql):
-        clean = LEADING_NOISE_RE.sub("", stmt)
-        hit = UNGUARDED_INSERT_RE.match(clean)
-        if hit and not INSERT_GUARD_RE.search(clean):
+        clean = LEADING_NOISE_RE.sub("", stmt).strip()
+        if not clean:
+            continue
+        if any(rx.match(clean) for rx in _ALLOWED):
+            continue
+        ins = _INSERT_RE.match(clean)
+        if ins:
+            if _INSERT_GUARD_RE.search(clean):
+                continue
             reasons.append(
-                f"INSERT INTO {hit.group(1)} without ON CONFLICT / WHERE NOT "
+                f"INSERT INTO {ins.group(1)} without ON CONFLICT / WHERE NOT "
                 "EXISTS — a second run would duplicate rows"
             )
-        d = DESTRUCTIVE_RE.match(clean)
-        if d:
-            reasons.append(
-                f"destructive statement `{d.group(1).split()[0].upper()}` — "
-                "not replayable"
-            )
+            continue
+        if _DO_RE.match(clean):
+            if _do_block_is_read_only(clean):
+                continue
+            reasons.append("DO block that writes — not provably replayable")
+            continue
+        head = " ".join(clean.split()[:6])[:72]
+        reasons.append(f"not on the replay allow-list: `{head}`")
     return reasons
 
 
@@ -1105,10 +1169,32 @@ def reapply_precheck(mig, row, sql) -> "str | None":
             "marked @non_transactional — re-apply only supports the "
             "transactional path, where the SQL and the ledger row commit together"
         )
-    unsafe = unsafe_to_rerun(sql)
-    if unsafe:
-        return "not re-runnable: " + " ; ".join(unsafe)
+    blockers = not_replayable(sql)
+    if blockers:
+        shown = " ; ".join(blockers[:4])
+        more = f" (+{len(blockers) - 4} more)" if len(blockers) > 4 else ""
+        return "not replayable: " + shown + more
     return None
+
+
+def _assert_in_transaction(conn, when: str) -> "None":
+    """Fail loudly if our transaction is no longer open.
+
+    A migration containing a top-level COMMIT would end the transaction psycopg
+    opened, so the SQL would already be durable while the ledger row is not —
+    and the rollback path would then print "rolled back" over work that is not
+    coming back. The allow-list refuses such files, but this is the cheap
+    verification that the promise held.
+    """
+    from psycopg.pq import TransactionStatus
+
+    st = conn.info.transaction_status
+    if st != TransactionStatus.INTRANS:
+        raise RuntimeError(
+            f"transaction is no longer open {when} (status={st!r}). The migration "
+            "SQL closed it — its effects may already be durable. The ledger row "
+            "was NOT written; inspect the database before retrying."
+        )
 
 
 def run_reapply(conn, local, remote, target_id: str, runner: str, git_sha: str) -> int:
@@ -1159,6 +1245,12 @@ def run_reapply(conn, local, remote, target_id: str, runner: str, git_sha: str) 
         with conn.cursor() as cur:
             cur.execute(sql)
             elapsed_ms = int((time.monotonic() - start) * 1000)
+            # Belt and braces on top of the allow-list : if the file managed to
+            # close our transaction anyway, the ledger row must NOT be written
+            # and we must not print "rolled back" over work that already
+            # committed. Checked before touching the ledger, and again before
+            # committing.
+            _assert_in_transaction(conn, "after running the migration SQL")
             # Guarded on the OLD checksum : if anything moved under us, 0 rows
             # match and we abort instead of reporting a silent success.
             cur.execute(
@@ -1176,6 +1268,7 @@ def run_reapply(conn, local, remote, target_id: str, runner: str, git_sha: str) 
                     f"ledger row for {target_id} changed during re-apply "
                     f"({cur.rowcount} rows matched, expected 1) — rolled back"
                 )
+        _assert_in_transaction(conn, "before committing the ledger row")
         conn.commit()
     except Exception:
         conn.rollback()

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -82,8 +82,12 @@ CREATE INDEX IF NOT EXISTS idx_schema_migrations_status
   ON infra.schema_migrations (status)
   WHERE status IN ('applying', 'failed');
 
+-- Audit trail for --reapply : why a row was rewritten. Additive and idempotent,
+-- so it lands on ledgers created before this column existed.
+ALTER TABLE infra.schema_migrations ADD COLUMN IF NOT EXISTS note TEXT;
+
 GRANT SELECT, INSERT ON infra.schema_migrations TO service_role;
-GRANT UPDATE (status, applied_at, execution_ms, error_message)
+GRANT UPDATE (status, applied_at, execution_ms, error_message, note)
   ON infra.schema_migrations TO service_role;
 """
 
@@ -987,7 +991,207 @@ def run_self_test() -> int:
     assert report_stale_pending([], 30) == 0
     assert report_stale_pending([("20260429_old", 127)], 30) == 1
 
+    # 7. Re-apply safety ---------------------------------------------------
+    assert unsafe_to_rerun("INSERT INTO t (a) VALUES (1);") != []
+    assert unsafe_to_rerun("INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING;") == []
+    assert unsafe_to_rerun(
+        "INSERT INTO t (a) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM t);"
+    ) == []
+    assert unsafe_to_rerun("TRUNCATE t;") != []
+    assert unsafe_to_rerun("DROP TABLE t;") != []
+    assert unsafe_to_rerun("DROP TABLE IF EXISTS t;") == []
+    assert unsafe_to_rerun("DELETE FROM t;") != []
+    assert unsafe_to_rerun("DELETE FROM t WHERE a = 1;") == []
+    # An INSERT parked inside a block comment is dead text, not a hazard. This is
+    # the case a grep-based check gets wrong on 20260429.
+    assert unsafe_to_rerun("/* disabled\nINSERT INTO t (a) VALUES (1);\n*/\nSELECT 1;") == []
+    assert unsafe_to_rerun("SELECT 'INSERT INTO t VALUES (1)';") == []
+
+    _lm = LocalMigration(id="x", path=Path("x.sql"), checksum="bbb",
+                         non_transactional=False)
+    _rm = RemoteMigration(id="x", checksum="aaa", status="applied",
+                          applied_at="2026-05-16", runner="baseline")
+    _ok_sql = "CREATE OR REPLACE VIEW v AS SELECT 1;"
+    assert reapply_precheck(_lm, _rm, _ok_sql) is None
+    # Not recorded at all.
+    assert "not recorded" in reapply_precheck(_lm, None, _ok_sql)
+    # Wrong status.
+    assert "not 'applied'" in reapply_precheck(
+        _lm, RemoteMigration("x", "aaa", "failed", None, None), _ok_sql)
+    # No drift.
+    assert "not in drift" in reapply_precheck(
+        _lm, RemoteMigration("x", "bbb", "applied", None, None), _ok_sql)
+    # Non-transactional is out of scope.
+    assert "non_transactional" in reapply_precheck(
+        LocalMigration("x", Path("x.sql"), "bbb", True), _rm, _ok_sql)
+    # Non-replayable SQL.
+    assert "not re-runnable" in reapply_precheck(
+        _lm, _rm, "INSERT INTO t (a) VALUES (1);")
+    # The real drifted file, when the checkout has it : must be re-runnable.
+    _real = MIGRATIONS_DIR / "20260429_diag_maintenance_via_kg.sql"
+    if _real.exists():
+        _r = unsafe_to_rerun(_real.read_text(encoding="utf-8"))
+        assert _r == [], _r
+
     print("OK — all self-tests passed.")
+    return 0
+
+
+# ── Re-apply a drifted migration ────────────────────────────────────────────
+#
+# A `drift` row means the ledger records checksum A while the file now holds
+# checksum B. The engine refuses every apply and dry-run until that is resolved,
+# and it has no way out : `checksum` is not in the column-scoped UPDATE grant,
+# and there is no DELETE grant (append-only ledger).
+#
+# The tempting fix — rewrite the checksum — makes the row *claim* the new bytes
+# were applied. That is an assertion, not a fact, and it silently ratifies a row
+# that may never have been true. Real case: 20260429_diag_maintenance_via_kg was
+# swept into `applied` by the 2026-05-16 bulk baseline, while PR #1084 states the
+# original migration "was never applied".
+#
+# So instead of asserting, re-execute. After a --reapply the row is true because
+# the bytes just ran, not because someone said so. That is only safe for a file
+# that can run twice, which is checked mechanically below rather than promised in
+# a header comment.
+
+UNGUARDED_INSERT_RE = re.compile(r"^\s*INSERT\s+INTO\s+([A-Za-z_][\w.\"]*)", re.IGNORECASE)
+INSERT_GUARD_RE = re.compile(r"ON\s+CONFLICT|WHERE\s+NOT\s+EXISTS", re.IGNORECASE)
+DESTRUCTIVE_RE = re.compile(
+    r"^\s*(DROP\s+TABLE(?!\s+IF\s+EXISTS)|TRUNCATE|DELETE\s+FROM(?![\s\S]*\bWHERE\b))",
+    re.IGNORECASE,
+)
+
+
+def unsafe_to_rerun(sql: str) -> "list[str]":
+    """Reasons this SQL must not be executed a second time. Empty = re-runnable.
+
+    Lexer-backed, so a statement quoted inside a string, a dollar-quoted body or
+    a block comment does not produce a hit. That matters : 20260429 keeps a whole
+    disabled INSERT inside a /* ... */ block for traceability, and a grep-based
+    check reports it as a duplication hazard when it is dead text.
+    """
+    reasons = []
+    for stmt in split_sql_statements(sql):
+        clean = LEADING_NOISE_RE.sub("", stmt)
+        hit = UNGUARDED_INSERT_RE.match(clean)
+        if hit and not INSERT_GUARD_RE.search(clean):
+            reasons.append(
+                f"INSERT INTO {hit.group(1)} without ON CONFLICT / WHERE NOT "
+                "EXISTS — a second run would duplicate rows"
+            )
+        d = DESTRUCTIVE_RE.match(clean)
+        if d:
+            reasons.append(
+                f"destructive statement `{d.group(1).split()[0].upper()}` — "
+                "not replayable"
+            )
+    return reasons
+
+
+def reapply_precheck(mig, row, sql) -> "str | None":
+    """Why `mig` cannot be re-applied, or None when it can.
+
+    Pure : no database. `row` is the RemoteMigration or None.
+    """
+    if row is None:
+        return "not recorded in the ledger — a normal apply covers this"
+    if row.status != "applied":
+        return f"ledger status is '{row.status}', not 'applied' — resolve that first"
+    if row.checksum == mig.checksum:
+        return "not in drift — the ledger already matches the file"
+    if mig.non_transactional:
+        return (
+            "marked @non_transactional — re-apply only supports the "
+            "transactional path, where the SQL and the ledger row commit together"
+        )
+    unsafe = unsafe_to_rerun(sql)
+    if unsafe:
+        return "not re-runnable: " + " ; ".join(unsafe)
+    return None
+
+
+def run_reapply(conn, local, remote, target_id: str, runner: str, git_sha: str) -> int:
+    mig = next((m for m in local if m.id == target_id), None)
+    if mig is None:
+        fail(8, f"{target_id}: no such file under {MIGRATIONS_DIR}/.")
+
+    sql = mig.path.read_text(encoding="utf-8")
+    row = remote.get(target_id)
+    why = reapply_precheck(mig, row, sql)
+    if why:
+        fail(8, f"{target_id}: {why}.")
+
+    # The columns this rewrites are NOT in the service_role grant : only the table
+    # owner can. Say so plainly instead of surfacing a bare 42501 mid-transaction.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT current_user,
+                   has_column_privilege('infra.schema_migrations', 'checksum', 'UPDATE'),
+                   has_column_privilege('infra.schema_migrations', 'runner', 'UPDATE'),
+                   has_column_privilege('infra.schema_migrations', 'git_sha', 'UPDATE')
+            """
+        )
+        who, c_ok, r_ok, g_ok = cur.fetchone()
+    if not (c_ok and r_ok and g_ok):
+        fail(
+            9,
+            f"role '{who}' cannot UPDATE checksum/runner/git_sha on "
+            "infra.schema_migrations (column-scoped grant). Re-apply needs the "
+            "table owner — the DATABASE_URL the engine bootstraps with.",
+        )
+
+    print(f"Re-applying {target_id}")
+    print(f"  ledger checksum : {row.checksum}")
+    print(f"  file checksum   : {mig.checksum}")
+    print(f"  recorded by     : {row.runner or '—'} at {row.applied_at or '—'}")
+    print(f"  statements      : {len(split_sql_statements(sql))}")
+
+    note = (
+        f"reapplied over a stale record: was checksum={row.checksum} "
+        f"runner={row.runner or '—'} applied_at={row.applied_at or '—'}"
+    )
+    reset_session(conn)
+    start = time.monotonic()
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            elapsed_ms = int((time.monotonic() - start) * 1000)
+            # Guarded on the OLD checksum : if anything moved under us, 0 rows
+            # match and we abort instead of reporting a silent success.
+            cur.execute(
+                """
+                UPDATE infra.schema_migrations
+                   SET checksum = %s, status = 'applied', applied_at = NOW(),
+                       execution_ms = %s, runner = %s, git_sha = %s, note = %s
+                 WHERE id = %s AND checksum = %s
+                """,
+                (mig.checksum, elapsed_ms, runner, git_sha, note,
+                 target_id, row.checksum),
+            )
+            if cur.rowcount != 1:
+                raise RuntimeError(
+                    f"ledger row for {target_id} changed during re-apply "
+                    f"({cur.rowcount} rows matched, expected 1) — rolled back"
+                )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.autocommit = True
+
+    print(f"OK in {elapsed_ms}ms — ledger now records {mig.checksum}")
+    write_step_summary(
+        ["## Re-applied", "",
+         f"`{target_id}` re-executed and re-recorded in {elapsed_ms}ms.", "",
+         f"- previous checksum : `{row.checksum}`",
+         f"- new checksum      : `{mig.checksum}`",
+         f"- previous record   : {row.runner or '—'} at {row.applied_at or '—'}",
+         ""]
+    )
     return 0
 
 
@@ -1103,6 +1307,15 @@ def main(argv: list[str]) -> int:
         help="Print the migration state table and exit. Read-only on the data.",
     )
     parser.add_argument(
+        "--reapply", type=str, default="", metavar="ID",
+        help=(
+            "Re-execute ONE migration whose ledger row is in drift, then rewrite "
+            "that row from the run. Refuses unless the row is a drifted "
+            "'applied', the file is transactional, and it contains no statement "
+            "that would misbehave on a second run. Needs the table owner."
+        ),
+    )
+    parser.add_argument(
         "--no-bootstrap", action="store_true",
         help=(
             "Skip the ledger DDL/GRANT bootstrap. Only valid with --status : it "
@@ -1152,11 +1365,11 @@ def main(argv: list[str]) -> int:
     if args.self_test:
         return run_self_test()
 
-    if args.no_bootstrap and not args.status:
+    if args.no_bootstrap and (not args.status or args.reapply or args.baseline):
         fail(
             2,
-            "--no-bootstrap is only valid with --status : every write path needs "
-            "the ledger DDL to exist.",
+            "--no-bootstrap is only valid with a bare --status : every write path "
+            "needs the ledger DDL to exist.",
         )
 
     local = parse_local_migrations()
@@ -1188,6 +1401,15 @@ def main(argv: list[str]) -> int:
             remote = fetch_remote(conn)
 
         rows, summary = classify(local, remote)
+
+        # Identity of THIS run, needed by every write mode below.
+        runner = f"gh-actions:{os.environ.get('GITHUB_RUN_ID', 'local')}"
+        git_sha = os.environ.get("GITHUB_SHA", "")
+
+        if args.reapply:
+            return run_reapply(
+                conn, local, remote, args.reapply, runner, git_sha
+            )
 
         if args.baseline:
             return run_baseline(conn, local, remote, args.exclude)
@@ -1246,9 +1468,6 @@ def main(argv: list[str]) -> int:
                 mode = "non-tx" if m.non_transactional else "tx"
                 print(f"  would apply {m.id} ({mode})")
             return 0
-
-        runner = f"gh-actions:{os.environ.get('GITHUB_RUN_ID', 'local')}"
-        git_sha = os.environ.get("GITHUB_SHA", "")
 
         applied: list[tuple[str, int]] = []
         for m in pending:


### PR DESCRIPTION
Une ligne en `drift` signifie que le ledger enregistre le checksum A alors que le fichier porte désormais B. Le moteur refuse alors **tout apply et tout dry-run** (`exit 5`), sans aucune sortie : `checksum` n'est pas dans le `GRANT UPDATE` restreint aux colonnes, et il n'y a pas de `GRANT DELETE` (ledger append-only).

## Pourquoi ré-exécuter plutôt que réécrire le checksum

Réécrire le checksum fait **affirmer** à la ligne que les nouveaux octets ont été appliqués. C'est une assertion, pas un fait. Cas réel, celui qui bloque le ledger aujourd'hui : `20260429_diag_maintenance_via_kg` a été balayé dans `applied` par le baseline de masse du 2026-05-16, alors que la PR #1084 écrit que la migration d'origine *« was never applied »*. Réécrire son checksum aurait effacé le dernier signal de cet incident.

Après un `--reapply`, la ligne est vraie parce que les octets viennent de tourner.

## ⚠️ Cette PR a été révisée après une réfutation adverse

La première version portait **deux défauts bloquants**, trouvés en faisant contester la PR avant merge, et reproduits par expérience sur un Postgres jetable :

**La garde approuvait 301 fichiers sur 303.** Une deny-list de quatre motifs, avec la polarité inversée : elle exemptait `DROP TABLE IF EXISTS`, et un self-test figeait cette exemption. `IF EXISTS` protège la **première** exécution contre une table absente — au **rejeu** des mois plus tard, la table existe et est peuplée.

Mesuré, pas supposé : `20260104_purchase_guide_v2_client_content.sql` ligne 9 fait `DROP TABLE IF EXISTS __seo_gamme_purchase_guide`. Cette table contient **241 lignes / 3696 kB** en production. L'ancienne garde la déclarait rejouable.

**Un `COMMIT` dans le fichier cassait l'atomicité annoncée.** 47 des 302 migrations portent un `BEGIN`/`COMMIT` de premier niveau, 46 passaient la garde. Un COMMIT termine la transaction ouverte par psycopg : le SQL devient durable, la ligne de ledger non, et le chemin d'erreur imprime « rolled back » sur du travail qui ne revient pas.

## La garde est désormais une ALLOW-LIST

Chaque instruction de premier niveau doit être d'une forme **prouvée** rejouable : `SET`/`RESET`, `SELECT`, `CREATE ... IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION|VIEW|PROCEDURE|TRIGGER|RULE`, `COMMENT ON`, `GRANT`/`REVOKE`, `INSERT ... ON CONFLICT | WHERE NOT EXISTS`, et un bloc `DO` **dont le corps ne contient aucun verbe d'écriture**. Tout le reste est refusé **en le nommant**. Élargir cette liste devient un acte délibéré.

Les blocs `DO` comptent : `20260429` en utilise deux comme post-conditions (`SELECT COUNT(*) INTO` puis `RAISE EXCEPTION`). Les refuser en bloc aurait refusé le fichier même que la fonctionnalité doit réparer.

| | avant | après |
|---|---:|---:|
| fichiers déclarés rejouables | **301 / 303** | **116 / 302** |
| `20260429` (la cible) | accepté | **accepté** ✅ |
| `20260104` (DROP de 241 lignes) | **accepté** ❌ | refusé, DROP cité ✅ |
| 47 fichiers à `BEGIN`/`COMMIT` | 46 acceptés ❌ | **0 accepté** ✅ |

Le lexer n'est pas un détail : `20260429` conserve un `INSERT INTO kg_safety_triggers` **entier et désactivé** dans un bloc `/* ... */` — « NE PAS DÉCOMMENTER sans nouvelle ADR ». Une vérification au grep le signale comme danger de duplication de règles de **sécurité**, alors que c'est du texte mort. Assertion dédiée.

## Les autres gardes

- **`reapply_precheck()`** — refuse si la ligne n'existe pas, si son statut n'est pas `applied`, s'il n'y a pas de drift, ou si le fichier est `@non_transactional`.
- **`_assert_in_transaction()`** — ceinture-bretelles : la transaction doit être ouverte avant d'écrire la ligne de ledger, et encore avant le commit. Plus jamais de « rolled back » imprimé sans l'avoir constaté.
- **Préflight de privilèges** — `has_column_privilege` sur `checksum`/`runner`/`git_sha`, rôle courant **nommé**, au lieu d'un `42501` nu.
- **`UPDATE` gardé sur l'ANCIEN checksum**, `rowcount == 1` exigé sinon rollback.
- **Colonne `note`** (additive) : ancien checksum, ancien runner, ancien `applied_at` conservés.

**87 assertions** au `--self-test`, dont les deux fichiers réels qui épinglent les deux directions de la garde.

## Injection de commande, même fichier

`exclude_ids`, `limit` et `confirm` étaient interpolés directement dans des blocs `run:`, sur un runner qui porte `DATABASE_URL`. Ils passent désormais par l'environnement — les trois, pas un sur trois.

## Ce que cette PR ne fait pas

Merger **n'exécute rien**. `--reapply` est un `workflow_dispatch` manuel, exclusif des autres modes, refusé sous `dry_run`, soumis au jeton `confirm=APPLY`.

Le chemin base n'est **pas** testé ici (pas de `DATABASE_URL` en local).

**Défaut préexistant signalé, hors périmètre :** le chemin transactionnel de `apply_migration()` envoie lui aussi le fichier entier en un seul `execute()`, et porte donc la même faille du `COMMIT` sur ces 47 fichiers. PR séparée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
