### PR TITLE
feat(migrations): `--only` — nommer ce qu'on applique, au lieu de compter la file

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -44,6 +44,14 @@ on:
         description: 'Apply at most N migrations this run (blank = no limit).'
         required: false
         default: ''
+      only_ids:
+        description: |
+          Apply EXACTLY these pending migrations (comma-separated ids) and nothing
+          else. Refuses an unknown id or one already in the ledger, and prints the
+          earlier pending migrations it steps over. Combine with dry_run=true to
+          preview. Blank = normal queue order.
+        required: false
+        default: ''
       baseline_only:
         description: |
           Mark every local migration as already-applied without running its SQL.
@@ -93,6 +101,12 @@ jobs:
           echo "::error::baseline_only cannot be combined with status_only / dry_run / limit. Pick one mode per run."
           exit 1
 
+      - name: 🛑 Reject only_ids combined with another mode
+        if: ${{ inputs.only_ids != '' && (inputs.baseline_only || inputs.status_only || inputs.limit != '' || inputs.reapply_id != '') }}
+        run: |
+          echo "::error::only_ids cannot be combined with baseline_only / status_only / limit / reapply_id. Pick one mode per run."
+          exit 1
+
       - name: 🛑 Reject reapply combined with another mode
         if: ${{ inputs.reapply_id != '' && (inputs.baseline_only || inputs.status_only || inputs.limit != '') }}
         run: |
@@ -127,6 +141,7 @@ jobs:
           # Operator-supplied strings reach the shell as env vars, never as `${{ }}`
           # interpolation inside `run:` — this runner holds DATABASE_URL.
           REAPPLY_ID: ${{ inputs.reapply_id }}
+          ONLY_IDS: ${{ inputs.only_ids }}
           EXCLUDE_IDS: ${{ inputs.exclude_ids }}
           LIMIT: ${{ inputs.limit }}
         run: |
@@ -144,6 +159,9 @@ jobs:
           else
             if [ "${{ inputs.dry_run }}" = "true" ]; then
               ARGS+=("--dry-run")
+            fi
+            if [ -n "$ONLY_IDS" ]; then
+              ARGS+=("--only" "$ONLY_IDS")
             fi
             if [ -n "$LIMIT" ]; then
               ARGS+=("--limit" "$LIMIT")

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -29,6 +29,7 @@ CLI
                                         --no-bootstrap
     python3 apply-supabase-migration.py --dry-run
     python3 apply-supabase-migration.py [--limit N]
+    python3 apply-supabase-migration.py --only 20260529_xtr_msg_crm_indexes
 
 Env vars consumed
 =================
@@ -1050,8 +1051,104 @@ def run_self_test() -> int:
         _r = not_replayable(_destructive.read_text(encoding="utf-8"))
         assert any("DROP TABLE IF EXISTS" in x for x in _r), _r
 
+    # 8. --only selection --------------------------------------------------
+    _mk = lambda i, c="c": LocalMigration(id=i, path=Path(i + ".sql"),
+                                          checksum=c, non_transactional=False)
+    _local = [_mk("20260101_a"), _mk("20260202_b"), _mk("20260303_c"),
+              _mk("20260404_d")]
+    _remote = {"20260202_b": RemoteMigration("20260202_b", "c", "applied",
+                                             "2026-02-02", "gh-actions:1")}
+
+    # Names exactly one file; steps over the pending ones that sort earlier.
+    _sel, _skip, _err = select_only(_local, _remote, "20260404_d")
+    assert _err == [] and [m.id for m in _sel] == ["20260404_d"], (_sel, _err)
+    assert _skip == ["20260101_a", "20260303_c"], _skip   # 20260202_b is applied
+
+    # Typed order does not matter : the engine's file order wins.
+    _sel, _skip, _err = select_only(_local, _remote, "20260404_d,20260101_a")
+    assert [m.id for m in _sel] == ["20260101_a", "20260404_d"], _sel
+    assert _skip == ["20260303_c"], _skip
+
+    # Duplicates and whitespace are tolerated.
+    _sel, _, _err = select_only(_local, _remote, " 20260101_a , 20260101_a ")
+    assert _err == [] and [m.id for m in _sel] == ["20260101_a"]
+
+    # Nothing selected earlier than the last one -> nothing stepped over.
+    _sel, _skip, _err = select_only(_local, _remote, "20260101_a")
+    assert _skip == [], _skip
+
+    # Refusals name the offender, and select nothing at all.
+    _sel, _, _err = select_only(_local, _remote, "20260101_a,20260909_ghost")
+    assert _sel == [] and any("20260909_ghost" in e and "no such file" in e
+                              for e in _err), _err
+    _sel, _, _err = select_only(_local, _remote, "20260202_b")
+    assert _sel == [] and any("not pending" in e and "applied" in e
+                              for e in _err), _err
+    assert select_only(_local, _remote, "")[2] != []
+    assert select_only(_local, _remote, " , ")[2] != []
+
     print("OK — all self-tests passed.")
     return 0
+
+
+# ── Selecting WHAT to apply ─────────────────────────────────────────────────
+#
+# `--limit N` applies the first N pending migrations in file order. That is a
+# positional hack, not a selection : to reach one file you must accept every file
+# before it. Measured on this repo today — applying `20260529_xtr_msg_crm_indexes`
+# needs `--limit 13`, which also applies twelve migrations nobody asked for,
+# including one that creates three tables and one that leaves a 5s
+# statement_timeout on the session.
+#
+# `--only ID[,ID...]` names what runs. Nothing else runs. This is the primitive
+# every mature migration tool has (Flyway `target`, Sqitch `deploy --to`), and
+# its absence is what made the apply queue head-blocked : an undecided migration
+# at the front held back every migration behind it.
+#
+# Stepping over earlier pending migrations is a real risk the engine cannot
+# evaluate — it does not know dependencies. So it never does it silently : the
+# skipped ids are printed and written to the job summary, and `--dry-run` shows
+# them before anything runs.
+
+
+def select_only(local, remote, only_csv: str):
+    """(selected, skipped_earlier, errors) for --only. Pure : no database.
+
+    `selected` comes back in the engine's canonical file order, whatever order
+    the operator typed. `skipped_earlier` lists pending migrations that sort
+    before the last selected one and are NOT selected — what this run steps over.
+    """
+    wanted, seen = [], set()
+    for raw in only_csv.split(","):
+        mid = raw.strip()
+        if mid and mid not in seen:
+            seen.add(mid)
+            wanted.append(mid)
+
+    if not wanted:
+        return [], [], ["--only was given no migration id"]
+
+    by_id = {m.id: m for m in local}
+    errors = []
+    for mid in wanted:
+        if mid not in by_id:
+            errors.append(f"{mid}: no such file under {MIGRATIONS_DIR}/")
+        elif mid in remote:
+            errors.append(
+                f"{mid}: already recorded in the ledger "
+                f"(status={remote[mid].status}) — not pending"
+            )
+    if errors:
+        return [], [], errors
+
+    selected = [m for m in local if m.id in seen]
+    last_idx = local.index(selected[-1])
+    skipped = [
+        m.id
+        for idx, m in enumerate(local)
+        if idx < last_idx and m.id not in seen and m.id not in remote
+    ]
+    return selected, skipped, []
 
 
 # ── Re-apply a drifted migration ────────────────────────────────────────────
@@ -1431,6 +1528,15 @@ def main(argv: list[str]) -> int:
         help="Show the apply plan without writing.",
     )
     parser.add_argument(
+        "--only", type=str, default="", metavar="ID[,ID...]",
+        help=(
+            "Apply exactly these pending migrations and nothing else, in file "
+            "order. Refuses an unknown id or one already in the ledger. Prints "
+            "the earlier pending migrations it steps over — the engine does not "
+            "know dependencies, so that judgement stays with you."
+        ),
+    )
+    parser.add_argument(
         "--limit", type=int, default=None,
         help="Apply at most N migrations this run (staged rollouts).",
     )
@@ -1457,6 +1563,14 @@ def main(argv: list[str]) -> int:
 
     if args.self_test:
         return run_self_test()
+
+    if args.only and (args.limit is not None or args.baseline or args.status
+                      or args.reapply):
+        fail(
+            2,
+            "--only is exclusive : it cannot be combined with --limit, "
+            "--baseline, --status or --reapply.",
+        )
 
     if args.no_bootstrap and (not args.status or args.reapply or args.baseline):
         fail(
@@ -1533,10 +1647,19 @@ def main(argv: list[str]) -> int:
             )
 
         pending = [m for m in local if m.id not in remote]
-        if args.limit is not None:
+        skipped_earlier: list[str] = []
+        if args.only:
+            pending, skipped_earlier, errors = select_only(
+                local, remote, args.only
+            )
+            if errors:
+                for e in errors:
+                    sys.stderr.write(f"[apply-supabase-migration] {e}\n")
+                fail(10, "--only refused — nothing was applied.")
+        elif args.limit is not None:
             pending = pending[: max(0, args.limit)]
 
-        # GitHub Step Summary (always)
+        # GitHub Step Summary — built once, written once.
         plan_lines = ["## Migration plan", ""]
         plan_lines.append("| Status | ID | Mode |")
         plan_lines.append("| --- | --- | --- |")
@@ -1545,10 +1668,32 @@ def main(argv: list[str]) -> int:
                 state = "✅ applied"
             elif m in pending:
                 state = "⏳ pending"
+            elif args.only:
+                state = "⏸️ not selected (--only)"
             else:
                 state = "⏸️ deferred (limit)"
             mode = "non-transactional" if m.non_transactional else "transactional"
             plan_lines.append(f"| {state} | `{m.id}` | {mode} |")
+
+        if skipped_earlier:
+            print()
+            print(
+                f"NOTE — this run steps over {len(skipped_earlier)} pending "
+                "migration(s) that sort earlier. The engine cannot check "
+                "dependencies; that judgement is yours:"
+            )
+            for mid in skipped_earlier:
+                print(f"  skipped  {mid}")
+            plan_lines += [
+                "",
+                f"### Stepped over ({len(skipped_earlier)})",
+                "",
+                "Pending migrations that sort earlier and are NOT part of this run.",
+                "",
+                "| ID |",
+                "| --- |",
+            ] + [f"| `{mid}` |" for mid in skipped_earlier] + [""]
+
         write_step_summary(plan_lines)
 
         if not pending:


### PR DESCRIPTION
## Le défaut

`--limit N` applique les **N premières** migrations en attente, dans l'ordre des fichiers. Ce n'est pas une sélection, c'est un **hack positionnel** : pour atteindre un fichier, il faut accepter tout ce qui le précède.

Mesuré sur la file d'aujourd'hui (57 en attente), pas supposé. Appliquer `20260529_xtr_msg_crm_indexes` — le correctif d'index invalide d'A5 (#1382) — exige `--limit 13`, ce qui applique **aussi douze migrations que personne n'a demandées** :

```
20260429_diag_maintenance_via_kg
20260513_default_privileges_data_api_post_oct30   ← laisse statement_timeout='5s' sur le rôle
20260520_supplier_truth_v1                        ← crée 3 tables, 2 index, 2 vues
20260521_seo_sitemap_freshness_000_enum
20260521_seo_sitemap_freshness_001_alert_rpc
20260522_vehicle_page_cached_volatile
20260524_create_trend_signals
20260526_seo_cwv_raw
20260527_seo_cwv_aggregation
20260528_seo_event_runtime_errors
20260528_xtr_msg_crm_v0
20260529_seo_cwv_dashboard_rpcs
```

C'est ce défaut, et pas un autre, qui rendait la file « bloquée par sa tête » : une migration en attente d'une décision produit (`20260520_supplier_truth_v1`) retenait toutes celles derrière elle. C'est aussi ce qui a rendu le séquencement de la réconciliation du ledger si périlleux à écrire.

## Le correctif

`--only ID[,ID...]` nomme ce qui tourne. Rien d'autre ne tourne. C'est la primitive qu'ont tous les moteurs matures — Flyway `target`, Sqitch `deploy --to` — et dont l'absence coûtait cher ici.

```bash
python3 scripts/ci/apply-supabase-migration.py --only 20260529_xtr_msg_crm_indexes --dry-run
```

- **Refuse en nommant** : id inconnu → `no such file under backend/supabase/migrations/` ; id déjà au ledger → `already recorded in the ledger (status=applied) — not pending`. Dans les deux cas **rien n'est sélectionné du tout** (exit 10, aucune écriture) — pas d'application partielle silencieuse.
- **L'ordre tapé n'a pas d'importance** : l'ordre canonique du moteur s'applique. Doublons et espaces tolérés.
- **Exclusif** de `--limit` / `--baseline` / `--status` / `--reapply` (exit 2, les quatre vérifiés).
- **Compose avec `--dry-run`** : on prévisualise exactement ce qui va tourner.

### Enjamber n'est jamais silencieux

Sauter des migrations en attente plus anciennes est un **vrai risque** que le moteur **ne peut pas** évaluer — il ignore les dépendances entre fichiers. Il ne le fait donc jamais en silence : les ids enjambés sont imprimés sur stdout **et** écrits dans le résumé de job, sous `### Stepped over (N)`, et `--dry-run` les montre **avant** que quoi que ce soit ne tourne. La décision reste à l'opérateur — mais elle est éclairée.

### Deux défauts de la zone touchée, corrigés au passage

1. `write_step_summary(plan_lines)` était appelé **deux fois** → le plan était écrit en double dans le résumé de job.
2. Le retour anticipé `if not pending: return 0` était **avant** l'écriture du résumé → un run sans rien à appliquer ne produisait **aucun** résumé. La région est restructurée : construire une fois, écrire une fois, **avant** le retour anticipé.
3. Le libellé `⏸️ deferred (limit)` mentait sous `--only` → `⏸️ not selected (--only)`.

## Vérification

```
$ python3 scripts/ci/apply-supabase-migration.py --self-test
OK — all self-tests passed.
  97 assertions au self-test          (10 dédiées à select_only)

$ ... --only X --limit 1      → exit 2  «--only is exclusive : it cannot be combined with…»
$ ... --only X --baseline     → exit 2
$ ... --only X --status       → exit 2
$ ... --only X --reapply Y    → exit 2
```

Le tableau « avant/après » ci-dessus est reproduit hors-ligne par `select_only()` (fonction **pure**, aucune base) contre les 302 fichiers réels et la liste des 57 en attente.

**Non vérifié ici** : le chemin base de données. `--only` réutilise la boucle d'application existante sans la modifier — il ne fait que restreindre la liste `pending` avant le plan. Aucun `DATABASE_URL` en local ; la première exécution réelle sera un `--dry-run`.

## Périmètre

Moteur de migration + input `only_ids` du workflow (passé par `env:`, comme les autres, pas d'interpolation dans un `run:`). **Zéro** changement runtime applicatif, zéro migration appliquée par cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)