### PR TITLE
fix(migrations): préserver `search_path` et ACL dans deux migrations en attente

### DIFF
--- a/backend/supabase/migrations/20260605_vlevel_capture_db_only_functions.sql
+++ b/backend/supabase/migrations/20260605_vlevel_capture_db_only_functions.sql
@@ -43,6 +43,7 @@ SET statement_timeout = '60s';
 CREATE OR REPLACE FUNCTION public.propagate_vlevel_per_typeid(p_pg_id bigint)
  RETURNS TABLE(updated bigint)
  LANGUAGE plpgsql
+ SET search_path = public
 AS $function$
 BEGIN
   RETURN QUERY
@@ -88,6 +89,7 @@ $function$;
 CREATE OR REPLACE FUNCTION public.validate_vlevel_integrity()
  RETURNS trigger
  LANGUAGE plpgsql
+ SET search_path = public
 AS $function$
 DECLARE
   v_existing_level TEXT;

--- a/backend/supabase/migrations/20260611_quality_features_r3_guide_semantics.sql
+++ b/backend/supabase/migrations/20260611_quality_features_r3_guide_semantics.sql
@@ -375,8 +375,8 @@ $function$;
 -- Restauration de l'ACL vivante après le DROP + CREATE.
 --
 -- POURQUOI CE BLOC EST NÉCESSAIRE
--- `DROP FUNCTION` (l.49) détruit l'ACL avec la fonction. Le `CREATE` qui suit
--- reçoit alors :
+-- Le `DROP FUNCTION IF EXISTS public.get_page_quality_features()` plus haut détruit
+-- l'ACL en même temps que la fonction. Le `CREATE` qui suit reçoit alors :
 --   * l'EXECUTE que PostgreSQL accorde à PUBLIC par défaut sur toute fonction, et
 --   * les default privileges Supabase du rôle postgres sur le schéma public
 --     ({postgres=X, anon=X, authenticated=X, service_role=X}).
@@ -384,6 +384,9 @@ $function$;
 -- mesurée le 2026-09-04 ne l'accorde qu'à postgres / authenticated / service_role :
 --   {postgres=X/postgres,authenticated=X/postgres,service_role=X/postgres}
 -- Sans ce bloc, la migration serait une RÉGRESSION de privilège silencieuse.
+--
+-- Les instructions sont désignées par leur nom, jamais par un numéro de ligne :
+-- une référence positionnelle pourrit au premier décalage du fichier.
 -- Réf mémoire : reference_supabase_default_privileges_grant_anon_execute_on_new_functions.
 -- ----------------------------------------------------------------------------
 REVOKE ALL ON FUNCTION public.get_page_quality_features() FROM PUBLIC;

--- a/backend/supabase/migrations/20260611_quality_features_r3_guide_semantics.sql
+++ b/backend/supabase/migrations/20260611_quality_features_r3_guide_semantics.sql
@@ -41,6 +41,7 @@ CREATE OR REPLACE FUNCTION public.safe_jsonb_array_length(x jsonb)
 RETURNS integer
 LANGUAGE sql
 IMMUTABLE
+SET search_path = public
 AS $fn$
   SELECT CASE WHEN jsonb_typeof(x) = 'array' THEN jsonb_array_length(x) ELSE 0 END;
 $fn$;
@@ -121,6 +122,7 @@ RETURNS TABLE(
 )
 LANGUAGE sql
 STABLE
+SET search_path = public
 AS $function$
 WITH
 gamme_base AS (
@@ -368,6 +370,26 @@ LEFT JOIN blog_advice ba ON ba.pg_id = g.pg_id
 LEFT JOIN guide_semantics gs ON gs.pg_id = g.pg_id
 ORDER BY g.pg_alias;
 $function$;
+
+-- ----------------------------------------------------------------------------
+-- Restauration de l'ACL vivante après le DROP + CREATE.
+--
+-- POURQUOI CE BLOC EST NÉCESSAIRE
+-- `DROP FUNCTION` (l.49) détruit l'ACL avec la fonction. Le `CREATE` qui suit
+-- reçoit alors :
+--   * l'EXECUTE que PostgreSQL accorde à PUBLIC par défaut sur toute fonction, et
+--   * les default privileges Supabase du rôle postgres sur le schéma public
+--     ({postgres=X, anon=X, authenticated=X, service_role=X}).
+-- Autrement dit `anon` et `PUBLIC` récupéreraient EXECUTE alors que l'ACL LIVE
+-- mesurée le 2026-09-04 ne l'accorde qu'à postgres / authenticated / service_role :
+--   {postgres=X/postgres,authenticated=X/postgres,service_role=X/postgres}
+-- Sans ce bloc, la migration serait une RÉGRESSION de privilège silencieuse.
+-- Réf mémoire : reference_supabase_default_privileges_grant_anon_execute_on_new_functions.
+-- ----------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.get_page_quality_features() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_page_quality_features() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_page_quality_features() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_page_quality_features() TO service_role;
 
 COMMENT ON FUNCTION public.get_page_quality_features() IS
   'Features qualité par gamme pour QualityScoringEngineService (v2.2). 2026-06-11 : +7 colonnes sémantiques R3_guide (guide_criteria_count, guide_guidance_copies_label_count, guide_positive_starter_count, guide_use_cases_count, guide_profile_marker_count, guide_generic_phrase_count, guide_action_marker_count) — portage D1/D2/D3 + GENERIC_WITHOUT_ACTION du quality-gates legacy buying-guide, salvage pré-purge RAG. Additive : colonnes existantes inchangées.';

--- a/log.md
+++ b/log.md
@@ -408,11 +408,5 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 ## 2026-09-04 — fix+migrations-preserve-search-path-and-acl (auto)
 
 - **Branche** : `fix+migrations-preserve-search-path-and-acl`
-- **Décision** : fix(migrations): préserver search_path et ACL dans deux migrations en attente
-- **Sortie** : PR #1391 | commits 6720119db
-
-## 2026-09-04 — fix+migrations-preserve-search-path-and-acl (auto)
-
-- **Branche** : `fix+migrations-preserve-search-path-and-acl`
 - **Décision** : fix(migrations): désigner l'instruction par son nom, pas par son numéro de ligne (+2 other commits)
 - **Sortie** : PR #1391 | commits 04c4d72f1 e70ad7c79 6720119db

--- a/log.md
+++ b/log.md
@@ -404,3 +404,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat+engine-reapply-drifted-migration`
 - **Décision** : feat(migrations): --reapply — réparer une ligne en drift par exécution, pas par affirmation
 - **Sortie** : PR #1389 | commits 9601898bf
+
+## 2026-09-04 — fix+migrations-preserve-search-path-and-acl (auto)
+
+- **Branche** : `fix+migrations-preserve-search-path-and-acl`
+- **Décision** : fix(migrations): préserver search_path et ACL dans deux migrations en attente
+- **Sortie** : PR #1391 | commits 6720119db

--- a/log.md
+++ b/log.md
@@ -410,3 +410,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix+migrations-preserve-search-path-and-acl`
 - **Décision** : fix(migrations): préserver search_path et ACL dans deux migrations en attente
 - **Sortie** : PR #1391 | commits 6720119db
+
+## 2026-09-04 — fix+migrations-preserve-search-path-and-acl (auto)
+
+- **Branche** : `fix+migrations-preserve-search-path-and-acl`
+- **Décision** : fix(migrations): désigner l'instruction par son nom, pas par son numéro de ligne (+2 other commits)
+- **Sortie** : PR #1391 | commits 04c4d72f1 e70ad7c79 6720119db


### PR DESCRIPTION
Les deux dernières migrations que la réconciliation du ledger a laissées `pending` **pour cause de régression**. Elles recréent des fonctions qui existent déjà en base sans reproduire ce que la base porte aujourd'hui : les lancer telles quelles aurait effacé un durcissement.

Tout ci-dessous est mesuré au catalogue Postgres le 2026-09-04, pas déduit d'un en-tête de fichier.

## `20260605` — le `CREATE OR REPLACE` efface le pin

`propagate_vlevel_per_typeid(bigint)` et `validate_vlevel_integrity()` portent `proconfig = {search_path=public}` en base. Le fichier déclare leurs corps **sans clause `SET`** — or `CREATE OR REPLACE FUNCTION` **remet `proconfig` à zéro** quand la nouvelle définition n'en porte pas.

Ce fichier se présente comme une simple capture no-op de fonctions DB-only. Il aurait dépinné deux fonctions.

## `20260611` — le `DROP`+`CREATE` efface le pin **et** l'ACL

Même défaut de pin sur `get_page_quality_features()` et, moins visible, sur `safe_jsonb_array_length(jsonb)` que ce fichier recrée aussi.

Le `DROP FUNCTION` (l.49) détruit en plus l'ACL. Le `CREATE` qui suit reçoit alors :

- l'`EXECUTE` que PostgreSQL accorde à **`PUBLIC`** par défaut sur toute fonction, et
- les default privileges Supabase du rôle `postgres` sur `public` : `{postgres=X, anon=X, authenticated=X, service_role=X}`.

L'ACL **vivante** est plus étroite :

```
{postgres=X/postgres,authenticated=X/postgres,service_role=X/postgres}
```

`anon` et `PUBLIC` auraient donc **gagné** `EXECUTE` sur une fonction qui expose 66 colonnes de features qualité. Régression de privilège silencieuse. D'où le bloc `REVOKE`/`GRANT` explicite qui reproduit l'ACL mesurée.

`safe_jsonb_array_length` **n'a pas besoin** de ce traitement, et c'est délibéré : elle est en `CREATE OR REPLACE` sans `DROP`, donc son ACL survit — vérifié, elle inclut légitimement `PUBLIC` et `anon`. Seul son `proconfig` devait être reproduit.

## Vérification

**La forme du pin.** Le live rend `SET search_path TO 'public'` (via `pg_get_functiondef`) ; j'écris `SET search_path = public`. Prouvé équivalent plutôt que supposé — fonction sonde créée dans `pg_temp` à l'intérieur d'un `BEGIN … ROLLBACK`, rien n'a persisté :

```
proconfig_produit  | identique_au_live
{search_path=public} | true
```

**Lint.** squawk : `Found 0 issues in 2 files` — déjà 0 avant l'édition, donc aucune régression.

**Pas de drift.** Aucune de ces 2 migrations n'est appliquée ; elles sont `pending` au ledger. Éditer le fichier ne crée donc aucun drift de checksum.

## Périmètre

Ces fichiers **ne sont pas appliqués** par cette PR. Ils redeviennent seulement *applicables*, via `--only <id>` après revue. Le ledger est à 297 lignes / 0 non-applied ; il restera 5 en attente après ce merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)