### PR TITLE
docs(governance): retirer une référence de gate fabriquée, nommer les vrais carriers

### DIFF
--- a/.squawk.toml
+++ b/.squawk.toml
@@ -27,8 +27,12 @@ excluded_paths = [
 fail_on_violations = true         # CI must hard-fail on any default-rule violation.
 
 # Legacy WARN rules NOT in squawk's stock set, captured separately :
-#   - DISABLE RLS / GRANT public : enforced by Supabase advisors + RPC Safety Gate
-#                                  (scripts/audit/rpc-safety-gate.js).
+#   - DISABLE RLS / GRANT public : enforced by the Supabase security advisors
+#                                  (rls_disabled_in_public, rls_enabled_no_policy,
+#                                  anon/authenticated_security_definer_function_executable).
+#                                  They are the sole carrier: the RPC Safety Gate
+#                                  (ci.yml job `rpc-gate-check`) reads .rpc() call
+#                                  sites only and inspects neither GRANT nor RLS.
 #   - DELETE-no-WHERE            : runtime-relevant, not migration-shape ; out of scope.
 #   - DROP POLICY                : pattern is idempotent re-create within same migration
 #                                  — design-allowed, not a safety issue.

--- a/backend/src/modules/admin/services/seo-control.service.ts
+++ b/backend/src/modules/admin/services/seo-control.service.ts
@@ -297,9 +297,9 @@ export class SeoControlService extends SupabaseBaseService {
    * Thin wrapper around the inherited callRpc() (SupabaseBaseService) for
    * fail-loud semantics : throws on error instead of returning { data, error }.
    *
-   * MUST use callRpc (not this.supabase.rpc direct) per RPC Safety Gate
-   * (scripts/audit/rpc-safety-gate.js + .github/workflows/ci.yml). Direct
-   * supabase.rpc bypasses the governance RpcGateService.
+   * MUST use callRpc (not this.supabase.rpc direct) per the RPC Safety Gate,
+   * whose logic is inline in .github/workflows/ci.yml (job `rpc-gate-check`).
+   * Direct supabase.rpc bypasses the governance RpcGateService.
    */
   private async invokeRpc<T>(
     name: string,


### PR DESCRIPTION
## Le défaut

`scripts/audit/rpc-safety-gate.js` est cité **deux fois** dans le repo. Il n'a **jamais existé** :

```
$ git log --oneline --all -- 'scripts/audit/rpc-safety-gate*'
(vide)
```

Chemin inventé, pas fichier supprimé — le pattern de dérive nommé par l'invariant 2 de `CLAUDE.md`.

## Les deux citations ne sont pas fausses de la même façon

| fichier | ce qui est faux | correction |
|---|---|---|
| `backend/src/modules/admin/services/seo-control.service.ts` | le **chemin** seulement — le gate est réel | pointe le job `rpc-gate-check` (`ci.yml`) |
| `.squawk.toml` | le **carrier** — le RPC Safety Gate ne lit ni `GRANT` ni `RLS` | nomme les advisors Supabase, seul carrier réel |

`ci.yml` job `rpc-gate-check` grep les `.rpc(` directs hors `supabase-base.service`/`callRpc` et `exit 1` hors liste de bypass. Il n'inspecte à aucun moment `GRANT` ni `RLS` — donc l'attribuer la responsabilité « DISABLE RLS / GRANT public » était une fausse assurance.

## Le vrai carrier, mesuré et non supposé

Advisors sécurité du projet live, 201 lints agrégés :

| n | niveau | lint |
|---|---|---|
| 123 | WARN | `authenticated_security_definer_function_executable` |
| 51 | WARN | `anon_security_definer_function_executable` |
| 20 | INFO | `rls_enabled_no_policy` |
| 3 | WARN | `function_search_path_mutable` |
| 3 | WARN | `extension_in_public` |
| 1 | WARN | `vulnerable_postgres_version` |
| **0** | — | `rls_disabled_in_public` |

## Ce que cette PR ne fait pas

**Aucun détecteur ajouté.** La responsabilité est déjà portée ; on la nomme correctement. En créer un second serait l'anti-pattern explicite de `.claude/rules/guardrails.md` (« ne pas ajouter un second détecteur pour une responsabilité déjà portée ailleurs »), passe 2.

Commentaires uniquement — **zéro delta runtime**, donc pas de tag `v*` propre à cette PR : elle part avec la prochaine release runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)