### PR TITLE
fix(migrations): rendre 20260529 idempotent sur le second index aussi

### DIFF
--- a/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
+++ b/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
@@ -51,6 +51,17 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_status_active
   WHERE msg_crm_status IS NOT NULL
     AND msg_crm_status NOT IN ('won', 'lost');
 
+-- Garde de reprise, symetrique de celle posee sur `status_active`. No-op
+-- aujourd'hui : `follow_up_due` n'existe pas. Elle couvre l'interruption du
+-- build ci-dessous : le job d'application est plafonne a `timeout-minutes: 20`
+-- (.github/workflows/apply-supabase-migrations.yml) alors que l'en-tete annonce
+-- 5-20 min PAR index. Un build interrompu laisse l'index INVALIDE ; la relance
+-- verrait le nom pris et `CREATE ... IF NOT EXISTS` serait un no-op silencieux
+-- -> migration « appliquee » avec un index inutilisable. C'est exactement le
+-- defaut repare plus haut, un index plus loin. Le `.down.sql` portait deja les
+-- deux DROP ; cette ligne retablit la symetrie cote up.
+DROP INDEX CONCURRENTLY IF EXISTS idx_xtr_msg_crm_follow_up_due;
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_follow_up_due
   ON ___xtr_msg (msg_crm_next_follow_up_at)
   WHERE msg_crm_next_follow_up_at IS NOT NULL


### PR DESCRIPTION
Suite directe de #1382, trouvée en préparant l'application de `20260529`.

## Le défaut

#1382 a posé un `DROP INDEX CONCURRENTLY IF EXISTS` avant le `CREATE` de `idx_xtr_msg_crm_status_active`, parce que cet index existe aujourd'hui en `indisvalid = false`. La garde a été posée comme **réparation d'un état constaté**, pas comme garde d'idempotence — `idx_xtr_msg_crm_follow_up_due` n'existant pas, il n'en a pas reçu.

```
SET lock_timeout = '5s';
DROP INDEX CONCURRENTLY IF EXISTS idx_xtr_msg_crm_status_active;   ← garde
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_status_active …
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_follow_up_due …   ← aucune
```

## Pourquoi c'est atteignable, et pas théorique

Le job d'application est plafonné à **`timeout-minutes: 20`** ([`apply-supabase-migrations.yml:91`](.github/workflows/apply-supabase-migrations.yml#L91)) alors que l'en-tête du fichier annonce lui-même « **5-20 minutes PAR index** ».

Mesuré au catalogue (lecture seule, sans scan) :

| métrique | valeur |
|---|---|
| `reltuples` | 14 590 978 |
| `relpages` | 935 631 |
| heap | 7 879 Mo |
| `pg_stats` sur `msg_crm_status` / `msg_crm_next_follow_up_at` | **aucune ligne** |

`CREATE INDEX CONCURRENTLY` = deux parcours complets du heap par index, plus l'attente des transactions ouvertes. Une sonde bornée à 200 k lignes correspondantes a d'ailleurs **dépassé le statement_timeout**, faute d'index sur ces colonnes — ce que la migration vient précisément créer.

## Le mode d'échec

Interruption pendant le **second** build → `follow_up_due` reste **INVALIDE** → la relance voit le nom pris → `CREATE … IF NOT EXISTS` est un **no-op silencieux** → migration enregistrée « appliquée » avec un index que le planner n'utilisera jamais. C'est exactement le défaut réparé par #1382, un index plus loin.

## Pourquoi la symétrie plutôt que le timeout

Relever `timeout-minutes` toucherait **toutes** les migrations et ne couvrirait ni l'éviction du runner, ni la coupure réseau. La garde symétrique rend la reprise correcte quelle qu'en soit la cause. Le `.down.sql` portait déjà les deux `DROP` : la symétrie existait au rollback et manquait à l'aller.

**No-op aujourd'hui** (`follow_up_due` n'existe pas), **aucun coût en régime nominal**, `DROP INDEX CONCURRENTLY` ne prend qu'un `SHARE UPDATE EXCLUSIVE` (n'a jamais bloqué les writes) et un index invalide n'est de toute façon jamais utilisé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)