### PR TITLE
fix(migrations): --retry pour une migration en échec + lever le statement_timeout hérité

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -76,6 +76,15 @@ on:
           confirm=APPLY and dry_run=false. Blank = not this mode.
         required: false
         default: ''
+      retry_id:
+        description: |
+          Re-run ONE migration whose ledger row is `failed`, reopening that row
+          rather than inserting a second one. Accepts @non_transactional files
+          and a file amended since the failure (fixing the cause usually means
+          editing it) — the change is printed and recorded in `note`. Needs
+          confirm=APPLY and dry_run=false. Blank = not this mode.
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -116,6 +125,18 @@ jobs:
           echo "::error::reapply_id cannot be combined with baseline_only / status_only / limit. Pick one mode per run."
           exit 1
 
+      - name: 🛑 Reject retry combined with another mode
+        if: ${{ inputs.retry_id != '' && (inputs.baseline_only || inputs.status_only || inputs.limit != '' || inputs.reapply_id != '' || inputs.only_ids != '') }}
+        run: |
+          echo "::error::retry_id cannot be combined with baseline_only / status_only / limit / reapply_id / only_ids. Pick one mode per run."
+          exit 1
+
+      - name: 🛑 Reject retry under dry_run
+        if: ${{ inputs.retry_id != '' && inputs.dry_run }}
+        run: |
+          echo "::error::retry_id executes the migration — there is no dry-run for it. Re-run with dry_run=false and confirm=APPLY."
+          exit 1
+
       - name: 🛑 Reject reapply under dry_run
         if: ${{ inputs.reapply_id != '' && inputs.dry_run }}
         run: |
@@ -144,6 +165,7 @@ jobs:
           # Operator-supplied strings reach the shell as env vars, never as `${{ }}`
           # interpolation inside `run:` — this runner holds DATABASE_URL.
           REAPPLY_ID: ${{ inputs.reapply_id }}
+          RETRY_ID: ${{ inputs.retry_id }}
           ONLY_IDS: ${{ inputs.only_ids }}
           EXCLUDE_IDS: ${{ inputs.exclude_ids }}
           LIMIT: ${{ inputs.limit }}
@@ -152,6 +174,8 @@ jobs:
           ARGS=()
           if [ -n "$REAPPLY_ID" ]; then
             ARGS+=("--reapply" "$REAPPLY_ID")
+          elif [ -n "$RETRY_ID" ]; then
+            ARGS+=("--retry" "$RETRY_ID")
           elif [ "${{ inputs.baseline_only }}" = "true" ]; then
             ARGS+=("--baseline")
             if [ -n "$EXCLUDE_IDS" ]; then

--- a/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
+++ b/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
@@ -1,6 +1,5 @@
 -- @non_transactional
 -- squawk-ignore-file ban-concurrent-index-creation-in-transaction
--- squawk-ignore-file require-timeout-settings
 --
 -- Migration: 20260529_xtr_msg_crm_indexes
 -- Follow-up structurel de #784 (mini-CRM V0). Crée les 2 indexes partiels
@@ -29,18 +28,46 @@
 -- SHARE UPDATE EXCLUSIVE (pas de blocage des writes) et un index invalide
 -- n'est jamais utilisé par le planner : retrait sans effet sur le runtime.
 --
--- squawk `require-timeout-settings` ignoré à dessein : un statement_timeout
--- sur un build CONCURRENTLY de 5-20 min le tuerait en laissant… un index
--- invalide (exactement le défaut réparé ici). Seul lock_timeout est posé
--- (fail-fast si un lock est tenu, sans démarrer le build).
+-- TIMEOUTS — corrigé après l'incident du 2026-09-04 (run 33839602437).
+-- Ce fichier portait `-- squawk-ignore-file require-timeout-settings`. Il est
+-- RETIRÉ : la règle qu'il faisait taire est exactement celle qui aurait prédit
+-- l'incident — « Missing `set statement_timeout` before potentially slow
+-- operations », pointant le DROP INDEX CONCURRENTLY. Vérifié avec la version
+-- utilisée par la CI (squawk 2.52.1, cf. ci.yml) : sans le SET ci-dessous la
+-- règle lève et sort en rc=1 ; avec lui, 0 problème. Un garde juste, réduit au
+-- silence par une justification fausse.
+-- La version précédente de cet en-tête raisonnait ainsi : « ne pas poser de
+-- statement_timeout, sinon il tuerait le build CONCURRENTLY ». Le raisonnement
+-- est faux, et c'est lui qui a produit l'incident : NE PAS poser la valeur ne
+-- veut pas dire « aucun timeout », cela veut dire HÉRITER celle du rôle. Sur ce
+-- projet Supabase, `ALTER ROLE postgres SET statement_timeout` vaut 60 s — et le
+-- runner se connecte précisément comme `postgres` :
+--   SELECT setconfig FROM pg_db_role_setting s JOIN pg_roles r ON r.oid=s.setrole
+--    WHERE r.rolname='postgres';   -->  {search_path=…, statement_timeout=60s}
+-- Le run a donc été tué à 60,588 s (`QueryCanceled`), laissant l'index en
+-- indisvalid=false — exactement le défaut que ce fichier répare.
+-- 60 s n'auraient jamais suffi : un parcours complet du heap de ___xtr_msg est
+-- mesuré à ~54 s (40 000 pages en 2 305 ms sur 935 631 pages), et un
+-- CREATE INDEX CONCURRENTLY en fait DEUX par index.
+-- D'où `statement_timeout = 0` EXPLICITE ci-dessous. La borne extérieure reste
+-- le `timeout-minutes: 20` du job (~4 min de parcours pour les deux index :
+-- confortable). `reset_session()` (#1388) restaure le défaut du rôle avant la
+-- migration suivante — la levée ne fuit pas.
+-- `lock_timeout` reste à 5 s : fail-fast si un verrou est tenu, sans démarrer
+-- le build.
 --
--- Durée typique : 5-20 minutes par index (CONCURRENTLY = 2 scans + suivi
--- des writes). N'occupe pas de lock bloquant → safe sur prod hot.
+-- Durée attendue : ~2 min par index. Mesure du 2026-09-04 (EXPLAIN ANALYZE,
+-- BUFFERS sur une plage de ctid) : 40 000 pages lues à froid en 2 305 ms, soit
+-- ~54 s pour les 935 631 pages du heap ; CONCURRENTLY en fait 2 par index, plus
+-- l'attente des transactions concurrentes. L'estimation « 5-20 min » d'origine
+-- n'était pas mesurée. N'occupe aucun lock bloquant → safe sur prod hot.
 --
 -- Rollback : companion .down.sql avec DROP INDEX CONCURRENTLY (symétrique
 -- sur le lock side ; SHARE UPDATE EXCLUSIVE ne bloque pas les writes).
 
 SET lock_timeout = '5s';
+-- Explicite, et non omis : voir l'en-tête. 0 = pas de limite pour CETTE session.
+SET statement_timeout = 0;
 
 -- Réparation : retire l'index INVALIDE laissé par le build interrompu
 -- (voir en-tête). No-op si l'index n'existe pas ou a déjà été réparé.

--- a/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
+++ b/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
@@ -53,8 +53,27 @@
 -- le `timeout-minutes: 20` du job (~4 min de parcours pour les deux index :
 -- confortable). `reset_session()` (#1388) restaure le défaut du rôle avant la
 -- migration suivante — la levée ne fuit pas.
--- `lock_timeout` reste à 5 s : fail-fast si un verrou est tenu, sans démarrer
--- le build.
+-- `lock_timeout` est AUSSI à 0, et ce n'est pas un oubli. La version précédente
+-- le posait à 5 s « pour échouer vite sans démarrer le build » — faux :
+-- `lock_timeout` s'applique à TOUT verrou, « table, index, ligne ou autre objet »,
+-- y compris implicitement acquis (doc PostgreSQL, runtime-config-client). Or un
+-- CREATE INDEX CONCURRENTLY attend TROIS fois les transactions existantes (doc
+-- sql-createindex), et chaque attente est une acquisition de verrou sur une
+-- transaction virtuelle. À 5 s, toute transaction concurrente un peu longue
+-- aurait tué le build APRÈS création de l'entrée de catalogue → index invalide,
+-- le défaut même que ce fichier répare.
+-- Le contre-argument (« à 0, une attente non bornée finit tuée par le job à
+-- 20 min et laisse 'applying' orphelin ») ne tient pas SUR CETTE BASE : tout
+-- bloqueur potentiel est lui-même borné par son statement_timeout de rôle
+-- (postgres/service_role 60 s, authenticated 8 s — pg_db_role_setting, mesuré
+-- le 2026-09-07). Une attente de verrou du CIC ne peut donc pas dépasser ~60 s
+-- par phase, loin des 20 min ; alors qu'à 5 s, n'importe quelle requête
+-- analytique d'une minute sur cette table de 15 M de lignes tuerait le build.
+-- Un échec de verrou reste bruyant (55P03 → mark_failed → 'failed' → --retry).
+-- Note : l'incident 2026-09-04 n'est PAS mort dans une attente : indisready=false
+-- + 60,6 s = mort pendant le PREMIER scan (~54 s), avant index_set_state_flags.
+-- Le verrou SHARE UPDATE EXCLUSIVE pris au démarrage est faible et rarement
+-- contendu : la borne extérieure utile est le `timeout-minutes` du job.
 --
 -- Durée attendue : ~2 min par index. Mesure du 2026-09-04 (EXPLAIN ANALYZE,
 -- BUFFERS sur une plage de ctid) : 40 000 pages lues à froid en 2 305 ms, soit
@@ -65,12 +84,16 @@
 -- Rollback : companion .down.sql avec DROP INDEX CONCURRENTLY (symétrique
 -- sur le lock side ; SHARE UPDATE EXCLUSIVE ne bloque pas les writes).
 
-SET lock_timeout = '5s';
+SET lock_timeout = 0;
 -- Explicite, et non omis : voir l'en-tête. 0 = pas de limite pour CETTE session.
 SET statement_timeout = 0;
 
 -- Réparation : retire l'index INVALIDE laissé par le build interrompu
--- (voir en-tête). No-op si l'index n'existe pas ou a déjà été réparé.
+-- (voir en-tête). No-op si l'index n'existe pas. Coût assumé : sur une reprise
+-- (--retry) après un succès PARTIEL (1er index valide, 2e interrompu), ce DROP
+-- retire aussi un index VALIDE et le reconstruit (~2 min). Un DROP conditionnel
+-- sur indisvalid exigerait un bloc DO, impossible avec CONCURRENTLY (non
+-- transactionnel) : la simplicité idempotente vaut ces 2 minutes.
 DROP INDEX CONCURRENTLY IF EXISTS idx_xtr_msg_crm_status_active;
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_status_active
@@ -81,8 +104,8 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_status_active
 -- Garde de reprise, symetrique de celle posee sur `status_active`. No-op
 -- aujourd'hui : `follow_up_due` n'existe pas. Elle couvre l'interruption du
 -- build ci-dessous : le job d'application est plafonne a `timeout-minutes: 20`
--- (.github/workflows/apply-supabase-migrations.yml) alors que l'en-tete annonce
--- 5-20 min PAR index. Un build interrompu laisse l'index INVALIDE ; la relance
+-- (.github/workflows/apply-supabase-migrations.yml) ; ~2 min par index mesures
+-- (voir l'en-tete). Un build interrompu laisse l'index INVALIDE ; la relance
 -- verrait le nom pris et `CREATE ... IF NOT EXISTS` serait un no-op silencieux
 -- -> migration « appliquee » avec un index inutilisable. C'est exactement le
 -- defaut repare plus haut, un index plus loin. Le `.down.sql` portait deja les

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -31,6 +31,7 @@ CLI
     python3 apply-supabase-migration.py --dry-run
     python3 apply-supabase-migration.py [--limit N]
     python3 apply-supabase-migration.py --only 20260529_xtr_msg_crm_indexes
+    python3 apply-supabase-migration.py --retry 20260529_xtr_msg_crm_indexes
 
 Env vars consumed
 =================
@@ -511,6 +512,43 @@ def mark_failed(cur, migration_id: str, error: str) -> "None":
     )
 
 
+def reopen_failed(
+    cur, mig: LocalMigration, runner: str, git_sha: str, note: str
+) -> "None":
+    """Move a 'failed' ledger row back to 'applying' for ONE retry.
+
+    UPDATE in place, never DELETE + INSERT : the ledger grants service_role no
+    DELETE at all, and keeping the row keeps its primary key — so the audit
+    trail in `note` stays continuous across the retry instead of restarting.
+
+    The WHERE clause re-checks `status = 'failed'`, so a row that changed
+    between the precheck and here touches nothing and trips the rowcount guard
+    below rather than silently reopening a live or already-applied migration.
+    """
+    cur.execute(
+        """
+        UPDATE infra.schema_migrations
+        SET status        = 'applying',
+            checksum      = %s,
+            started_at    = NOW(),
+            applied_at    = NULL,
+            execution_ms  = NULL,
+            runner        = %s,
+            git_sha       = %s,
+            error_message = NULL,
+            note          = %s
+        WHERE id = %s AND status = 'failed'
+        """,
+        (mig.checksum, runner, git_sha, note[:2000], mig.id),
+    )
+    if cur.rowcount != 1:
+        raise RuntimeError(
+            f"{mig.id}: expected exactly one 'failed' row to reopen, the UPDATE "
+            f"touched {cur.rowcount}. The ledger changed between the precheck "
+            "and now — nothing was applied."
+        )
+
+
 # ── Session hygiene between migrations ──────────────────────────────────────
 #
 # The engine reuses ONE connection for the whole run. A migration that issues a
@@ -575,9 +613,16 @@ def reset_session(conn) -> "None":
 
 
 def apply_migration(
-    conn, mig: LocalMigration, runner: str, git_sha: str
+    conn, mig: LocalMigration, runner: str, git_sha: str,
+    *, resume_note: "str | None" = None,
 ) -> int:
-    """Apply one migration. Returns elapsed ms. Raises on failure."""
+    """Apply one migration. Returns elapsed ms. Raises on failure.
+
+    `resume_note` switches the ledger bookkeeping from "insert a new row" to
+    "reopen the existing 'failed' one" (--retry). The SQL execution itself is
+    byte-for-byte the same path in both cases : a retry must not be a second,
+    subtly different way of running a migration.
+    """
     sql = mig.path.read_text(encoding="utf-8")
     start = time.monotonic()
 
@@ -587,7 +632,10 @@ def apply_migration(
         # the next run will refuse to overwrite (Case D in the verify flow).
         conn.autocommit = True
         with conn.cursor() as cur:
-            insert_applying(cur, mig, runner, git_sha)
+            if resume_note is None:
+                insert_applying(cur, mig, runner, git_sha)
+            else:
+                reopen_failed(cur, mig, runner, git_sha, resume_note)
         try:
             # Send each statement in its OWN execute(). A multi-statement
             # simple-query string is wrapped by Postgres in an implicit
@@ -613,9 +661,16 @@ def apply_migration(
     conn.autocommit = False
     try:
         with conn.cursor() as cur:
+            if resume_note is not None:
+                # Same transaction as the SQL : if the retry fails again, the
+                # reopen rolls back with it and the row stays 'failed'.
+                reopen_failed(cur, mig, runner, git_sha, resume_note)
             cur.execute(sql)
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            insert_applied_tx(cur, mig, elapsed_ms, runner, git_sha)
+            if resume_note is None:
+                insert_applied_tx(cur, mig, elapsed_ms, runner, git_sha)
+            else:
+                mark_applied(cur, mig.id, elapsed_ms)
         conn.commit()
     except Exception:
         conn.rollback()
@@ -790,6 +845,10 @@ def status_step_summary(rows, summary) -> "list[str]":
             f"### Blockers ({len(blockers)})",
             "",
             "These stop every apply **and every dry-run** (exit 5) until resolved.",
+            "",
+            "Ways out, by state: `failed` → `--retry ID` (re-runs it, reopening "
+            "the row); `drift` → `--reapply ID`; `applying` → establish by hand "
+            "whether a run is still live before touching anything.",
             "",
             "| ID | State |",
             "| --- | --- |",
@@ -1204,6 +1263,20 @@ def run_self_test() -> int:
         LocalMigration("x", Path("x.sql"), "bbb", True), _rm, _ok_sql)
     assert "not replayable" in reapply_precheck(_lm, _rm, "DROP TABLE IF EXISTS t;")
 
+    # retry_precheck — the mirror image : only a 'failed' row is retryable.
+    _failed = RemoteMigration("x", "aaa", "failed", None, "gh-actions:1")
+    assert retry_precheck(_lm, _failed) is None
+    # An amended file is the NORMAL case for a retry, never a refusal.
+    assert retry_precheck(
+        LocalMigration("x", Path("x.sql"), "zzz", False), _failed) is None
+    # …including a @non_transactional one, which --reapply refuses outright.
+    assert retry_precheck(
+        LocalMigration("x", Path("x.sql"), "zzz", True), _failed) is None
+    assert "not recorded" in retry_precheck(_lm, None)
+    assert "nothing to retry" in retry_precheck(_lm, _rm)
+    assert "still live" in retry_precheck(
+        _lm, RemoteMigration("x", "aaa", "applying", None, None))
+
     # The two real files that pin both directions of this gate.
     _target = MIGRATIONS_DIR / "20260429_diag_maintenance_via_kg.sql"
     if _target.exists():
@@ -1438,6 +1511,35 @@ def reapply_precheck(mig, row, sql) -> "str | None":
     return None
 
 
+def retry_precheck(mig, row) -> "str | None":
+    """Why `mig` cannot be retried, or None when it can.
+
+    Pure : no database. `row` is the RemoteMigration or None.
+
+    Deliberately does NOT require the checksum to match. A retry exists to run
+    a migration again AFTER the cause of its failure was removed, and removing
+    it usually means editing the file. The change is printed and recorded in
+    `note` — refusing it would leave a failed migration with no governed way
+    back, which is the hole this primitive closes.
+    """
+    if row is None:
+        return "not recorded in the ledger — a normal apply already covers this"
+    if row.status == "applied":
+        return (
+            "ledger status is 'applied' — nothing to retry "
+            "(--reapply covers a drifted 'applied' row)"
+        )
+    if row.status == "applying":
+        return (
+            "ledger status is 'applying' — either a run is still live, or one "
+            "died before it could record the outcome. Establish which by hand "
+            "first: retrying under a live run would execute the file twice"
+        )
+    if row.status != "failed":
+        return f"ledger status is '{row.status}', not 'failed'"
+    return None
+
+
 def _assert_in_transaction(conn, when: str) -> "None":
     """Fail loudly if our transaction is no longer open.
 
@@ -1544,6 +1646,106 @@ def run_reapply(conn, local, remote, target_id: str, runner: str, git_sha: str) 
          f"- previous checksum : `{row.checksum}`",
          f"- new checksum      : `{mig.checksum}`",
          f"- previous record   : {row.runner or '—'} at {row.applied_at or '—'}",
+         ""]
+    )
+    return 0
+
+
+# ── Retry (Flyway repair + re-run / Sqitch revert-free rerun) ────────────
+
+
+def run_retry(
+    conn, local, remote, target_id: str, runner: str, git_sha: str
+) -> int:
+    """Re-run ONE migration whose ledger row is 'failed'.
+
+    Closes a real hole: once a migration fails, its id IS in the ledger, so it
+    is no longer pending; `--only` refuses a recorded id, `--reapply` refuses a
+    row that is not a drifted 'applied' (and refuses @non_transactional files
+    outright), and `insert_applying` is a bare INSERT that would raise on the
+    primary key. Without this, a failed migration is unreachable by every
+    governed path and the whole queue stays blocked behind it (exit 5).
+    """
+    mig = next((m for m in local if m.id == target_id), None)
+    if mig is None:
+        fail(11, f"{target_id}: no such file under {MIGRATIONS_DIR}/.")
+
+    row = remote.get(target_id)
+    why = retry_precheck(mig, row)
+    if why:
+        fail(11, f"{target_id}: {why}.")
+
+    # `checksum` and `started_at` sit OUTSIDE the service_role column grant :
+    # only the table owner can reopen a row. Say so plainly instead of
+    # surfacing a bare 42501 halfway through.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT current_user,
+                   has_column_privilege('infra.schema_migrations',
+                                        'checksum', 'UPDATE'),
+                   has_column_privilege('infra.schema_migrations',
+                                        'started_at', 'UPDATE')
+            """
+        )
+        who, c_ok, s_ok = cur.fetchone()
+    if not (c_ok and s_ok):
+        fail(
+            9,
+            f"role '{who}' cannot UPDATE checksum/started_at on "
+            "infra.schema_migrations (column-scoped grant). --retry needs the "
+            "table owner — the DATABASE_URL the engine bootstraps with.",
+        )
+
+    # RemoteMigration carries neither started_at nor error_message (it exists to
+    # serve --status). Fetch the failure detail for this one id rather than
+    # widening a type the whole engine shares.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT started_at::text, coalesce(error_message, '')
+            FROM infra.schema_migrations WHERE id = %s
+            """,
+            (target_id,),
+        )
+        failed_at, prev_error = cur.fetchone()
+
+    sql = mig.path.read_text(encoding="utf-8")
+    amended = row.checksum != mig.checksum
+    mode = "non-tx" if mig.non_transactional else "tx"
+    first_line = (prev_error.splitlines() or ["—"])[0][:200]
+
+    print(f"Retrying {target_id} ({mode})")
+    print(f"  failed at       : {failed_at or '—'} under {row.runner or '—'}")
+    print(f"  failed with     : {first_line or '—'}")
+    print(f"  ledger checksum : {row.checksum}")
+    print(f"  file checksum   : {mig.checksum}")
+    print(f"  statements      : {len(split_sql_statements(sql))}")
+    if amended:
+        print("  the file was AMENDED since the failure — recorded in note")
+    else:
+        print(
+            "  the file is BYTE-IDENTICAL to the one that failed — a retry only "
+            "makes sense if the cause was outside the file (a lock that has "
+            "since cleared, a timeout since raised)"
+        )
+
+    note = (
+        f"retried after failure: was checksum={row.checksum} "
+        f"runner={row.runner or '—'} started_at={failed_at or '—'} "
+        f"error={first_line}"
+    )
+    reset_session(conn)
+    elapsed_ms = apply_migration(conn, mig, runner, git_sha, resume_note=note)
+    print(f"OK in {elapsed_ms}ms")
+    write_step_summary(
+        ["## Retried", "",
+         f"`{target_id}` re-executed after a failure, in {elapsed_ms}ms.", "",
+         f"- previously failed at : {failed_at or '—'} ({row.runner or '—'})",
+         f"- previous error       : `{first_line or '—'}`",
+         f"- file since the failure : "
+         f"{'AMENDED' if amended else 'byte-identical'}",
+         f"- ledger checksum      : `{row.checksum}` → `{mig.checksum}`",
          ""]
     )
     return 0
@@ -1706,6 +1908,17 @@ def main(argv: list[str]) -> int:
         ),
     )
     parser.add_argument(
+        "--retry", type=str, default="", metavar="ID",
+        help=(
+            "Re-run ONE migration whose ledger row is 'failed', reopening that "
+            "row instead of inserting a second one. Refuses unless the row is "
+            "exactly 'failed'. Unlike --reapply it accepts @non_transactional "
+            "files and an amended file — fixing the cause of a failure usually "
+            "means editing it; the change is printed and recorded in `note`. "
+            "Needs the table owner."
+        ),
+    )
+    parser.add_argument(
         "--no-bootstrap", action="store_true",
         help=(
             "Skip the ledger DDL/GRANT bootstrap. Only valid with --status : it "
@@ -1769,11 +1982,20 @@ def main(argv: list[str]) -> int:
         return run_lint_markers(args.lint_markers)
 
     if args.only and (args.limit is not None or args.baseline or args.status
-                      or args.reapply):
+                      or args.reapply or args.retry):
         fail(
             2,
             "--only is exclusive : it cannot be combined with --limit, "
-            "--baseline, --status or --reapply.",
+            "--baseline, --status, --reapply or --retry.",
+        )
+
+    if args.retry and (args.limit is not None or args.baseline or args.status
+                       or args.reapply or args.dry_run):
+        fail(
+            2,
+            "--retry is exclusive : it cannot be combined with --limit, "
+            "--baseline, --status, --reapply or --dry-run. There is no dry-run "
+            "for a retry — it executes the migration.",
         )
 
     if args.no_bootstrap and (not args.status or args.reapply or args.baseline):
@@ -1821,6 +2043,11 @@ def main(argv: list[str]) -> int:
             return run_reapply(
                 conn, local, remote, args.reapply, runner, git_sha
             )
+
+        # Before the blocker check below : a 'failed' row IS a blocker, so a
+        # retry has to run ahead of the very gate it exists to clear.
+        if args.retry:
+            return run_retry(conn, local, remote, args.retry, runner, git_sha)
 
         if args.baseline:
             return run_baseline(conn, local, remote, args.exclude)

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -559,7 +559,8 @@ def reopen_failed(
 # This is not hypothetical. `20260513_default_privileges_data_api_post_oct30.sql`
 # sets `lock_timeout = '1s'` and `statement_timeout = '5s'`. The next migrations
 # in lexicographic order include `20260529_xtr_msg_crm_indexes.sql`, whose
-# CREATE INDEX CONCURRENTLY is documented at 5-20 minutes per index. Under a
+# CREATE INDEX CONCURRENTLY was measured at ~2 minutes per index on
+# ___xtr_msg (two heap scans of ~54 s each, 2026-09-04). Under a
 # leaked 5s timeout it would be killed, leave the index INVALID — which
 # `CREATE INDEX CONCURRENTLY IF NOT EXISTS` then silently treats as a no-op on
 # every later attempt — and write a `failed` ledger row that blocks all runs.
@@ -614,7 +615,7 @@ def reset_session(conn) -> "None":
 
 def apply_migration(
     conn, mig: LocalMigration, runner: str, git_sha: str,
-    *, resume_note: "str | None" = None,
+    *, resume_note: "str | None" = None, sql: "str | None" = None,
 ) -> int:
     """Apply one migration. Returns elapsed ms. Raises on failure.
 
@@ -622,8 +623,13 @@ def apply_migration(
     "reopen the existing 'failed' one" (--retry). The SQL execution itself is
     byte-for-byte the same path in both cases : a retry must not be a second,
     subtly different way of running a migration.
+
+    `sql`, when given, is the text a caller already validated (run_retry's A5
+    gate) : executing exactly that text, not a fresh read, is what makes the
+    gate's verdict apply to what runs.
     """
-    sql = mig.path.read_text(encoding="utf-8")
+    if sql is None:
+        sql = mig.path.read_text(encoding="utf-8")
     start = time.monotonic()
 
     if mig.non_transactional:
@@ -661,16 +667,21 @@ def apply_migration(
     conn.autocommit = False
     try:
         with conn.cursor() as cur:
-            if resume_note is not None:
-                # Same transaction as the SQL : if the retry fails again, the
-                # reopen rolls back with it and the row stays 'failed'.
-                reopen_failed(cur, mig, runner, git_sha, resume_note)
             cur.execute(sql)
             elapsed_ms = int((time.monotonic() - start) * 1000)
             if resume_note is None:
                 insert_applied_tx(cur, mig, elapsed_ms, runner, git_sha)
             else:
+                # Ledger writes come AFTER the SQL, never before : a file that
+                # closes our transaction (a stray COMMIT) would otherwise make
+                # 'applying' durable with no run behind it — an orphan row no
+                # mode can clear. Checked the same way run_reapply does, then
+                # reopen + mark_applied commit together with the SQL, or not at
+                # all : a retry that fails again leaves the row 'failed'.
+                _assert_in_transaction(conn, "after running the migration SQL")
+                reopen_failed(cur, mig, runner, git_sha, resume_note)
                 mark_applied(cur, mig.id, elapsed_ms)
+                _assert_in_transaction(conn, "before committing the ledger row")
         conn.commit()
     except Exception:
         conn.rollback()
@@ -1277,6 +1288,49 @@ def run_self_test() -> int:
     assert "still live" in retry_precheck(
         _lm, RemoteMigration("x", "aaa", "applying", None, None))
 
+    # run_retry must refuse an A5-inconsistent file with exit 7 BEFORE any
+    # ledger write. Exercised in-process : fail() is swapped for a raiser and
+    # the connection is a stub whose only job is to record what was executed.
+    import tempfile as _tf
+    _g = globals()
+    _saved_fail = _g["fail"]
+    class _Exit(Exception):
+        def __init__(self, code, msg): self.code, self.msg = code, msg
+    _g["fail"] = lambda code, msg: (_ for _ in ()).throw(_Exit(code, msg))
+    class _Cur:
+        def __init__(self, conn): self.conn, self.rowcount = conn, 1
+        def execute(self, q, p=None): self.conn.log.append(" ".join(q.split()))
+        def fetchone(self): return self.conn.rows.pop(0)
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+    class _Conn:
+        autocommit = True
+        def __init__(self):
+            self.log = []
+            # privilege probe (5 columns), then failure detail (2 columns)
+            self.rows = [("postgres", True, True, True, True), ("2026-09-04", "boom")]
+        def cursor(self): return _Cur(self)
+    try:
+        with _tf.TemporaryDirectory() as _d:
+            _p = Path(_d) / "20260901_a5_bad.sql"
+            _p.write_text("-- @non_transactional\nCREATE TABLE t (id int);\n")
+            _bad = LocalMigration(id=_p.stem, path=_p, checksum="new", non_transactional=True)
+            _row = RemoteMigration(_p.stem, "old", "failed", None, "gh-actions:1")
+            _c = _Conn()
+            import io as _io, contextlib as _cl
+            _out = _io.StringIO()
+            try:
+                with _cl.redirect_stdout(_out):
+                    run_retry(_c, [_bad], {_p.stem: _row}, _p.stem, "self-test", "")
+                raise AssertionError("run_retry accepted an A5-inconsistent file")
+            except _Exit as _e:
+                assert _e.code == 7, _e.code
+            assert "::error::" in _out.getvalue()
+            assert "Retrying" not in _out.getvalue()
+            assert not any("UPDATE infra.schema_migrations" in q for q in _c.log)
+    finally:
+        _g["fail"] = _saved_fail
+
     # The two real files that pin both directions of this gate.
     _target = MIGRATIONS_DIR / "20260429_diag_maintenance_via_kg.sql"
     if _target.exists():
@@ -1675,7 +1729,8 @@ def run_retry(
     if why:
         fail(11, f"{target_id}: {why}.")
 
-    # `checksum` and `started_at` sit OUTSIDE the service_role column grant :
+    # `checksum`, `started_at`, `runner`, `git_sha` sit OUTSIDE the service_role
+    # column grant (every column reopen_failed writes that the grant omits) :
     # only the table owner can reopen a row. Say so plainly instead of
     # surfacing a bare 42501 halfway through.
     with conn.cursor() as cur:
@@ -1685,14 +1740,18 @@ def run_retry(
                    has_column_privilege('infra.schema_migrations',
                                         'checksum', 'UPDATE'),
                    has_column_privilege('infra.schema_migrations',
-                                        'started_at', 'UPDATE')
+                                        'started_at', 'UPDATE'),
+                   has_column_privilege('infra.schema_migrations',
+                                        'runner', 'UPDATE'),
+                   has_column_privilege('infra.schema_migrations',
+                                        'git_sha', 'UPDATE')
             """
         )
-        who, c_ok, s_ok = cur.fetchone()
-    if not (c_ok and s_ok):
+        who, c_ok, s_ok, r_ok, g_ok = cur.fetchone()
+    if not (c_ok and s_ok and r_ok and g_ok):
         fail(
             9,
-            f"role '{who}' cannot UPDATE checksum/started_at on "
+            f"role '{who}' cannot UPDATE checksum/started_at/runner/git_sha on "
             "infra.schema_migrations (column-scoped grant). --retry needs the "
             "table owner — the DATABASE_URL the engine bootstraps with.",
         )
@@ -1712,7 +1771,9 @@ def run_retry(
 
     sql = mig.path.read_text(encoding="utf-8")
 
-    # A5 gate — the SAME gate every apply path runs, with the SAME exit code.
+    # A5 gate — the same function and exit code as the apply / dry-run path in
+    # main(). (run_reapply does not run it : it only accepts transactional
+    # files, and widening it is a separate change.)
     # A retry is by design the mode for a file amended since it failed, and an
     # amendment is exactly where a marker/statement contradiction can appear :
     # this path needs the gate most, not least. Checked before any print or
@@ -1752,7 +1813,9 @@ def run_retry(
         f"error={first_line}"
     )
     reset_session(conn)
-    elapsed_ms = apply_migration(conn, mig, runner, git_sha, resume_note=note)
+    elapsed_ms = apply_migration(
+        conn, mig, runner, git_sha, resume_note=note, sql=sql
+    )
     print(f"OK in {elapsed_ms}ms")
     write_step_summary(
         ["## Retried", "",
@@ -1915,7 +1978,7 @@ def main(argv: list[str]) -> int:
         help="Print the migration state table and exit. Read-only on the data.",
     )
     parser.add_argument(
-        "--reapply", type=str, default="", metavar="ID",
+        "--reapply", type=str, default=None, metavar="ID",
         help=(
             "Re-execute ONE migration whose ledger row is in drift, then rewrite "
             "that row from the run. Refuses unless the row is a drifted "
@@ -1957,7 +2020,7 @@ def main(argv: list[str]) -> int:
         help="Show the apply plan without writing.",
     )
     parser.add_argument(
-        "--only", type=str, default="", metavar="ID[,ID...]",
+        "--only", type=str, default=None, metavar="ID[,ID...]",
         help=(
             "Apply exactly these pending migrations and nothing else, in file "
             "order. Refuses an unknown id or one already in the ledger. Prints "
@@ -1997,8 +2060,9 @@ def main(argv: list[str]) -> int:
     if args.lint_markers:
         return run_lint_markers(args.lint_markers)
 
-    if args.only and (args.limit is not None or args.baseline or args.status
-                      or args.reapply or args.retry is not None):
+    if args.only is not None and (args.limit is not None or args.baseline
+                                  or args.status or args.reapply is not None
+                                  or args.retry is not None):
         fail(
             2,
             "--only is exclusive : it cannot be combined with --limit, "
@@ -2010,9 +2074,14 @@ def main(argv: list[str]) -> int:
     # full-queue apply below.
     if args.retry is not None and not args.retry.strip():
         fail(11, "--retry was given an empty migration id — nothing was retried.")
+    if args.reapply is not None and not args.reapply.strip():
+        fail(8, "--reapply was given an empty migration id — nothing was re-applied.")
+    if args.only is not None and not args.only.strip():
+        fail(10, "--only was given an empty migration id — nothing was applied.")
 
     if args.retry is not None and (args.limit is not None or args.baseline
-                                   or args.status or args.reapply or args.dry_run):
+                                   or args.status or args.reapply is not None
+                                   or args.dry_run):
         fail(
             2,
             "--retry is exclusive : it cannot be combined with --limit, "
@@ -2020,7 +2089,8 @@ def main(argv: list[str]) -> int:
             "for a retry — it executes the migration.",
         )
 
-    if args.no_bootstrap and (not args.status or args.reapply or args.baseline):
+    if args.no_bootstrap and (not args.status or args.reapply is not None
+                              or args.baseline):
         fail(
             2,
             "--no-bootstrap is only valid with a bare --status : every write path "
@@ -2061,9 +2131,9 @@ def main(argv: list[str]) -> int:
         runner = f"gh-actions:{os.environ.get('GITHUB_RUN_ID', 'local')}"
         git_sha = os.environ.get("GITHUB_SHA", "")
 
-        if args.reapply:
+        if args.reapply is not None:
             return run_reapply(
-                conn, local, remote, args.reapply, runner, git_sha
+                conn, local, remote, args.reapply.strip(), runner, git_sha
             )
 
         # Before the blocker check below : a 'failed' row IS a blocker, so a
@@ -2103,7 +2173,7 @@ def main(argv: list[str]) -> int:
 
         pending = [m for m in local if m.id not in remote]
         skipped_earlier: list[str] = []
-        if args.only:
+        if args.only is not None:
             pending, skipped_earlier, errors = select_only(
                 local, remote, args.only
             )
@@ -2148,7 +2218,7 @@ def main(argv: list[str]) -> int:
                 state = "✅ applied"
             elif m in pending:
                 state = "⏳ pending"
-            elif args.only:
+            elif args.only is not None:
                 state = "⏸️ not selected (--only)"
             else:
                 state = "⏸️ deferred (limit)"

--- a/scripts/ci/apply-supabase-migration.py
+++ b/scripts/ci/apply-supabase-migration.py
@@ -1711,6 +1711,22 @@ def run_retry(
         failed_at, prev_error = cur.fetchone()
 
     sql = mig.path.read_text(encoding="utf-8")
+
+    # A5 gate — the SAME gate every apply path runs, with the SAME exit code.
+    # A retry is by design the mode for a file amended since it failed, and an
+    # amendment is exactly where a marker/statement contradiction can appear :
+    # this path needs the gate most, not least. Checked before any print or
+    # ledger write, so a refused retry leaves the 'failed' row untouched.
+    mismatches = reconcile_non_transactional(sql)
+    if mismatches:
+        for msg in mismatches:
+            print(f"::error::{target_id}: {msg}")
+        fail(
+            7,
+            f"{len(mismatches)} @non_transactional mismatch(es) in {target_id} "
+            "— fix the file (see --lint-markers). Nothing was retried.",
+        )
+
     amended = row.checksum != mig.checksum
     mode = "non-tx" if mig.non_transactional else "tx"
     first_line = (prev_error.splitlines() or ["—"])[0][:200]
@@ -1908,7 +1924,7 @@ def main(argv: list[str]) -> int:
         ),
     )
     parser.add_argument(
-        "--retry", type=str, default="", metavar="ID",
+        "--retry", type=str, default=None, metavar="ID",
         help=(
             "Re-run ONE migration whose ledger row is 'failed', reopening that "
             "row instead of inserting a second one. Refuses unless the row is "
@@ -1982,15 +1998,21 @@ def main(argv: list[str]) -> int:
         return run_lint_markers(args.lint_markers)
 
     if args.only and (args.limit is not None or args.baseline or args.status
-                      or args.reapply or args.retry):
+                      or args.reapply or args.retry is not None):
         fail(
             2,
             "--only is exclusive : it cannot be combined with --limit, "
             "--baseline, --status, --reapply or --retry.",
         )
 
-    if args.retry and (args.limit is not None or args.baseline or args.status
-                       or args.reapply or args.dry_run):
+    # `default=None` so an EMPTY value is distinguishable from an absent flag :
+    # `--retry "$ID"` with ID unset must refuse, never fall through to the
+    # full-queue apply below.
+    if args.retry is not None and not args.retry.strip():
+        fail(11, "--retry was given an empty migration id — nothing was retried.")
+
+    if args.retry is not None and (args.limit is not None or args.baseline
+                                   or args.status or args.reapply or args.dry_run):
         fail(
             2,
             "--retry is exclusive : it cannot be combined with --limit, "
@@ -2046,8 +2068,10 @@ def main(argv: list[str]) -> int:
 
         # Before the blocker check below : a 'failed' row IS a blocker, so a
         # retry has to run ahead of the very gate it exists to clear.
-        if args.retry:
-            return run_retry(conn, local, remote, args.retry, runner, git_sha)
+        if args.retry is not None:
+            return run_retry(
+                conn, local, remote, args.retry.strip(), runner, git_sha
+            )
 
         if args.baseline:
             return run_baseline(conn, local, remote, args.exclude)


### PR DESCRIPTION
Incident du 2026-09-04, run [`33839602437`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/33839602437) : `20260529_xtr_msg_crm_indexes` tué à **60,588 s** par `QueryCanceled`. Deux défauts distincts — l'un a créé la panne, l'autre l'a rendue **irréparable**.

## 1 — Cause racine : omettre `statement_timeout`, c'est en hériter un

L'en-tête du fichier justifiait de **ne pas** poser `statement_timeout` : « il tuerait le build CONCURRENTLY ». Le raisonnement est inversé. Ne pas poser la valeur ne donne pas « aucun timeout » — cela donne **celle du rôle** :

```sql
SELECT setconfig FROM pg_db_role_setting s JOIN pg_roles r ON r.oid = s.setrole
 WHERE r.rolname = 'postgres';
-- {"search_path=...", statement_timeout=60s}
```

…et le runner se connecte précisément comme `postgres`.

**60 s n'auraient jamais suffi.** Mesure du heap de `___xtr_msg` (`EXPLAIN ANALYZE, BUFFERS` sur une plage de `ctid`) : **40 000 pages en 2 305 ms**, soit ~**54 s** pour les 935 631 pages — et `CREATE INDEX CONCURRENTLY` en fait **deux par index**. La migration ne pouvait pas passer, à aucun essai.

Correctif : `SET statement_timeout = 0` **explicite**.

### Le garde existait, et il était juste

`squawk require-timeout-settings` dit mot pour mot ce qui allait arriver :

```
warning[require-timeout-settings]: Missing `set statement_timeout` before potentially slow operations
   ╭▸ 20260529_xtr_msg_crm_indexes.sql:63:1
63 │ DROP INDEX CONCURRENTLY IF EXISTS idx_xtr_msg_crm_status_active;
```

Il était réduit au silence par `-- squawk-ignore-file require-timeout-settings`, au nom de la justification fausse ci-dessus. **L'ignore est retiré.** Vérifié avec la version qu'utilise la CI (squawk **2.52.1**, cf. `ci.yml`) : sans le SET la règle lève et sort en `rc=1` ; avec lui, 0 problème. L'autre ignore du fichier (`ban-concurrent-index-creation-in-transaction`) a été testé **vivant** et reste — il est légitime sous `assume_in_transaction = true`.

La durée annoncée « 5-20 min par index » n'était pas mesurée ; remplacée par la mesure (~2 min/index) — ce qui confirme que `timeout-minutes: 20` **n'a jamais été en cause** et n'est pas touché.

## 2 — Le trou : une migration en échec était irrécupérable

Après `mark_failed`, l'id **est** au ledger. Donc :

| chemin | verdict |
|---|---|
| `pending = [m for m in local if m.id not in remote]` | l'exclut |
| `--only` | refuse : « already recorded in the ledger (status=failed) » |
| `--reapply` | refuse ×2 : statut ≠ `applied`, **et** `@non_transactional` non supporté |
| `insert_applying` | INSERT nu → violation de clé primaire |

Aucun chemin gouverné n'y menait. Et `failed` étant un **bloqueur**, toute la file restait arrêtée en exit 5 — `20260605` et `20260611`, prêtes, incluses.

### `--retry <ID>`

Dans la famille de `--only` / `--reapply` / `--baseline` :

- **`retry_precheck()`** pur et couvert par `--self-test` — n'accepte que `status='failed'` ; refuse `applied` (c'est `--reapply`) et `applying` (un run peut être vivant).
- **N'exige pas l'égalité de checksum** : réparer la cause d'un échec veut dire éditer le fichier. Le changement est imprimé et consigné dans `note`, pas interdit. Un fichier inchangé est signalé comme tel.
- **`reopen_failed()`** fait un `UPDATE` en place, jamais `DELETE`+`INSERT` — le ledger n'accorde aucun `DELETE` à `service_role` — avec `WHERE status='failed'` et une garde `rowcount != 1`.
- L'exécution SQL **réutilise `apply_migration()`** : un retry ne doit pas être une seconde manière, subtilement différente, de lancer une migration. Sur le chemin transactionnel, le `reopen` est dans la même transaction que le SQL : si le retry échoue, la ligne reste `failed`.
- Aiguillé **avant** le contrôle de bloqueurs, puisqu'il existe pour le lever.
- Exclusif de tous les autres modes ; **pas de dry-run** (il exécute). Exit **11** (code libre, tous distincts).
- `--status` cesse d'annoncer une impasse : il nomme désormais la sortie par état.

## Vérifications

```
--self-test                                    OK (assertions retry_precheck incluses)
--lint-markers 20260529_...sql                 OK — @non_transactional reconciled
squawk 2.52.1 --config .squawk.toml <fichier>  Found 0 issues
gardes d'exclusivité (5 combinaisons)          rc=2 sur chacune
```

**Ce que cette PR ne fait pas** : elle ne relance pas la migration et ne touche pas la DB. Après merge, la reprise est `--retry 20260529_xtr_msg_crm_indexes`, sous décision owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)