### PR TITLE
docs(agents): amorcer Codex sur le canon via un AGENTS.md racine pointeur

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -276,6 +276,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: high
+  - glob: AGENTS.md
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
   - glob: log*.md
     domain: D15
     owner: '@ak125'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md — monorepo `nestjs-remix-monorepo`
+
+> **Fichier d'amorçage. Il ne contient aucune règle.**
+>
+> Il existe pour une seule raison : les agents qui découvrent leurs instructions via
+> `AGENTS.md` — Codex et assimilés — ne reçoivent **aucune** injection automatique de
+> `CLAUDE.md`, `.claude/rules/**` ou de la mémoire projet. Là où un autre harnais reçoit le
+> canon sans rien demander, toi tu dois aller le lire.
+>
+> Ce fichier ne recopie donc **rien** : toute règle recopiée à la main ici dériverait en
+> silence de sa source. Il ne fait qu'indiquer **quoi lire, dans quel ordre, avant d'agir**.
+
+## Rôle
+
+Agent d'ingénierie sur un repo **gouverné**. Tu n'es **pas souverain** : mode lecture seule par
+défaut, cartographier avant de muter, et accord de l'owner sur les zones STOP.
+
+Tu ne peux pas déduire les règles de ce repo en lisant son code. Elles sont écrites, elles sont
+ailleurs, et les lire est ta première action — pas une option.
+
+## Lecture obligatoire, dans cet ordre, avant toute action
+
+1. **`./CLAUDE.md`** — le contrat d'exécution (9 invariants) et les **zones STOP**.
+   À lire **en entier**. C'est la source de vérité comportementale de ce repo.
+2. **`.claude/rules/<domaine>.md`** — la règle du bounded-context que tu touches :
+   `backend.md` · `frontend.md` · `payments.md` · `deployment.md` (**avant toute action
+   infra**) · `guardrails.md` · `security-hooks.md` · `context7.md` · `agent-doc-search.md`.
+3. **`audit/registry/canonical.json`** — source de vérité machine du Repository Control Plane,
+   à interroger **via `jq` avec un filtre**, jamais en lecture intégrale. Puis
+   `.claude/knowledge/REPO_MAP.md` pour la projection lisible.
+4. **`tail -n 80 log.md`** — contexte récent. Jamais le fichier entier.
+
+`Grep` et `Glob` viennent **après** cette cartographie, jamais avant.
+
+## Zones STOP
+
+Elles sont définies par l'**invariant 9 de `CLAUDE.md`**, et **volontairement pas recopiées
+ici** : une liste de sécurité maintenue à la main à deux endroits finit par diverger sans
+bruit, et ce repo a déjà payé ce défaut (d'où les copies vérifiées par hash sous
+`.claude/canon-mirrors/`).
+
+Conséquence directe : **tu ne peux pas savoir ce qui est interdit sans avoir lu `CLAUDE.md`.**
+C'est la raison pour laquelle cette lecture est la première action, et non une formalité.
+
+## Hiérarchie
+
+- **Reporte à** l'owner du repo, seul à pouvoir lever une zone STOP, par accord nominatif.
+- La gouvernance canon (décisions d'architecture, règles, politiques) vit dans un **dépôt
+  séparé**. Aucune ne naît dans ce monorepo. Voir `CLAUDE.md`.
+
+## Infrastructure
+
+Le vocabulaire de déploiement est strict et vérifié par un lint d'intégration continue :
+charger `.claude/rules/deployment.md` **avant** d'y toucher, et ne rien déduire du reste.
+
+Ne jamais inscrire ici une adresse IP, une URL d'infrastructure, un identifiant unique ou une
+clé : `scripts/agents/validate-agents-md.sh` bloque, et c'est voulu.
+
+## Format de sortie
+
+**CONTRAT DE SORTIE** : défini par `.claude/canon-mirrors/agent-exit-contract.md`, dérivée
+verrouillée par hash. Le lire, ne pas le recopier, ne pas le résumer de mémoire.

--- a/log.md
+++ b/log.md
@@ -410,3 +410,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix+migrations-preserve-search-path-and-acl`
 - **Décision** : fix(migrations): désigner l'instruction par son nom, pas par son numéro de ligne (+2 other commits)
 - **Sortie** : PR #1391 | commits 04c4d72f1 e70ad7c79 6720119db
+
+## 2026-09-04 — chore/codex-agents-md-bootstrap (auto)
+
+- **Branche** : `chore/codex-agents-md-bootstrap`
+- **Décision** : docs(agents): amorcer Codex sur le canon via un AGENTS.md racine pointeur
+- **Sortie** : PR aucune | commits 64e534ecb


### PR DESCRIPTION
## Summary

Codex découvre ses instructions via `AGENTS.md`, jamais via `CLAUDE.md`. Aucun `AGENTS.md` n'existait à la racine : Codex tournait donc dans ce repo sans un octet d'instruction projet, avec un sandbox par défaut qui lui accorde l'écriture. Ce fichier d'amorçage ne porte que de la navigation — il dit quoi lire, dans quel ordre, et ne recopie aucune règle.

## Test plan

- [x] `bash scripts/agents/validate-agents-md.sh --file AGENTS.md` → PASS (0 block, 0 warn)
- [x] `node scripts/registry/check-new-files.js --base origin/main` → `ok` (ownerGlob `AGENTS.md`, owner `@ak125`, domain D15)
- [x] `codex debug prompt-input` → bloc `<INSTRUCTIONS>` de 3 211 caractères effectivement chargé
- [ ] CI verte (`registry-new-file-gate`, `validate-agents-md`)

## Changes

- `AGENTS.md` (nouveau, 62 lignes) — amorçage pointeur : ordre de lecture obligatoire `CLAUDE.md` → `.claude/rules/<domaine>.md` → `audit/registry/canonical.json` via `jq` → `tail -n 80 log.md`.
- `.spec/00-canon/repository-registry/ownership.yaml` — +5 lignes, glob `AGENTS.md` → D15 / `@ak125`. **Commit isolé, owner-directed override** (voir plus bas).
- `log.md` — entrée de session générée par le hook `stop-log-session-suggest.sh`.

---

## Improvement Check

- **Problem:** Codex, qui dispose du droit d'écriture sur le repo, n'avait accès ni aux 9 invariants, ni à `.claude/rules/**`, ni aux zones STOP.
- **Evidence before:** `codex debug prompt-input` depuis `/opt/automecanik/app` → 22 948 octets de contexte modèle, dont **0 octet d'instruction projet**. Aucun `AGENTS.md` à la racine (jamais créé, non gitignoré).
- **Expected gain:** tout agent lisant `AGENTS.md` est routé vers le canon avant d'agir, au lieu d'opérer à l'aveugle.
- **Risk:** faible — fichier documentaire, aucune surface runtime. Le risque réel serait la **dérive silencieuse** si ce fichier recopiait du canon ; c'est précisément ce qui a été retiré (voir ci-dessous). Rollback = suppression du fichier.
- **Test:** validateur `validate-agents-md.sh` + gate `check-new-files.js` + preuve de chargement `codex debug prompt-input`.
- **Evidence after:** validateur PASS 0/0 · gate `ok` · bloc `<INSTRUCTIONS>` chargé, 3 211 caractères, 7/7 sondes de navigation présentes, 0/6 sondes de canon reformulé.
- **Verdict:** GO
- **Next action:** aucune. Le décalage d'outillage subsiste par choix — les 13 skills de `.claude/skills/` restent invisibles à Codex, hors périmètre de cette PR.

### Note de conception — pourquoi aucun canon n'est recopié ici

Une première version énumérait les 5 zones STOP et reformulait 8 invariants « pour éviter un second saut ». Elle a été retirée : c'était une paraphrase manuelle du canon sur une seconde surface, sans hash ni détection de dérive. Ce repo a déjà payé ce défaut — l'AEC a été canonisé en v1.0.0 avec le motif « copies orphelines monorepo + seo-batch (drift constaté empiriquement) », d'où les dérivées vérifiées par hash sous `.claude/canon-mirrors/` et leur workflow.

La ligne de partage retenue tient au mode de défaillance : **un chemin rompu échoue bruyamment** (l'agent ne trouve pas le fichier et le signale), **une règle recopiée périmée échoue en silence**. Une surface d'instructions secondaire ne porte donc que de la navigation. Les zones STOP sont renvoyées à l'invariant 9 de `CLAUDE.md`, avec la raison donnée à l'agent.

### Note de gouvernance — `ownership.yaml`

`.spec/00-canon/**` est canon owner-only. Le gate rendait `missing_both` sur `AGENTS.md`. La règle a été signalée explicitement à l'owner, qui a fourni le snippet et demandé son application : les 4 conditions de l'exception owner-directed sont réunies (snippet fourni par l'owner, scope purement mécanique, commit isolé, aucun autre fichier canon touché). L'entrée est le clone exact de celle de `CLAUDE.md`.

---

## Runtime verification

- **Surface:** outillage agent (aucune surface applicative)
- **Environment:** machine DEV — Codex CLI, `codex debug prompt-input` (rendu local, hors quota)
- **Verdict:** PASS — le bloc `<INSTRUCTIONS>` passe de absent à 3 211 caractères chargés, sondes de navigation 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
