### PR TITLE
chore(registry): resync la vérité générée L1 + L3 (catch-up dédié)

### DIFF
--- a/.claude/knowledge/REPO_MAP.md
+++ b/.claude/knowledge/REPO_MAP.md
@@ -3,7 +3,7 @@ title: Repository Map
 kind: registry-index
 generated_at: "1970-01-01T00:00:00.000Z"
 source: audit/registry/canonical.json
-source_sha256: e8337b2eb84a920d62e7e8f9528aff9cce3b0b1455b7bfef85718e4b16388813
+source_sha256: c1377cfe55c37663baac68ed066a49eb0e5ad8cfd2d83f5c1b62de6bd39badda
 schema_version: "1.0.0"
 do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-058 PR-F)
 ---
@@ -24,7 +24,7 @@ do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-
 | Dependencies (Layer 1) | 237 |
 | Runtime entrypoints (Layer 1) | 515 |
 
-Source sotFingerprint: `8c6a3cad7141`.
+Source sotFingerprint: `35c0b9542058`.
 
 ## Comment l'utiliser
 

--- a/audit/db-usage-map.json
+++ b/audit/db-usage-map.json
@@ -2,7 +2,7 @@
   "_generated_by": "scripts/audit/build-db-usage-map.js",
   "note": "Candidates only — never a \"dead\" verdict. A real DROP table/function goes through the RPC Gate + a vault ADR, never from this map.",
   "important_caveats": [
-    "896 `.from(<non-literal>)` callsites exist in backend/src — a literal-only scan UNDER-counts table usage; treat candidate_orphan_tables as \"needs manual check\", not \"dead\".",
+    "897 `.from(<non-literal>)` callsites exist in backend/src — a literal-only scan UNDER-counts table usage; treat candidate_orphan_tables as \"needs manual check\", not \"dead\".",
     "Migration parsing is regex-based and tracks last CREATE vs last DROP per object (date-prefixed filenames ≈ chronological); re-create-after-drop edge cases may slip through.",
     "RLS-only / dashboard / external-cron / RPC-internal usage is invisible here — see per-candidate caveats."
   ],
@@ -14,10 +14,10 @@
     "rpc_with_callsites": 14,
     "trigger_functions": 30,
     "candidate_orphan_rpc": 198,
-    "dynamic_from_callsites": 896,
-    "dynamic_rpc_callsites": 2,
-    "migrations_scanned": 340,
-    "backend_files_scanned": 1372
+    "dynamic_from_callsites": 897,
+    "dynamic_rpc_callsites": 1,
+    "migrations_scanned": 342,
+    "backend_files_scanned": 1377
   },
   "tables": {
     "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7": {
@@ -268,10 +268,9 @@
     "__cross_gamme_car_new": {
       "used_by": [
         "backend/src/modules/admin/services/gamme-detail-enricher.service.ts",
-        "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
         "backend/src/modules/blog/services/blog-article-relation.service.ts"
       ],
-      "used_by_count": 3,
+      "used_by_count": 2,
       "in_migrations": [],
       "rls_present": true,
       "in_knowledge_db": false
@@ -14294,16 +14293,16 @@
     {
       "file": "backend/src/shared/crypto/password-crypto.service.ts",
       "line": 246
+    },
+    {
+      "file": "backend/src/workers/processors/__tests__/seo-monitor.processor.test.ts",
+      "line": 78
     }
   ],
   "dynamic_rpc_callsites": [
     {
       "file": "backend/src/database/services/supabase-base.service.ts",
       "line": 509
-    },
-    {
-      "file": "backend/src/modules/admin/services/r1-keyword-plan-batch.service.ts",
-      "line": 218
     }
   ]
 }

--- a/audit/module-boundaries.json
+++ b/audit/module-boundaries.json
@@ -17,8 +17,8 @@
         "backend/src/modules/admin/services/r1-image-prompt-builders",
         "backend/src/modules/admin/services/r1-image-prompt-builders/__tests__"
       ],
-      "files_count": 145,
-      "loc_total": 40669,
+      "files_count": 146,
+      "loc_total": 40877,
       "has_barrel": true
     },
     "agentic-engine": {
@@ -118,8 +118,8 @@
       "dirs": [
         "backend/src/cache"
       ],
-      "files_count": 2,
-      "loc_total": 466,
+      "files_count": 3,
+      "loc_total": 620,
       "has_barrel": false
     },
     "cart": {
@@ -185,8 +185,8 @@
         "backend/src/modules/config/services",
         "backend/src/modules/config/validators"
       ],
-      "files_count": 95,
-      "loc_total": 23793,
+      "files_count": 96,
+      "loc_total": 23947,
       "has_barrel": true
     },
     "customers": {
@@ -224,8 +224,8 @@
         "backend/src/modules/rm/services/__tests__",
         "backend/src/modules/rm/utils"
       ],
-      "files_count": 12,
-      "loc_total": 2528,
+      "files_count": 13,
+      "loc_total": 3044,
       "has_barrel": false
     },
     "diagnostic-engine": {
@@ -699,8 +699,8 @@
         "scripts/wiki-generators",
         "scripts/wiki-generators/__tests__"
       ],
-      "files_count": 168,
-      "loc_total": 34249,
+      "files_count": 170,
+      "loc_total": 35388,
       "has_barrel": true
     },
     "search": {
@@ -1019,11 +1019,12 @@
       "dirs": [
         "backend/src/workers",
         "backend/src/workers/processors",
+        "backend/src/workers/processors/__tests__",
         "backend/src/workers/services",
         "backend/src/workers/types"
       ],
-      "files_count": 16,
-      "loc_total": 3550,
+      "files_count": 17,
+      "loc_total": 3709,
       "has_barrel": false
     }
   },
@@ -1056,7 +1057,7 @@
     {
       "from": "admin",
       "to": "config",
-      "count": 69
+      "count": 71
     },
     {
       "from": "admin",

--- a/audit/registry/canonical.json
+++ b/audit/registry/canonical.json
@@ -7600,7 +7600,9 @@
         "returnType": "TABLE(updated bigint)",
         "schema": "public",
         "schemaVersion": "1.0.0",
-        "searchPath": [],
+        "searchPath": [
+          "public"
+        ],
         "securityDefiner": false,
         "sourceConfidence": "high",
         "status": "UNKNOWN",
@@ -8338,7 +8340,9 @@
         "returnType": "integer",
         "schema": "public",
         "schemaVersion": "1.0.0",
-        "searchPath": [],
+        "searchPath": [
+          "public"
+        ],
         "securityDefiner": false,
         "sourceConfidence": "high",
         "status": "UNKNOWN",
@@ -8954,7 +8958,9 @@
         "returnType": "trigger",
         "schema": "public",
         "schemaVersion": "1.0.0",
-        "searchPath": [],
+        "searchPath": [
+          "public"
+        ],
         "securityDefiner": false,
         "sourceConfidence": "high",
         "status": "UNKNOWN",
@@ -98212,15 +98218,15 @@
       ".spec/00-canon/repository-registry/automation-reality.yaml": "98f10df3b19858e0d723a5a21218be5e599b0c3f6038a3672b10bbb02baf0e29",
       ".spec/00-canon/repository-registry/delete-policy.yaml": "2e698ddddc3d11c244c710271a02e376ce471812c53290439a55220bf6c7aff6",
       ".spec/00-canon/repository-registry/domains.yaml": "670a81abb20bf96ded77ca329883305243207680f9c05aa66190502dd4f8d2a2",
-      ".spec/00-canon/repository-registry/ownership.yaml": "ecd9307653f98ef29f6551a8977735d38fc903f9fad64bc3e8a77e7885b8f400",
+      ".spec/00-canon/repository-registry/ownership.yaml": "50b4fb7069d096d2e3c0fd74b7a9c576fb1e74cc8712f645688ad009ee757017",
       ".spec/00-canon/repository-registry/status-overrides.yaml": "6acccd32de6d9c15b47621ab22d9f2d3e34861ea8b6b1a3cd559f68a9fa32e02",
       "audit/registry/db.json": "c874feb59f5d00601c29a139560da9ecd2d63678eea0eddc4bb4fbd8d79672d1",
       "audit/registry/deps.json": "6f667991be593e37b2798c4ca0f0689d89c412731aa2bdf50000248da9f2c5bd",
       "audit/registry/files.json": "c764b429d515654d426bf887ed5cf17ce246c4791b75c1e3862350b91f017ffd",
-      "audit/registry/rpc.json": "e7d09287e11bb447da93a48d1a18e4c5ee13ad6667a6e10356a3af95d7463cbd",
+      "audit/registry/rpc.json": "1ccf24c62a2cc645fdf0e61ee2cc78506411c61f2762088584ff4820ca79cdfe",
       "audit/registry/runtime.json": "314a3bda98e2b9bb87a4b6a88a1efa131a3c12505d9e56b5f60eeebd23e5f70f"
     },
-    "sotFingerprint": "8c6a3cad7141"
+    "sotFingerprint": "35c0b9542058"
   },
   "runtime": [
     {

--- a/audit/registry/rpc.json
+++ b/audit/registry/rpc.json
@@ -7187,7 +7187,9 @@
       "returnType": "TABLE(updated bigint)",
       "schema": "public",
       "schemaVersion": "1.0.0",
-      "searchPath": [],
+      "searchPath": [
+        "public"
+      ],
       "securityDefiner": false,
       "sourceConfidence": "high",
       "status": "UNKNOWN",
@@ -7925,7 +7927,9 @@
       "returnType": "integer",
       "schema": "public",
       "schemaVersion": "1.0.0",
-      "searchPath": [],
+      "searchPath": [
+        "public"
+      ],
       "securityDefiner": false,
       "sourceConfidence": "high",
       "status": "UNKNOWN",
@@ -8541,7 +8545,9 @@
       "returnType": "trigger",
       "schema": "public",
       "schemaVersion": "1.0.0",
-      "searchPath": [],
+      "searchPath": [
+        "public"
+      ],
       "securityDefiner": false,
       "sourceConfidence": "high",
       "status": "UNKNOWN",

--- a/audit/runtime-entrypoints.json
+++ b/audit/runtime-entrypoints.json
@@ -2721,6 +2721,8 @@
       "backend/supabase/migrations/20260703_blog_advice_increment_views_rpc.sql",
       "backend/supabase/migrations/20260703_blog_advice_increment_views_rpc_grant_tighten.down.sql",
       "backend/supabase/migrations/20260703_blog_advice_increment_views_rpc_grant_tighten.sql",
+      "backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.down.sql",
+      "backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.sql",
       "backend/supabase/migrations/README.md"
     ],
     "ci_workflows": [
@@ -2756,6 +2758,7 @@
       ".github/workflows/governance-checks.yml",
       ".github/workflows/impeccable-ratchet.yml",
       ".github/workflows/marketing-voice-hash.yml",
+      ".github/workflows/migration-ledger-freshness.yml",
       ".github/workflows/monorepo-invariants.yml",
       ".github/workflows/morning-health-digest.yml",
       ".github/workflows/orphan-files-ratchet.yml",
@@ -2841,6 +2844,7 @@
       "scripts/audit/ts7-shadow-parity.test.ts",
       "scripts/audit/ts7-shadow-parity.ts",
       "scripts/check-no-client-localhost.sh",
+      "scripts/ci/assert-r2-golden.test.mjs",
       "scripts/ci/preprod-response-probe.test.mjs",
       "scripts/ci/preprod-response-suite.test.mjs",
       "scripts/ci/prod-rollback.test.mjs",
@@ -2883,7 +2887,7 @@
       "tests/registry/rpc-parser.test.ts"
     ]
   },
-  "runtime_files_count": 1495,
+  "runtime_files_count": 1499,
   "runtime_files": [
     ".claude/knowledge/REPO_MAP.md",
     ".dependency-cruiser.cjs",
@@ -2919,6 +2923,7 @@
     ".github/workflows/governance-checks.yml",
     ".github/workflows/impeccable-ratchet.yml",
     ".github/workflows/marketing-voice-hash.yml",
+    ".github/workflows/migration-ledger-freshness.yml",
     ".github/workflows/monorepo-invariants.yml",
     ".github/workflows/morning-health-digest.yml",
     ".github/workflows/orphan-files-ratchet.yml",
@@ -4058,6 +4063,8 @@
     "backend/supabase/migrations/20260703_blog_advice_increment_views_rpc.sql",
     "backend/supabase/migrations/20260703_blog_advice_increment_views_rpc_grant_tighten.down.sql",
     "backend/supabase/migrations/20260703_blog_advice_increment_views_rpc_grant_tighten.sql",
+    "backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.down.sql",
+    "backend/supabase/migrations/20260902_b0_rm_rpc_volatility_stable.sql",
     "backend/supabase/migrations/README.md",
     "backend/tests/unit/route-wildcard-middleware.test.ts",
     "docker/lighthouse/Dockerfile",
@@ -4339,6 +4346,7 @@
     "scripts/audit/ts7-shadow-parity.test.ts",
     "scripts/audit/ts7-shadow-parity.ts",
     "scripts/check-no-client-localhost.sh",
+    "scripts/ci/assert-r2-golden.test.mjs",
     "scripts/ci/preprod-response-probe.test.mjs",
     "scripts/ci/preprod-response-suite.test.mjs",
     "scripts/ci/prod-rollback.test.mjs",


### PR DESCRIPTION
## Summary

Rattrapage dédié de la vérité générée du Repository Control Plane. Les projections L1 + L3 avaient dérivé de leurs sources ; `registry-fresh.yml` le signalait depuis plusieurs runs sur `main`, mais en warn-only (`continue-on-error` au niveau du job, hors required checks), donc sans jamais bloquer.

Cette PR n'a **que** cet objet. C'est l'application de la doctrine de séparation par blast radius : #1396 avait délibérément différé ce rattrapage plutôt que de l'absorber dans une PR ciblée.

## Test plan

- [x] `npm run audit:inventory` puis `npm run registry` — producteurs officiels, zéro édition manuelle
- [x] `npm run registry:validate-invariants` → ✓ All 6 invariants PASS (I1..I6), dont **I6 réparé**
- [x] Guard `check-no-manual-edit-generated.sh` franchi par reproductibilité de hash (pas de bypass)
- [x] Reproduction byte-identique du rebuild CI (empreintes ci-dessous)
- [ ] CI verte

## Changes

6 fichiers, tous générés : `audit/registry/canonical.json`, `audit/registry/rpc.json`, `audit/db-usage-map.json`, `audit/module-boundaries.json`, `audit/runtime-entrypoints.json`, `.claude/knowledge/REPO_MAP.md`.

---

## Improvement Check

- **Problem:** les projections registry committées ne dérivaient plus de leurs sources ; I6 (`checkCanonicalFresh`) était `STALE` sur `main`.
- **Evidence before:** sur `main` (`9e8ecb428`), `npm run registry:validate-invariants` → `[ERROR] I6-canonical-fresh: canonical.json STALE vs .spec/00-canon/repository-registry/ownership.yaml`. Steps `PR-8 inventory freshness`, `Deep-inventory freshness` et `Freshness diff` en échec depuis plusieurs runs.
- **Expected gain:** le registre redevient une projection fidèle — les agents et gates qui le lisent cessent de raisonner sur une vue périmée.
- **Risk:** faible. Aucun code d'exécution, que des artefacts générés reproductibles. Rollback = `git revert`.
- **Test:** producteurs officiels + `registry:validate-invariants` + guard de reproductibilité.
- **Evidence after:** ✓ All 6 invariants PASS. Diff = 56 insertions / 36 suppressions sur 6 fichiers.
- **Verdict:** GO
- **Next action:** aucune. Le warning I3 (cycle `forwardRef` `auth` ↔ `users`) préexiste et sort du périmètre.

### Contenu réel de la dérive (pas du churn d'horodatage)

- `searchPath: []` corrigé en `["public"]` sur plusieurs RPC — reflet des migrations récentes qui préservent `search_path` (#1391).
- 4 fichiers absents des entrypoints runtime, désormais enregistrés (**1495 → 1499**) : la paire `20260902_b0_rm_rpc_volatility_stable`, le workflow `migration-ledger-freshness.yml`, et `assert-r2-golden.test.mjs`.
- L'empreinte de `ownership.yaml` dans `canonical.meta.inputHashes`, restée en arrière depuis l'ajout du glob `AGENTS.md` en #1396.

### Note de méthode — un premier rebuild a été jeté

Une première reconstruction, menée dans un worktree dont `node_modules` était un lien symbolique vers le checkout principal, produisait un diff de ~460 lignes dans `files.json` remplaçant les specifiers d'espace de travail par des chemins résolus hors du worktree (`"@repo/database-types"` → `"../../../packages/database-types/dist/index.d.ts"`). Artefact d'environnement, pas de la dérive : jeté, puis `npm ci` réel dans le worktree.

Le rebuild propre reproduit le runner CI à l'octet près — empreintes identiques à celles imprimées par le run `33841589360` : `files.json c764b429d515`, `rpc.json 1ccf24c62a2c`, `canonical.json c1377cfe55c3`.

---

## Runtime verification

- **Surface:** projection (artefacts générés du control plane)
- **Environment:** machine DEV, worktree avec `npm ci` propre
- **Verdict:** PASS — I6 passe de `STALE` à vert, les 6 invariants sont au vert, reproduction CI byte-identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
