### PR TITLE
docs(guardrails): le cas miroir — une garde juste réduite au silence par un motif faux

### DIFF
--- a/.claude/rules/guardrails.md
+++ b/.claude/rules/guardrails.md
@@ -55,6 +55,39 @@ prévue était les **conditions #0–#8** et la phase **PR-3 backend NestJS-awar
   de revue et de **suppression bottom-up**, pas une preuve d'atteignabilité.
 - ❌ Conclure « détecteur cassé » avant les 4 passes ci-dessus.
 
+## Le cas miroir — une garde juste, réduite au silence par un motif faux
+
+Le symptôme trompeur ci-dessus a un jumeau : **une garde correcte, active au bon
+moment, dont on a supprimé le verdict par une directive d'exemption** (`squawk-ignore`,
+`eslint-disable`, skip ast-grep, `--exclude`), justifiée par un raisonnement qui était
+lui-même faux. La garde ne se trompe pas ; on l'a fait taire.
+
+Cas réel (2026-09-04, run `33839602437`) : `20260529_xtr_msg_crm_indexes.sql` portait
+`-- squawk-ignore-file require-timeout-settings`, motivé ainsi : « ne pas poser de
+`statement_timeout`, il tuerait le build CONCURRENTLY ». Or omettre un GUC ne le
+désactive pas, il fait **hériter** celui du rôle — 60 s pour `postgres` sur ce projet.
+Le build a été tué à 60,588 s. La règle étouffée disait mot pour mot ce qui allait se
+produire : *« Missing `set statement_timeout` before potentially slow operations »*,
+en pointant l'instruction fautive. Correction : PR #1395 — `SET statement_timeout = 0`
+explicite, et la suppression **retirée** après avoir re-testé la règle vivante avec la
+version de squawk qu'utilise la CI.
+
+**Deux passes de plus, avant d'écrire ou de conserver une exemption :**
+
+**5. Lancer la garde SANS l'exemption et citer son verdict** dans la justification.
+Une exemption qui ne cite pas ce que la règle aurait dit n'a pas été confrontée à la
+règle. Si le verdict décrit un défaut réel, la bonne réponse est de corriger le défaut,
+pas d'écrire l'exemption.
+
+**6. Quand la cause est corrigée, re-tester si l'exemption est encore nécessaire** —
+et, pour chaque exemption voisine du même fichier, vérifier qu'elle est encore
+*vivante* (la retirer fait-il lever la règle ?). Une exemption morte est pire qu'inutile :
+elle continuera d'étouffer la règle le jour où quelqu'un retirera le correctif.
+
+Les mémoires d'agent sont une surface d'exemption comme les autres : la consigne fausse
+ci-dessus vivait dans `MEMORY.md`, auto-chargé à chaque session, et s'y est propagée
+jusqu'au fichier. Corriger le fichier sans corriger la mémoire reproduit l'incident.
+
 ## Quand la garde est réellement défectueuse
 
 Corriger la cause racine, jamais le symptôme, et **prouver la correction sur un cas réel**

--- a/log.md
+++ b/log.md
@@ -416,3 +416,21 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/codex-agents-md-bootstrap`
 - **Décision** : docs(agents): amorcer Codex sur le canon via un AGENTS.md racine pointeur
 - **Sortie** : PR aucune | commits 64e534ecb
+
+## 2026-09-04 — fix/fabricated-rpc-safety-gate-reference (auto)
+
+- **Branche** : `fix/fabricated-rpc-safety-gate-reference`
+- **Décision** : docs(governance): retirer une référence de gate fabriquée, nommer les vrais carriers
+- **Sortie** : PR #1392 | commits 5ce3cc612
+
+## 2026-09-04 — fix/20260529-idempotent-concurrent-index (auto)
+
+- **Branche** : `fix/20260529-idempotent-concurrent-index`
+- **Décision** : fix(migrations): rendre 20260529 idempotent sur le SECOND index aussi
+- **Sortie** : PR #1393 | commits d238d79ec
+
+## 2026-09-04 — fix/engine-retry-failed-migration (auto)
+
+- **Branche** : `fix/engine-retry-failed-migration`
+- **Décision** : fix(migrations): --retry pour une migration en échec + lever le timeout hérité
+- **Sortie** : PR #1395 | commits 09dd81c97


### PR DESCRIPTION
Suite de #1395. `.claude/rules/guardrails.md` traite le cas *« une garde correcte exécutée au mauvais moment produit les mêmes symptômes qu'une garde défectueuse »*. L'incident du 2026-09-04 en révèle le **jumeau** : une garde correcte, active au bon moment, dont le verdict a été **supprimé par une exemption** justifiée par un raisonnement faux.

## Le cas

`20260529_xtr_msg_crm_indexes.sql` portait `-- squawk-ignore-file require-timeout-settings`, au motif : « ne pas poser de `statement_timeout`, il tuerait le build CONCURRENTLY ». Or omettre un GUC ne le désactive pas — il fait **hériter** celui du rôle, 60 s pour `postgres` sur ce projet. Le build a été tué à 60,588 s. La règle étouffée disait mot pour mot ce qui allait se produire :

```
warning[require-timeout-settings]: Missing `set statement_timeout` before potentially slow operations
```

## Ce que la PR ajoute

Deux passes, dans la continuité des quatre existantes :

- **5.** Lancer la garde **sans** l'exemption et **citer son verdict** dans la justification. Une exemption qui ne cite pas ce que la règle aurait dit n'a pas été confrontée à la règle.
- **6.** Quand la cause est corrigée, **re-tester** si l'exemption est encore nécessaire — et si les exemptions voisines du même fichier sont encore *vivantes*. Une exemption morte continuera d'étouffer la règle le jour où quelqu'un retirera le correctif.

Et une note : les mémoires d'agent (`MEMORY.md`, auto-chargé) sont une surface d'exemption comme les autres — la consigne fausse y vivait et s'est propagée jusqu'au fichier. Corriger le fichier sans corriger la mémoire reproduit l'incident.

## `log.md`

Rattrape trois entrées de session que le hook Stop avait commitées dans des worktrees jamais poussés (#1392, #1393, #1395) — branches supprimées au merge, entrées perdues. Format identique aux entrées existantes.

**Docs uniquement — zéro delta runtime.** Aucun détecteur ajouté : c'est une règle de conduite, pas un gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)