### PR TITLE
docs(ledger): 270 des 300 lignes « applied » sont des baselines jamais vérifiées

### DIFF
--- a/audit/massdoc-ledger-declared-objects-2026-09-07.md
+++ b/audit/massdoc-ledger-declared-objects-2026-09-07.md
@@ -1,0 +1,126 @@
+# Le ledger dit « appliquée ». La base dit « absente ». 24 fois.
+
+> Mesuré le 2026-09-07 sur le projet live, **lecture seule**. Reproductible :
+> `python3 scripts/audit/extract-declared-objects.py /tmp/declared.json` produit la
+> liste des objets déclarés par chaque migration ; la requête catalogue qui vérifie
+> leur existence est dérivée de cette liste. Aucune mutation.
+
+## Le fait
+
+`infra.schema_migrations` compte **300 lignes `applied`, 0 `failed`, 0 `applying`,
+0 drift**. C'est vrai — et ça ne veut pas dire ce qu'on croit :
+
+| origine de la ligne | nombre | ce que la ligne prouve |
+|---|---|---|
+| `baseline-2026-05-16` | **221** | rien n'a été exécuté — l'objet est *supposé* déjà là |
+| `baseline-33810961050` (2026-09-02) | **49** | idem |
+| exécutions réelles | **30** | la migration a tourné, durée mesurée |
+
+**270 des 300 lignes sont des suppositions**, pas des exécutions. C'est le mode
+d'emploi documenté de `--baseline` (« adopter le moteur sur un projet où les
+migrations sont déjà déployées par un autre canal ») — mais **rien n'a jamais
+vérifié la supposition**.
+
+## La vérification, faite
+
+Pour chaque fichier de migration, les objets déclarés (`CREATE TABLE`, `VIEW`,
+`FUNCTION`, `TYPE`, `ALTER TYPE … ADD VALUE`) ont été extraits puis cherchés au
+catalogue, **tous schémas confondus**.
+
+| type d'objet | déclarés vérifiés | absents |
+|---|---|---|
+| relations (tables, vues) | 148 | **38** |
+| fonctions | 37 | **10** |
+| types | 11 | **3** |
+| valeurs d'enum | 5 | **1** |
+
+Les 38 relations absentes se séparent proprement en deux :
+
+**a) 14 archivées volontairement** — présentes dans le schéma `_archive`, déplacées
+par `SET SCHEMA` : les 7 tables `__agentic_*`, `__seo_entity`,
+`__seo_entity_score_v10`, `v_seo_dashboard_kpis`, `v_seo_index_losses_7d`,
+`v_seo_operational_queue`, `v_seo_temperature_stats`, `v_seo_url_health`.
+Ce n'est pas une anomalie du ledger, c'est un archivage — mais il n'a laissé
+**aucune trace de migration** dans le dépôt, et le code qui les lit n'a pas suivi.
+
+**b) 24 introuvables dans tous les schémas** — déclarées par une migration que le
+ledger dit `applied`, et nulle part en base :
+
+`__lighthouse_alerts` · `__lighthouse_runs` · `__marketing_brief` ·
+`__phase2a_audit_reports` · `__retention_trigger_rules` · `__seo_crux_alert_state` ·
+`__seo_crux_field_history` · `__seo_entity_health` · `__seo_index_status` ·
+`__seo_sitemap_file` · `__seo_snapshot_cf_analytics` · `__seo_snapshot_runtime_logs` ·
+`__seo_surface_duplicate_decisions` · `__seo_surface_duplicate_scores` ·
+`__seo_surface_fingerprints` · `__ux_captures` · `__ux_debt` · `__ux_design_systems` ·
+`__ux_perf_gates` · `mcp_validation_log` · `rag_documents` ·
+`supplier_inventory_snapshots` · `supplier_runtime_profile` · `supplier_truth_projection`
+
+Fonctions absentes : `calculate_risk_flags` · `count_sitemap_urls_by_temperature` ·
+`detect_satellite_pages` · `get_sitemap_urls_by_temperature` · `get_stabilize_pages` ·
+`kg_diagnose` · `link_satellites_to_entities` · `refresh_temperature_scores` ·
+`snapshot_index_status` · `sync_entity_health_from_scores`.
+Types absents : `claim_priority_enum` · `claim_status_enum` · `quote_status_enum`.
+Valeur d'enum absente : `seo_event_type.crux_fetch_run`.
+
+## Ce qui est réellement cassé aujourd'hui
+
+10 des 24 relations introuvables sont **lues par du code applicatif** — 27 sites
+d'appel `.from()`. Chacun est un `42P01` latent, invisible au typecheck (le client
+Supabase n'est pas typé `Database`) :
+
+| relation absente | appels `.from()` |
+|---|---|
+| `__seo_index_status` | 6 |
+| `__marketing_brief` | 4 |
+| `__seo_crux_field_history` | 4 |
+| `__seo_entity_health` | 3 |
+| `rag_documents` | 3 |
+| `__seo_crux_alert_state` | 2 |
+| `mcp_validation_log` | 2 |
+| `__phase2a_audit_reports` | 1 |
+| `__seo_snapshot_cf_analytics` | 1 |
+| `__seo_snapshot_runtime_logs` | 1 |
+
+S'y ajoutent les 3 fonctions du sitemap v10 appelées par `callRpc` et les 5 `.from()`
+vers des objets archivés, déjà décrits dans
+`audit/ledger-tail-owner-decisions-2026-09-04.md`.
+
+## La cause racine
+
+Ce n'est pas « une migration a raté ». C'est que **`--baseline` inscrit une hypothèse
+au même rang qu'un fait**, et que rien dans la chaîne ne la confronte ensuite au
+catalogue. Le moteur vérifie la fraîcheur ledger ↔ *fichiers* (checksum, drift,
+`--status`) ; personne ne vérifie ledger ↔ *base*.
+
+L'exemple le plus net : `20260514_seo_crux_field_history`, baselinée le 2026-05-16,
+`execution_ms = 0`. Elle déclare une table partitionnée, une table d'état d'alerte,
+4 index, la RLS, 4 politiques et une valeur d'enum. **Aucun de ces objets n'existe.**
+Le code, lui, les lit : l'endpoint `GET /api/admin/seo-monitoring/timeseries/crux`
+et `CruxAlerterService` (dormant, non planifié).
+
+## Le correctif structurel
+
+**Un gate de cohérence ledger ↔ catalogue**, dans la même famille que les invariants
+existants : pour chaque migration `applied`, les objets qu'elle déclare doivent
+exister — ou l'écart doit être déclaré explicitement (archivé, retiré, remplacé).
+Le dépistage est déjà écrit et rejouable
+(`scripts/audit/extract-declared-objects.py`) ; ce qui manque est la partie qui
+interroge le catalogue en CI et la liste d'écarts assumés.
+
+Ce qu'il ne faut **pas** faire : rejouer les 270 baselines. La plupart des objets
+existent ; l'archivage de 14 relations était délibéré ; et certaines familles
+absentes (`__ux_*`, `__lighthouse_*`) correspondent à des chantiers jamais activés,
+qu'il faut retirer plutôt que ressusciter.
+
+## Ce qui attend un arbitrage
+
+Pour chacune des 24 relations introuvables, une seule question : **ressusciter ou
+retirer ?** Les trois familles se distinguent bien :
+
+| famille | relations | lecture recommandée |
+|---|---|---|
+| chantiers jamais activés | `__ux_*` (4), `__lighthouse_*` (2), `__phase2a_audit_reports`, `__retention_trigger_rules`, `mcp_validation_log` | **retirer** le code lecteur ; les tables n'ont jamais servi |
+| supplier-truth | `supplier_inventory_snapshots`, `supplier_truth_projection`, `supplier_runtime_profile` | **retirer** — PR #837 a déjà tranché : le canon est `supplier_offer_snapshot` ; cf. §1 du brief |
+| surfaces SEO vivantes | `__seo_index_status`, `__seo_crux_*`, `__seo_entity_health`, `__seo_surface_*`, `__seo_sitemap_file`, `__seo_snapshot_*`, `__marketing_brief`, `rag_documents` | **cas par cas** — zone SEO indexée, accord nominatif requis |
+
+_Aucune action prise. Ce document mesure et instruit ; il ne tranche pas._

--- a/scripts/audit/extract-declared-objects.py
+++ b/scripts/audit/extract-declared-objects.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Extrait les objets que CHAQUE migration déclare créer, et émet la requête
+catalogue qui vérifie leur existence.
+
+Pourquoi : `infra.schema_migrations` dit qu'une migration est `applied`. Sur ce
+projet, 270 des 300 lignes `applied` sont des **baselines** (`--baseline` : la
+migration est marquée appliquée SANS être exécutée, parce qu'on suppose que
+l'objet est déjà là par un autre canal). Rien n'a jamais vérifié cette
+supposition. Le 2026-09-07, l'échantillon a trouvé 24 relations, 10 fonctions,
+3 types et 1 valeur d'enum déclarés par des migrations `applied` et absents de
+TOUS les schémas — dont 10 relations lues par du code applicatif.
+
+Ce script ne se connecte PAS à la base : il produit le SQL de vérification, à
+exécuter en lecture seule. Séparer l'extraction (déterministe, testable hors
+ligne) de la vérification (qui a besoin d'un accès) garde l'outil rejouable.
+
+    python3 scripts/audit/extract-declared-objects.py /tmp/declared.json
+
+Limites assumées : analyse par expressions régulières, pas un parseur SQL. Elle
+sur-détecte (fragments de `CREATE TABLE IF NOT EXISTS` mal découpés) et
+sous-détecte (DDL construit dynamiquement dans un DO $$). Les partitions datées
+sont écartées. C'est un instrument de dépistage, pas une preuve : chaque absence
+signalée se confirme au catalogue avant toute conclusion.
+"""
+import re, json, pathlib, sys
+D = pathlib.Path("backend/supabase/migrations")
+pats = {
+ "table": re.compile(r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-zA-Z0-9_.\"]+)", re.I),
+ "view":  re.compile(r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-zA-Z0-9_.\"]+)", re.I),
+ "function": re.compile(r"CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([a-zA-Z0-9_.\"]+)\s*\(", re.I),
+ "type": re.compile(r"CREATE\s+TYPE\s+([a-zA-Z0-9_.\"]+)", re.I),
+ "enumvalue": re.compile(r"ALTER\s+TYPE\s+([a-zA-Z0-9_.\"]+)\s+ADD\s+VALUE\s+(?:IF\s+NOT\s+EXISTS\s+)?'([^']+)'", re.I),
+}
+out = {}
+for f in sorted(D.glob("*.sql")):
+    if f.name.endswith(".down.sql"): continue
+    txt = f.read_text(encoding="utf-8", errors="replace")
+    # retirer les commentaires ligne pour éviter les faux positifs
+    body = "\n".join(l.split("--")[0] for l in txt.splitlines())
+    decl = []
+    for kind, rx in pats.items():
+        for m in rx.finditer(body):
+            if kind == "enumvalue":
+                decl.append([kind, m.group(1).strip('"').lower(), m.group(2)])
+            else:
+                n = m.group(1).strip('"').lower()
+                if n.startswith("__seo_crux_field_history_2026"): continue  # partitions datées
+                decl.append([kind, n, None])
+    if decl: out[f.stem] = decl
+json.dump(out, open(sys.argv[1], "w"), indent=0)
+print(f"  {len(out)} migrations déclarent {sum(len(v) for v in out.values())} objets")


### PR DESCRIPTION
## Le fait

`infra.schema_migrations` : **300 `applied`, 0 `failed`, 0 `applying`, 0 drift**.
C'est vrai, et ça ne veut pas dire ce qu'on croit.

| origine de la ligne | nombre |
|---|---|
| `baseline-2026-05-16` | **221** |
| `baseline-33810961050` (2026-09-02) | **49** |
| exécutions réelles | **30** |

**270 des 300 lignes sont des suppositions.** `--baseline` est fait pour ça — adopter
le moteur sur un projet déjà déployé par un autre canal — mais **rien n'a jamais
vérifié la supposition**.

## La confrontation, faite

Objets déclarés par chaque migration (`CREATE TABLE|VIEW|FUNCTION|TYPE`,
`ALTER TYPE … ADD VALUE`) cherchés au catalogue, **tous schémas confondus**.

| type | vérifiés | absents |
|---|---|---|
| relations | 148 | **38** |
| fonctions | 37 | **10** |
| types | 11 | **3** |
| valeurs d'enum | 5 | **1** |

Les 38 relations se séparent nettement :

- **14 archivées volontairement** — présentes dans `_archive` (`SET SCHEMA`). Archivage
  délibéré, mais sans aucune migration au dépôt, et le code lecteur n'a pas suivi.
- **24 introuvables partout** — dont **10 lues par du code applicatif, 27 sites `.from()`**.
  Chacun est un `42P01` latent, invisible au typecheck : le client Supabase n'est pas
  typé `Database`.

| relation absente | appels `.from()` |
|---|---|
| `__seo_index_status` | 6 |
| `__marketing_brief` | 4 |
| `__seo_crux_field_history` | 4 |
| `__seo_entity_health` | 3 |
| `rag_documents` | 3 |
| `__seo_crux_alert_state` | 2 |
| `mcp_validation_log` | 2 |
| `__phase2a_audit_reports` · `__seo_snapshot_cf_analytics` · `__seo_snapshot_runtime_logs` | 1 chacune |

## La cause racine

Le moteur vérifie la fraîcheur **ledger ↔ fichiers** (checksum, drift, `--status`).
**Personne ne vérifie ledger ↔ base.** L'exemple le plus net :
`20260514_seo_crux_field_history`, baselinée, `execution_ms = 0`, déclare une table
partitionnée, une table d'état, 4 index, la RLS, 4 politiques et une valeur d'enum —
**aucun de ces objets n'existe**, et l'endpoint `GET /api/admin/seo-monitoring/timeseries/crux`
les lit.

## Ce que cette PR fait, et ne fait pas

**Fait** : mesure, documente, et livre le dépistage rejouable
(`scripts/audit/extract-declared-objects.py`, sans connexion base — il émet la liste
des objets déclarés et le SQL de vérification).

**Ne fait pas** : aucun objet créé, supprimé ou modifié ; aucune migration rejouée.
Rejouer les 270 baselines serait le mauvais geste — la plupart des objets existent,
l'archivage des 14 était voulu, et des familles entières (`__ux_*`, `__lighthouse_*`)
correspondent à des chantiers jamais activés qu'il faut **retirer**, pas ressusciter.

## Ce qui attend un arbitrage owner

Pour chacune des 24 : ressusciter ou retirer ? Trois familles bien distinctes :

| famille | lecture recommandée |
|---|---|
| chantiers jamais activés (`__ux_*`, `__lighthouse_*`, `__phase2a_audit_reports`, `__retention_trigger_rules`, `mcp_validation_log`) | **retirer** le code lecteur |
| supplier-truth (3 tables) | **retirer** — PR #837 a déjà tranché : le canon est `supplier_offer_snapshot` |
| surfaces SEO vivantes (`__seo_*`, `__marketing_brief`, `rag_documents`) | **cas par cas** — zone SEO indexée, accord nominatif requis |

Le correctif structurel proposé est un **gate de cohérence ledger ↔ catalogue**, dans
la famille des invariants existants, avec une liste d'écarts assumés. Il n'est pas
inclus ici : cette PR instruit, elle ne tranche pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
