### PR TITLE
feat(audit): mesurer la charge réelle pour trancher XL → Large, au lieu de la déduire du disque

### DIFF
--- a/audit/massdoc-workload-measurement-xl-to-large-2026-09-07.md
+++ b/audit/massdoc-workload-measurement-xl-to-large-2026-09-07.md
@@ -1,0 +1,200 @@
+# XL → Large : le CPU n'a jamais été le problème. La taille de la base, si.
+
+> Mesuré le 2026-09-07 (soirée, ~20:00 UTC) sur le projet live, **lecture seule**,
+> `SET default_transaction_read_only = on`. Reproductible :
+> `python3 scripts/audit/sample-db-workload.py --duration 1800`.
+> Aucune mutation, aucun reset de compteur, aucune extension installée.
+
+## Pourquoi les compteurs disaient n'importe quoi
+
+`pg_stat_database` court depuis le **2025-06-06** — 458 jours — et
+`pg_stat_statements` depuis le **2025-12-10**, saturé à 4 905/5 000 entrées
+(donc en éviction). Ces deux fenêtres englobent l'ingestion TecDoc : 507 M
+d'insertions, ~79 h de travail. Le résultat est un jeu de moyennes qui ne
+décrivent aucun instant réel :
+
+| grandeur | moyenne cumulée (458 j) | mesure courante (différentielle) |
+|---|---|---|
+| transactions/s | 8,76 | **4,2 – 5,7** |
+| taux de cache | 94,17 % | **91,9 – 98,3 %** (variable par minute) |
+| lectures disque | 348 To *au total* | **0,14 – 6,6 Mo/s** |
+
+Un compteur cumulé répond à « qu'est-ce qui s'est passé depuis un an ». Il ne
+répond jamais à « de quoi cette base a-t-elle besoin maintenant ». D'où
+l'instrument : deux relevés espacés, et la dérivée entre les deux.
+
+## Ce que Large change réellement
+
+Source : [Supabase — Compute and Disk](https://supabase.com/docs/guides/platform/compute-and-disk)
+et [How to change max database connections](https://supabase.com/docs/guides/troubleshooting/how-to-change-max-database-connections-_BQ8P5),
+consultées le 2026-09-07.
+
+| | XL (aujourd'hui) | Large (cible) | mesure courante | verdict |
+|---|---|---|---|---|
+| CPU | 4 cœurs ARM dédiés | 2 cœurs ARM dédiés | **0,18 session active en moyenne, 2 au pic** | ✅ très large marge |
+| Mémoire | 16 Go (`shared_buffers` 4 Go) | 8 Go (`shared_buffers` ~2 Go) | cache 91,9–98,3 %, 3,0 Mo/s lus | ⚠️ **non tranché** |
+| Max connections | 240 | 160 | **15 au pic** | ✅ marge ×10 |
+| Pooler max clients | 1 000 | 800 | — | ✅ |
+| Replication slots / WAL senders | 24 | 8 | **0 utilisé, 0 actif** | ✅ pas un bloqueur |
+| Taille de base recommandée | 500 Go | **200 Go** | **240 Go** | ❌ **hors enveloppe** |
+| Prix | ~210 $/mois | ~110 $/mois | — | −100 $/mois |
+
+## Le bloqueur, et il n'est pas où on le cherchait
+
+**La base fait 240 Go. Large en recommande 200.** Ce n'est pas une limite dure —
+Supabase la présente comme une recommandation, pas un refus — mais c'est le seul
+axe des sept ci-dessus qui soit hors enveloppe, et il l'est de 40 Go.
+
+Cela **change le statut du chantier TecDoc** : ce n'est pas un travail parallèle
+qui se ferait « aussi », c'est le préalable qui ramène la base dans l'enveloppe.
+Les 113,5 Go des six schémas `tecdoc_*` (audit
+`massdoc-tecdoc-layers-disposition-2026-09-07.md`, PR #1409) porteraient la base
+de **240 Go à ~126 Go**, soit confortablement sous les 200 Go.
+
+L'ordre est donc contraint, et il l'est par la mesure, pas par une préférence :
+
+```
+  données          disque              compute
+  ───────          ──────              ───────
+  sortir TecDoc    upgrade PG          XL → Large
+  240 → ~126 Go    right-size le       4→2 vCPU, 16→8 Go
+       │           disque alloué            │
+       │                 │                  │
+       └─── préalable ───┴──── préalable ───┘
+```
+
+Le disque ne rétrécit jamais tout seul : seul un upgrade de version PostgreSQL
+re-dimensionne à ≈ 1,2 × la taille de la base (mesuré et instruit dans
+`audit/massdoc-db-size-and-compute-2026-09-07.md`).
+
+## Le relevé
+
+Quatre fenêtres de 30 s, 30 ticks chacune, le 2026-09-07 à 19:57–19:59 UTC —
+**heure creuse**, c'est la limite principale de ce relevé.
+
+| fenêtre | tps | cache hit | lu disque | sessions actives (moy / p95 / max) | connexions |
+|---|---|---|---|---|---|
+| 1 | 4,23 | 96,94 % | 0,26 Mo/s | 0,033 / 0 / 1 | 14 |
+| 2 | 4,17 | 95,51 % | 6,59 Mo/s | 0,333 / 1 / 1 | 14 |
+| 3 | 5,45 | 91,93 % | 5,03 Mo/s | 0,300 / 2 / 2 | 13 |
+| 4 | 5,74 | 98,33 % | 0,14 Mo/s | 0,069 / 1 / 1 | 15 |
+| **résumé** | **4,9** | **min 91,93 %** | **moy 3,03 · max 6,59 Mo/s** | **0,184 / 2 / 2** | **max 15** |
+
+**0,184 session active en moyenne sur 4 vCPU** = environ 4,6 % d'un seul cœur.
+Même en admettant un facteur 10 entre cette heure creuse et le pic, deux cœurs
+resteraient deux fois trop grands. Le CPU n'est pas ce qui retient XL.
+
+### Ce que lit le disque
+
+Différentiel de `pg_statio_user_tables` sur 90 s — **86,1 % des blocs lus
+viennent d'une seule table** :
+
+| relation | Mo lus disque | hit % | taille | part |
+|---|---|---|---|---|
+| `pieces_relation_type` | 55,40 | 93,9 % | 53,0 Go | **86,1 %** |
+| `pieces` | 2,17 | 95,5 % | 1,85 Go | 3,4 % |
+| `pieces_price` | 1,70 | 85,2 % | 0,79 Go | 2,6 % |
+| `pieces_ref_search` | 1,61 | 80,1 % | 10,6 Go | 2,5 % |
+| `pieces_media_img` | 1,48 | 84,4 % | 3,47 Go | 2,3 % |
+| `pieces_relation_criteria` | 1,01 | 92,6 % | 32,6 Go | 1,6 % |
+
+**Correction d'un audit antérieur du même jour** : `massdoc-db-size-and-compute-2026-09-07.md`
+désignait `pieces_ref_search` (10,1 Go, 35,4 % de hit) et `___xtr_msg` (10 Go,
+27,5 %) comme l'argument contre Large. Ces deux ratios sont des **cumuls sur
+458 jours**. Sur la charge courante, `pieces_ref_search` pèse 2,5 % des lectures
+et `___xtr_msg` **n'apparaît pas du tout**. Le working set réel est
+`pieces_relation_type`. Le sens de l'erreur est le même que celui contre lequel
+l'audit TecDoc mettait en garde — lire un fossile comme une mesure — et il
+s'appliquait à mon propre texte.
+
+### Le producteur de charge
+
+`pg_stat_activity` échantillonné à 0,4 s sur 130 s : **69 ticks actifs sur 71
+appartiennent à `authenticator` / `postgrest`**, dont 67 à une seule forme de
+requête. Le trafic est donc du rendu de page, pas du batch.
+
+Les gros consommateurs cumulés (`pg_stat_statements`, à lire avec la réserve
+d'éviction) :
+
+| RPC | appels | CPU cumulé | ms/appel | actif maintenant ? |
+|---|---|---|---|---|
+| `get_alternative_vehicles_for_gamme` | 423 002 | 1 058 h | **9 006** | **non** — batch admin (`r1-keyword-plan-batch.service.ts`) |
+| `rm_get_page_complete_v2` | 8 618 759 | 654 h | 273 | oui |
+| `get_pieces_for_type_gamme_v3` | 2 421 260 | 339 h | 504 | oui |
+| `get_soft_404_alternatives` | 541 602 | 139 h | 926 | oui — **288 Mo de disque pour 9 appels** (~32 Mo/appel) |
+
+`get_soft_404_alternatives` explique à elle seule les pics de lecture disque du
+relevé (fenêtres 2 et 3). C'est un levier de performance indépendant de la
+question du compute, et il n'est pas instruit ici.
+
+## Effet d'observation — deux erreurs, dont une évitée de justesse
+
+La première version de l'échantillonneur lisait `pg_stat_statements` à chaque
+tick et rapportait « un fichier temporaire de 18,43 Mo toutes les 15 s ».
+Vérification faite avant de le rapporter comme un défaut applicatif : **chaque
+lecture de `pg_stat_statements` sur ce projet écrit 18,43 Mo de fichier
+temporaire** (4 905 entrées, textes de requête matérialisés au-delà de
+`work_mem` = 16 Mo). La sonde fabriquait la métrique qu'elle observait.
+
+Mais la correction était elle-même incomplète : après suppression de toute lecture
+de `pg_stat_statements` par l'instrument, **les fichiers de 18,43 Mo persistaient,
+2 par minute**. Le producteur, identifié par capture de `pg_stat_activity` :
+**`supabase_admin` / `postgres_exporter`** — l'agent de métriques de la plateforme
+elle-même, qui scrute `pg_stat_statements` en boucle.
+
+Conséquence chiffrée : la collecte de métriques de la plateforme génère à elle
+seule de l'ordre de **37 Mo/min ≈ 53 Go/jour d'écriture de fichiers temporaires**
+sur cette base, uniquement parce que `pg_stat_statements` est saturé. C'est une
+charge d'I/O constante que personne n'a demandée, et elle **grossirait en Large**
+si `work_mem` y est plus bas. Traitement possible (non instruit ici, hors
+périmètre) : réduire `pg_stat_statements.max` ou la longueur de texte conservée.
+
+L'instrument versionné ne lit plus jamais `pg_stat_statements` ; la raison est
+écrite dans son en-tête pour que personne ne la réintroduise.
+
+## Verdict
+
+**Sur le CPU, les connexions et les slots de réplication : Large suffit, mesuré.**
+Les marges sont d'un ordre de grandeur, pas de quelques pourcents.
+
+**Sur la mémoire : non tranché, et ce relevé ne peut pas le trancher.** Passer de
+4 Go à 2 Go de `shared_buffers` sur un working set dominé par une table de 53 Go
+déjà à 93,9 % de hit augmentera les lectures disque — de combien, aucune mesure
+disponible ne le dit. L'instrument qui répondrait est **`pg_buffercache`** :
+disponible sur ce projet, **non installé**. L'installer est un `CREATE EXTENSION`,
+donc une mutation de production — **décision owner**, hors du périmètre lecture
+seule de cet audit.
+
+**Sur la taille : hors enveloppe aujourd'hui** (240 Go vs 200 Go recommandés), et
+c'est ce qui ordonne le chantier.
+
+### Ce qu'il reste à faire, dans l'ordre
+
+1. **Sortir TecDoc** (113,5 Go) — préalable, pas un travail parallèle. Bloqué par
+   `scripts/tecdoc-mysql-to-csv.py`, absent du disque et de git, appelé en dur par
+   six scripts (PR #1409). 240 Go → ~126 Go.
+2. **Échantillonner aux heures de pointe** — ce relevé est de soirée. Même
+   commande, `--duration 3600`, sur une fenêtre de trafic réel. Sans cela, « Large
+   suffit » reste une extrapolation depuis l'heure creuse.
+3. **Décision owner : `CREATE EXTENSION pg_buffercache`** — seul moyen de savoir
+   quelle fraction des 4 Go de `shared_buffers` est réellement occupée et par
+   quoi. Sans lui, l'axe mémoire restera non tranché quel que soit le nombre de
+   relevés.
+4. **Upgrade PostgreSQL** pour re-dimensionner le disque (après 1).
+5. **XL → Large** (après 1, 2, 3, 4).
+
+## Manifeste de couverture
+
+| axe de dimensionnement | statut | preuve |
+|---|---|---|
+| CPU / vCPU | **Vérifié** | 4 fenêtres × 30 ticks, `pg_stat_activity` |
+| Connexions | **Vérifié** | max 15 observé vs 240 configurées |
+| Replication slots | **Vérifié** | `pg_replication_slots` = 0 |
+| Taille de base | **Vérifié** | `pg_database_size` = 240 Go vs 200 Go doc Supabase |
+| Working set (quelles tables) | **Vérifié** | différentiel `pg_statio_user_tables` |
+| Mémoire / `shared_buffers` | **Non-vérifiable en l'état** | exige `pg_buffercache` (owner) |
+| Comportement au pic | **Non vérifié** | relevé de soirée uniquement |
+| Débit / IOPS disque | **Non vérifié** | `track_io_timing` est désactivé sur ce projet |
+
+_Aucune action prise sur la base. Ce document mesure ; il ne tranche pas le
+passage en Large, et il ne le recommande pas encore._

--- a/scripts/audit/sample-db-workload.py
+++ b/scripts/audit/sample-db-workload.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Échantillonneur **différentiel** de la charge PostgreSQL — lecture seule.
+
+POURQUOI CET INSTRUMENT EXISTE
+------------------------------
+La question « le compute XL (4 vCPU / 16 Go) peut-il descendre en Large
+(2 vCPU / 8 Go) ? » ne se tranche pas sur la taille du disque, et elle ne se
+tranche pas non plus sur les compteurs `pg_stat_*` tels quels : ils sont
+**cumulés depuis le dernier reset** — `pg_stat_database` depuis le 2025-06-06
+(458 jours au 2026-09-07), `pg_stat_statements` depuis le 2025-12-10 **et
+saturé** (4 905/5 000 entrées ⇒ éviction active). Sur ce projet ces fenêtres
+englobent l'ingestion TecDoc (507 M d'insertions, ~79 h) : la moyenne cumulée
+annonce 8,76 tps quand la mesure courante en donne ~4. Un compteur cumulé
+répond à « qu'est-ce qui s'est passé depuis un an », jamais à « de quoi cette
+base a-t-elle besoin maintenant ».
+
+Le seul relevé honnête est donc **différentiel** : deux lectures espacées, et
+la dérivée entre les deux. C'est ce que fait ce script, sans rien muter et sans
+jamais toucher aux compteurs.
+
+CE QU'IL MESURE, ET RIEN DE PLUS
+--------------------------------
+Par fenêtre d'agrégation :
+
+- `sessions_actives_moy / p95 / max` — échantillonné à haute fréquence dans
+  `pg_stat_activity`. **C'est le chiffre qui dimensionne le vCPU** : une
+  moyenne de 0,1 session active veut dire qu'un seul cœur suffirait ; une
+  moyenne proche du nombre de vCPU veut dire que le CPU est le goulot.
+- `cache_hit_pct` et `lu_disque_mo_s` — dérivés de `pg_stat_database`. **C'est
+  le couple qui dimensionne la RAM** : à `shared_buffers` constant, un débit de
+  lecture disque soutenu signifie que le working set déborde déjà du cache.
+- `temp_fichiers / temp_mo` — débordements de `work_mem`.
+- `connexions` vs `max_connections` — Supabase réduit `max_connections` avec la
+  taille de compute (240 en XL). Une pointe proche du plafond est un bloqueur
+  indépendant du CPU et de la RAM.
+
+Il **ne dit pas** si Large suffit. Il produit les relevés qui permettent de le
+dire, et seulement pour la fenêtre observée : une mesure de soirée ne prouve
+rien sur l'heure de pointe. Échantillonner aux heures de pointe fait partie de
+la mesure, pas des détails d'exécution.
+
+CONTRAT DE PÉRIMÈTRE — OBSERVATION, JAMAIS UN GATE
+--------------------------------------------------
+Ce script n'a **aucun seuil** et ne sort jamais non-zéro sur une valeur
+mesurée. Il n'est pas branché en CI et ne doit pas l'être : un gate de capacité
+serait un second détecteur pour une responsabilité que personne ne porte
+aujourd'hui, et il échouerait sur la variance normale du trafic
+(`.claude/rules/guardrails.md`, passes 2 et 4). Les décisions de compute sont
+owner-gated.
+
+POURQUOI IL NE LIT PAS `pg_stat_statements`
+-------------------------------------------
+Mesuré le 2026-09-07 : **chaque `SELECT … FROM pg_stat_statements` écrit un
+fichier temporaire de 18,43 Mo** sur ce projet (4 905 entrées, textes de requête
+matérialisés). Une sonde qui interroge `pg_stat_statements` à chaque tick
+fabrique donc elle-même les débordements `work_mem` qu'elle est censée
+observer — la première version de cet échantillonneur a rapporté « 18 Mo de
+temp toutes les 15 s » qui étaient intégralement les siens. L'effet
+d'observation est corrigé à la cause : ce script ne touche pas à la vue.
+Pour identifier *quelle* requête consomme, faire un différentiel
+`pg_stat_statements` **séparé et ponctuel**, en sachant qu'il se compte
+lui-même.
+
+USAGE
+-----
+    export DATABASE_URL=…                       # pooler ⇒ user = postgres.<ref>
+    python3 scripts/audit/sample-db-workload.py --duration 1800
+    python3 scripts/audit/sample-db-workload.py --duration 3600 --emit audit/…json
+    python3 scripts/audit/sample-db-workload.py --self-test    # pas de DB
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+
+# Fenêtre d'agrégation et fréquence d'échantillonnage des sessions. Le tick est
+# court parce qu'une requête de 300 ms est invisible à un tick de 60 s : c'est
+# la fréquence qui fait la fidélité de `sessions_actives_moy`, pas la fenêtre.
+DEFAULT_WINDOW_S = 60.0
+DEFAULT_TICK_S = 1.0
+
+DB_COUNTERS = """
+SELECT xact_commit + xact_rollback AS xacts,
+       blks_read, blks_hit, temp_files, temp_bytes, numbackends
+  FROM pg_stat_database
+ WHERE datname = current_database()
+"""
+
+# `pg_stat_activity` est une vue mémoire : pas de lecture de fichier, pas de
+# tri, donc pas de fichier temporaire — contrairement à pg_stat_statements.
+ACTIVITY = """
+SELECT count(*) FILTER (WHERE state = 'active')                        AS actives,
+       count(*) FILTER (WHERE state = 'active'
+                          AND wait_event_type IS NOT NULL)             AS actives_en_attente,
+       count(*)                                                        AS connexions
+  FROM pg_stat_activity
+ WHERE datname = current_database() AND pid <> pg_backend_pid()
+"""
+
+SETTINGS = """
+SELECT current_setting('max_connections')::int,
+       current_setting('shared_buffers'),
+       current_setting('effective_cache_size'),
+       current_setting('work_mem')
+"""
+
+
+def fail(code: int, msg: str) -> None:
+    print(f"ERREUR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+# --------------------------------------------------------------------------
+# Agrégation — fonctions pures, couvertes par --self-test
+# --------------------------------------------------------------------------
+
+def percentile(values: list[float], q: float) -> float:
+    """Percentile par rang le plus proche (borné aux extrêmes de l'échantillon).
+
+    `statistics.quantiles` interpole et refuse n < 2 ; sur des comptages de
+    sessions, une valeur interpolée n'existe pas dans le système observé.
+    """
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = max(0, min(len(ordered) - 1, int(round(q * (len(ordered) - 1)))))
+    return float(ordered[idx])
+
+
+def window_metrics(before: dict, after: dict, ticks: list[dict], elapsed_s: float) -> dict:
+    """Dérive une fenêtre à partir de deux relevés de compteurs et des ticks.
+
+    `elapsed_s` est mesuré sur une horloge monotone par l'appelant : l'heure
+    murale peut sauter, et une division par un intervalle faux fabrique
+    silencieusement des débits faux.
+    """
+    if elapsed_s <= 0:
+        raise ValueError("elapsed_s doit être > 0")
+    read = after["blks_read"] - before["blks_read"]
+    hit = after["blks_hit"] - before["blks_hit"]
+    actives = [t["actives"] for t in ticks]
+    conns = [t["connexions"] for t in ticks]
+    return {
+        "fenetre_s": round(elapsed_s, 1),
+        "ticks": len(ticks),
+        "tps": round((after["xacts"] - before["xacts"]) / elapsed_s, 2),
+        "cache_hit_pct": round(100.0 * hit / (hit + read), 2) if (hit + read) else None,
+        "lu_disque_mo": round(read * 8192 / 1e6, 2),
+        "lu_disque_mo_s": round(read * 8192 / 1e6 / elapsed_s, 3),
+        "sessions_actives_moy": round(statistics.fmean(actives), 3) if actives else 0.0,
+        "sessions_actives_p95": percentile([float(a) for a in actives], 0.95),
+        "sessions_actives_max": max(actives) if actives else 0,
+        "actives_en_attente_max": max((t["actives_en_attente"] for t in ticks), default=0),
+        "connexions_moy": round(statistics.fmean(conns), 1) if conns else 0.0,
+        "connexions_max": max(conns) if conns else 0,
+        "temp_fichiers": after["temp_files"] - before["temp_files"],
+        "temp_mo": round((after["temp_bytes"] - before["temp_bytes"]) / 1e6, 2),
+    }
+
+
+def summarize(windows: list[dict]) -> dict:
+    """Résume les fenêtres. Les maxima priment : c'est la pointe qui dimensionne."""
+    if not windows:
+        return {}
+    total_s = sum(w["fenetre_s"] for w in windows)
+    total_mo = sum(w["lu_disque_mo"] for w in windows)
+    moy = [w["sessions_actives_moy"] for w in windows]
+    return {
+        "fenetres": len(windows),
+        "duree_totale_s": round(total_s, 1),
+        "tps_moy": round(statistics.fmean([w["tps"] for w in windows]), 2),
+        "sessions_actives_moy": round(statistics.fmean(moy), 3),
+        "sessions_actives_p95_max": max(w["sessions_actives_p95"] for w in windows),
+        "sessions_actives_max": max(w["sessions_actives_max"] for w in windows),
+        "actives_en_attente_max": max(w["actives_en_attente_max"] for w in windows),
+        "connexions_max": max(w["connexions_max"] for w in windows),
+        "lu_disque_mo_s_moy": round(total_mo / total_s, 3) if total_s else 0.0,
+        "lu_disque_mo_s_max": max(w["lu_disque_mo_s"] for w in windows),
+        "cache_hit_pct_min": min(
+            (w["cache_hit_pct"] for w in windows if w["cache_hit_pct"] is not None),
+            default=None,
+        ),
+        "temp_mo_total": round(sum(w["temp_mo"] for w in windows), 2),
+    }
+
+
+# --------------------------------------------------------------------------
+# Collecte
+# --------------------------------------------------------------------------
+
+def connect():
+    try:
+        import psycopg
+    except ImportError:
+        fail(EXIT_USAGE, "psycopg manquant — pip install 'psycopg[binary]==3.2.*'")
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        fail(EXIT_USAGE, "DATABASE_URL absent de l'environnement.")
+    return psycopg.connect(url, autocommit=True)
+
+
+def read_counters(cur) -> dict:
+    cur.execute(DB_COUNTERS)
+    cols = [c.name for c in cur.description]
+    return dict(zip(cols, cur.fetchone()))
+
+
+def read_tick(cur) -> dict:
+    cur.execute(ACTIVITY)
+    actives, waiting, conns = cur.fetchone()
+    return {"actives": actives, "actives_en_attente": waiting, "connexions": conns}
+
+
+def run(duration_s: float, window_s: float, tick_s: float, emit: str | None) -> int:
+    with connect() as conn, conn.cursor() as cur:
+        # Le read-only est affirmé côté serveur, pas seulement par convention :
+        # toute écriture accidentelle échouerait au lieu de passer.
+        cur.execute("SET default_transaction_read_only = on")
+        cur.execute("SET statement_timeout = '15s'")
+        cur.execute(SETTINGS)
+        max_conn, shared_buffers, eff_cache, work_mem = cur.fetchone()
+        header = {
+            "debut": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "max_connections": max_conn,
+            "shared_buffers": shared_buffers,
+            "effective_cache_size": eff_cache,
+            "work_mem": work_mem,
+        }
+        print(json.dumps({"entete": header}, ensure_ascii=False), flush=True)
+
+        windows: list[dict] = []
+        deadline = time.monotonic() + duration_s
+        while time.monotonic() < deadline:
+            w_start = time.monotonic()
+            before = read_counters(cur)
+            ticks: list[dict] = []
+            w_end = min(w_start + window_s, deadline)
+            while time.monotonic() < w_end:
+                ticks.append(read_tick(cur))
+                time.sleep(tick_s)
+            after = read_counters(cur)
+            w = window_metrics(before, after, ticks, time.monotonic() - w_start)
+            w["ts"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            windows.append(w)
+            print(json.dumps(w, ensure_ascii=False), flush=True)
+
+    resume = summarize(windows)
+    print(json.dumps({"resume": resume}, ensure_ascii=False), flush=True)
+    if emit:
+        with open(emit, "w", encoding="utf-8") as fh:
+            json.dump({"entete": header, "fenetres": windows, "resume": resume},
+                      fh, ensure_ascii=False, indent=2)
+        print(f"→ {emit}", file=sys.stderr)
+    return EXIT_OK
+
+
+# --------------------------------------------------------------------------
+# Self-test — aucune DB requise
+# --------------------------------------------------------------------------
+
+def self_test() -> int:
+    n = 0
+
+    def check(cond, label):
+        nonlocal n
+        assert cond, label
+        n += 1
+
+    check(percentile([], 0.95) == 0.0, "percentile: échantillon vide → 0")
+    check(percentile([3.0], 0.95) == 3.0, "percentile: un seul point")
+    # Rang le plus proche : jamais une valeur absente de l'échantillon.
+    check(percentile([0.0, 0.0, 0.0, 5.0], 0.95) == 5.0, "percentile: p95 atteint le max")
+    check(percentile([0.0, 1.0, 2.0, 3.0], 0.5) in (1.0, 2.0), "percentile: médiane dans l'échantillon")
+    check(all(percentile([1.0, 2.0, 9.0], q) in (1.0, 2.0, 9.0) for q in (0.0, 0.5, 0.95, 1.0)),
+          "percentile: n'interpole jamais")
+
+    before = {"xacts": 100, "blks_read": 10, "blks_hit": 90,
+              "temp_files": 0, "temp_bytes": 0, "numbackends": 5}
+    after = {"xacts": 400, "blks_read": 60, "blks_hit": 1030,
+             "temp_files": 2, "temp_bytes": 3_000_000, "numbackends": 6}
+    ticks = [{"actives": 0, "actives_en_attente": 0, "connexions": 10},
+             {"actives": 2, "actives_en_attente": 1, "connexions": 12},
+             {"actives": 1, "actives_en_attente": 0, "connexions": 11}]
+    w = window_metrics(before, after, ticks, 60.0)
+    check(w["tps"] == 5.0, "tps = 300 transactions / 60 s")
+    # 50 blocs lus, 940 hits ⇒ 940/990.
+    check(w["cache_hit_pct"] == 94.95, f"cache_hit attendu 94.95, obtenu {w['cache_hit_pct']}")
+    check(w["lu_disque_mo"] == 0.41, f"50 blocs = 0.41 Mo, obtenu {w['lu_disque_mo']}")
+    check(w["sessions_actives_moy"] == 1.0, "moyenne (0+2+1)/3")
+    check(w["sessions_actives_max"] == 2, "max des ticks")
+    check(w["actives_en_attente_max"] == 1, "max des actives en attente")
+    check(w["connexions_max"] == 12, "max des connexions")
+    check(w["temp_fichiers"] == 2 and w["temp_mo"] == 3.0, "delta temp")
+    check(w["ticks"] == 3, "nombre de ticks conservé")
+
+    # Une fenêtre sans I/O disque du tout ne doit pas annoncer 0 % de cache.
+    quiet_after = dict(before, xacts=100)
+    wq = window_metrics(before, quiet_after, ticks, 10.0)
+    check(wq["cache_hit_pct"] is None, "aucun bloc touché ⇒ hit ratio indéfini, pas 0")
+    check(wq["tps"] == 0.0, "aucune transaction ⇒ 0 tps")
+
+    try:
+        window_metrics(before, after, ticks, 0)
+    except ValueError:
+        n += 1
+    else:
+        raise AssertionError("elapsed_s = 0 doit lever, pas diviser par zéro")
+
+    s = summarize([w, wq])
+    check(s["fenetres"] == 2, "résumé: 2 fenêtres")
+    check(s["sessions_actives_max"] == 2, "résumé: max propagé")
+    check(s["cache_hit_pct_min"] == 94.95, "résumé: min ignore les fenêtres sans I/O")
+    check(summarize([]) == {}, "résumé d'une liste vide")
+
+    print(f"self-test OK — {n} assertions")
+    return EXIT_OK
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        description="Échantillonneur différentiel read-only de la charge PostgreSQL.",
+        epilog="Observation seule — aucun seuil, aucun verdict, jamais en CI.",
+    )
+    p.add_argument("--duration", type=float, default=1800.0,
+                   help="durée totale du relevé en secondes (défaut 1800)")
+    p.add_argument("--window", type=float, default=DEFAULT_WINDOW_S,
+                   help=f"fenêtre d'agrégation en secondes (défaut {DEFAULT_WINDOW_S:g})")
+    p.add_argument("--tick", type=float, default=DEFAULT_TICK_S,
+                   help=f"période d'échantillonnage des sessions (défaut {DEFAULT_TICK_S:g})")
+    p.add_argument("--emit", metavar="FICHIER", help="écrit le relevé complet en JSON")
+    p.add_argument("--self-test", action="store_true", help="teste les fonctions pures, sans DB")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if args.tick <= 0 or args.window <= 0 or args.duration <= 0:
+        fail(EXIT_USAGE, "--duration, --window et --tick doivent être > 0.")
+    if args.tick > args.window:
+        fail(EXIT_USAGE, "--tick doit être ≤ --window, sinon la fenêtre n'a aucun tick.")
+    return run(args.duration, args.window, args.tick, args.emit)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Le problème de méthode

« Large suffit-il ? » était instruit avec des compteurs **cumulés** : `pg_stat_database` depuis le 2025-06-06 (458 j), `pg_stat_statements` depuis le 2025-12-10 **et saturé** (4 905/5 000 ⇒ éviction). Les deux fenêtres englobent l'ingestion TecDoc — 507 M d'insertions, ~79 h. Résultat : la moyenne cumulée annonce **8,76 tps** là où la mesure courante en donne **4,2 – 5,7**.

Un compteur cumulé répond à « qu'est-ce qui s'est passé depuis un an ». Jamais à « de quoi cette base a-t-elle besoin maintenant ».

## Ce que livre ce PR

**`scripts/audit/sample-db-workload.py`** — échantillonneur différentiel, lecture seule affirmée côté serveur (`SET default_transaction_read_only = on`).

Contrat de périmètre écrit dans l'en-tête : **aucun seuil, aucun verdict, jamais en CI.** Un gate de capacité serait un second détecteur pour une responsabilité que personne ne porte, et il échouerait sur la variance normale du trafic (`.claude/rules/guardrails.md`, passes 2 et 4).

## Ce que le relevé tranche

4 fenêtres × 30 ticks, 2026-09-07 19:57–19:59 UTC :

| axe | XL aujourd'hui | Large | mesuré | verdict |
|---|---|---|---|---|
| CPU | 4 vCPU | 2 vCPU | **0,184 session active moy · 2 au pic** | ✅ marge ×10 |
| Connexions | 240 | 160 | **15 au pic** | ✅ |
| Replication slots | 24 | 8 | **0 utilisé** | ✅ pas le bloqueur craint |
| Mémoire | 16 Go | 8 Go | cache 91,9–98,3 % | ⚠️ **non tranché** |
| Taille de base | 500 Go rec. | **200 Go rec.** | **240 Go** | ❌ **hors enveloppe** |

**0,184 session active sur 4 vCPU ≈ 4,6 % d'un cœur.** Le CPU n'a jamais été ce qui retenait XL.

## Le bloqueur réel, et ce qu'il implique

**240 Go contre 200 Go recommandés en Large** — le seul des sept axes hors enveloppe. Cela **requalifie le chantier TecDoc** : les 113,5 Go de #1409 ne sont pas un travail parallèle, c'est le préalable qui ramène la base à ~126 Go.

L'ordre devient contraint par la mesure, pas par une préférence : sortir TecDoc → upgrade PG (right-size disque) → XL → Large.

## Deux corrections d'audits du même jour

**1. `massdoc-db-size-and-compute-2026-09-07.md` visait les mauvaises tables.** Il désignait `pieces_ref_search` (35,4 % de hit) et `___xtr_msg` (27,5 %) comme l'argument contre Large — ce sont des **ratios cumulés sur 458 jours**. Sur la charge courante : `pieces_ref_search` = 2,5 % des lectures, `___xtr_msg` **absent**. Le working set réel est `pieces_relation_type` — 53 Go, **86,1 % des blocs lus**. L'erreur est exactement celle contre laquelle l'audit TecDoc mettait en garde, appliquée à mon propre texte.

**2. Effet d'observation, attrapé puis re-corrigé.** La première sonde rapportait « 18,43 Mo de temp toutes les 15 s ». Vérification avant de le rapporter comme défaut applicatif : **toute lecture de `pg_stat_statements` sur ce projet écrit 18,43 Mo de fichier temporaire** (4 905 entrées, textes matérialisés > `work_mem` 16 Mo). La sonde fabriquait sa propre métrique.

Mais la correction était incomplète : l'instrument purgé de toute lecture pgss, **les 18,43 Mo persistaient, 2/min**. Producteur identifié par capture `pg_stat_activity` : **`supabase_admin` / `postgres_exporter`**, l'agent de métriques de la plateforme. Soit ~**53 Go/jour d'écritures temporaires** dues à la seule saturation de pgss — et qui **grossiraient en Large** si `work_mem` y est plus bas.

## Ce que ce PR ne prétend pas

- **La mémoire reste non tranchée.** `shared_buffers` 4 → 2 Go sur un working set dominé par une table de 53 Go déjà à 93,9 % de hit augmentera les lectures disque — d'un montant qu'aucune mesure disponible ne donne. L'instrument qui répondrait est **`pg_buffercache` : disponible, non installé**. L'installer est un `CREATE EXTENSION`, donc une mutation de production — **décision owner**, hors du périmètre lecture seule.
- **Le relevé est de soirée.** Une mesure en heure creuse ne prouve rien sur le pic. `--duration 3600` sur une fenêtre de trafic réel fait partie de la mesure, pas des détails.
- **Aucune recommandation de passer en Large.** Le document mesure ; il ne tranche pas.

## Evidence

```
$ python3 scripts/audit/sample-db-workload.py --self-test
self-test OK — 21 assertions

$ bash scripts/lint/check-preprod-vocabulary.sh
✅ Preprod vocabulary lint: 642 file(s) checked, 0 violations.

$ python3 scripts/audit/sample-db-workload.py --duration 10 --window 5 --tick 30
ERREUR: --tick doit être ≤ --window, sinon la fenêtre n'a aucun tick.

$ DATABASE_URL= python3 scripts/audit/sample-db-workload.py --duration 5
ERREUR: DATABASE_URL absent de l'environnement.

$ node scripts/registry/check-new-files.js
[check-new-files] new files: 2 (2 ok, 0 failures)

$ # le registry n'indexe que .ts/.tsx/.js/.mjs/.cjs (2 837 fichiers, 0 .py, 0 .md)
$ # ⇒ ce PR ne peut pas déplacer canonical.json : aucune régénération, aucune cascade PR-8b
```

Tous les chemins cités dans le document ont été vérifiés présents sur `main` — sauf `scripts/tecdoc-mysql-to-csv.py`, cité précisément **parce qu'il est absent** (c'est le bloqueur n° 1 de #1409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
