### PR TITLE
chore(tecdoc): remettre sous git le parseur et les 7 artefacts du pipeline, retrouvés en objets orphelins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,8 @@ agent-submissions/
 # CSV exports at root (Ahrefs, Search Console, etc.)
 *.csv
 !packages/**/*.csv
+# Fixture de non-regression du parseur TecDoc : la sortie attendue DOIT etre versionnee
+!scripts/tecdoc-parser-fixtures/*.csv
 
 # PDFs (source brochures, not for git)
 frontend/*.pdf

--- a/audit/massdoc-tecdoc-artifact-recovery-2026-09-07.md
+++ b/audit/massdoc-tecdoc-artifact-recovery-2026-09-07.md
@@ -1,0 +1,135 @@
+# Récupération des artefacts TecDoc — provenance et vérification
+
+> 2026-09-07. PR **strictement non destructive** : elle ne fait que remettre sous contrôle
+> de version des fichiers retrouvés. Aucune base touchée, aucun `DROP`, aucune donnée
+> supprimée, aucun resize, aucun changement de compute.
+
+## Pourquoi maintenant
+
+Le pipeline d'import TecDoc dépendait de fichiers qui n'existaient plus qu'à **deux
+endroits fragiles** : des objets Git **orphelins** (non atteignables depuis une branche,
+un tag ou le reflog) dans le dépôt de la machine DEV, et le disque de cette même machine.
+
+`git rev-list --objects --all --reflog | grep c4da30a1` renvoie **zéro** : un
+`git gc --prune` détruisait définitivement le parseur, et avec lui toute possibilité de
+reconstruire `tecdoc_raw` — donc `source_linkages`. Les audits antérieurs
+(`massdoc-c1-tecdoc-reproducibility-2026-09-02.md`, PR #1409) l'avaient déclaré
+« absent du disque **et de git** » : la première moitié est vraie, la seconde est fausse.
+L'instrument utilisé (`git log --all`) ne voit pas les objets non atteignables.
+
+## Artefacts récupérés
+
+Les 8 fichiers sont restaurés **à leur chemin d'origine**. C'est nécessaire pour les
+scripts : sept appelants référencent le parseur par le chemin absolu
+`/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py`.
+
+| fichier | provenance | blob Git (sha1) | statut |
+|---|---|---|---|
+| `scripts/tecdoc-mysql-to-csv.py` | objet orphelin, dépôt DEV | `c4da30a15cf51fb10f2c77620502e0e7e421eaf9` | **original récupéré** — octet pour octet |
+| `scripts/tecdoc-batch-load.sh` | objet orphelin, dépôt DEV | `41ae2667d82a29c8451f59f0560a16614524a946` | **original récupéré** — octet pour octet |
+| `scripts/tecdoc-batch-load.py` | objet orphelin, dépôt DEV | `cc3075bf8ef437debbd6cfdad7f6da7d8e00c59f` | **original récupéré** — octet pour octet |
+| `scripts/recover-tecdoc-images.py` | objet orphelin, dépôt DEV | `c7a6e67f71f2d098c95270028a776e2e3ace7c7e` | original récupéré **puis expurgé** (§Sécurité) |
+| `docs/audit/recovered-tecdoc-2026-09-07/tecdoc-source-mapping.md`<br>_origine : `.spec/00-canon/db-governance/`_ | objet orphelin, dépôt DEV | `af25a1f2b8849a5ec71a646749c931b7ce2b458f` | **document historique** — octet pour octet |
+| `docs/audit/recovered-tecdoc-2026-09-07/tecdoc-apply-mapping.md`<br>_origine : `.spec/00-canon/db-governance/`_ | objet orphelin, dépôt DEV | `4ce4583694aca7c2abbb2e17bcccfff12ccfcdbb` | **document historique** — octet pour octet |
+| `docs/audit/recovered-tecdoc-2026-09-07/runbook-reimport-tecdoc-images.md`<br>_origine : `docs/`_ | objet orphelin, dépôt DEV | `7e7d030bd307427aa54a242104ec0f65cdcf74f3` | **document historique** — octet pour octet |
+| `docs/audit/recovered-tecdoc-2026-09-07/tecdoc-ingestion-rootcause-2026-04-13.md`<br>_origine : `.spec/reports/`_ | objet orphelin, dépôt DEV | `f7530d825303b98b10a58051d9960ea32719817d` | document historique **puis expurgé** (§Sécurité) |
+
+Récupération : `git cat-file -p <blob> > <chemin>`. Chaque fichier a été revérifié après
+copie par `git hash-object`, qui rend le sha1 attendu — les 8 correspondent.
+
+> **Les 4 scripts sont restaurés à leur chemin d'origine** — c'est une nécessité
+> technique : sept appelants référencent le parseur par chemin absolu.
+>
+> **Les 4 documents sont regroupés sous `docs/audit/recovered-tecdoc-2026-09-07/`**,
+> et non à leur chemin d'origine, pour deux raisons. (1) Deux d'entre eux venaient de
+> `.spec/00-canon/` : y restaurer des documents **historiques** leur rendrait une
+> apparence d'autorité canon courante, que le CLAUDE.md signale précisément comme
+> dangereuse (« legacy `.spec/00-canon` docs self-declare CANON but closure-status »).
+> Le canon vit au vault. (2) `docs/audit/**` est déjà couvert par un glob d'ownership
+> existant, là où `.spec/00-canon/db-governance/**` et `.spec/reports/**` ne le sont
+> pas — les y placer exigerait une édition de `ownership.yaml`, qui est owner-only.
+> Le chemin d'origine de chacun est conservé dans le tableau ci-dessus.
+
+## Sécurité — une expurgation, et une rotation à faire
+
+Le scan de secrets a **échoué** sur 2 des 8 fichiers, et il a fallu le lire pour le voir :
+`scripts/recover-tecdoc-images.py:50-51` portait les identifiants du portail TecDoc **en
+clair**, et le rapport root-cause (lignes 86-87) les recopiait verbatim (c'est ce rapport, écrit en avril 2026, qui signalait déjà la dette).
+
+Deux constats qui ont décidé du traitement :
+
+1. **Le secret n'est PAS dans l'historique atteignable.** `git log --all` sur ce chemin
+   ne rend rien, et la recherche du littéral sur les commits atteignables non plus.
+   L'exposer serait donc une **régression introduite par cette PR**, pas la perpétuation
+   d'un état existant.
+2. **`gitleaks` ne le détecte pas** — `no leaks found` sur les 8 fichiers, avec la
+   configuration du dépôt. Le mot de passe est court et sans préfixe reconnaissable. La
+   garde CI serait **verte et fausse** ; on ne peut pas s'appuyer dessus ici.
+
+Traitement retenu : les deux littéraux sont remplacés par une lecture d'environnement,
+sur le modèle que le fichier applique déjà à `SUPABASE_KEY`. C'est la **seule**
+modification de contenu de cette PR, et elle est délibérée.
+
+> **Action owner requise, hors PR** : les identifiants du portail TecDoc utilisés par ce
+> script doivent être considérés comme **compromis et tournés**. Ils ont séjourné en clair
+> dans un objet Git sur la machine DEV. Le compte concerné est identifiable dans le blob
+> d'origine `c7a6e67f…`, non reproduit ici.
+
+Aucun autre secret : les scripts lisent `SUPABASE_SERVICE_ROLE_KEY` et
+`SUPABASE_DB_PASSWORD` depuis l'environnement ou `backend/.env`. Les valeurs par défaut
+présentes (`aws-0-eu-west-3.pooler.supabase.com`, `db.<ref>.supabase.co`, `postgres.<ref>`,
+`https://<ref>.supabase.co`) sont des hôtes et identifiants publics ; le project-ref
+figure déjà dans 138 fichiers du dépôt, dont `.gitleaks.toml`.
+
+## Dette de portabilité — signalée, non corrigée
+
+Conformément au périmètre, **aucun chemin n'a été « corrigé »**. Les scripts d'origine
+contiennent des chemins absolus, qui restent valides tant que les fichiers sont à leur
+place d'origine :
+
+| fichier | dette |
+|---|---|
+| `tecdoc-batch-load.sh:15-20` | `/opt/automecanik/app/.github/SQL-CONVERTED.7z`, `/opt/automecanik/data/tecdoc/{filelists,workdir,logs}`, et le parseur en absolu |
+| `tecdoc-mysql-to-csv.py` | aucun chemin absolu, mais **lit le fichier entier en mémoire** (`f.read()`) : 640 Mo d'entrée → ~2 Go de RSS. À revoir avant tout rejeu de masse |
+| `tecdoc-batch-load.py:101-117` | valeurs de connexion par défaut en dur ; remonte à `../backend/.env` |
+| `recover-tecdoc-images.py:62` | remonte à `../backend/.env` |
+| les 3 scripts | `/opt/automecanik/data/tecdoc/` est **hors dépôt** : 17 autres scripts du pipeline y vivent encore, non versionnés |
+
+## Ce que la validation prouve
+
+`bash scripts/test-tecdoc-mysql-to-csv.sh --with-large` → **PASS=9 FAIL=0 SKIP=0**.
+
+Le parseur committé (sha256 `bde7657f851eccdb8146f1c12c5ab286dc45784575a15e018b13416bd46e01b7`)
+régénère **octet pour octet** les 7 sorties produites par le pipeline réel en mars 2026,
+y compris `012.csv` (1 177 199 036 octets, 13 336 463 lignes, ~2 min). Plus une fixture
+synthétique sans aucune dépendance, qui couvre `NULL` vs chaîne vide, `\'`, `''`, `\\`,
+virgule et guillemet (quoting RFC 4180), `\t`, `\r`, `\n` en champ multi-ligne,
+`0000-00-00`, et la continuité du compteur `_source_row_no` entre deux `INSERT`.
+
+Les octets des 7 fixtures réelles ne sont **pas** versionnés : ce sont des données TecDoc
+sous licence. `scripts/tecdoc-parser-fixtures/real-fixtures.sha256` en porte les
+empreintes, ce qui permet de rejouer la validation sur une machine qui dispose du
+répertoire sans redistribuer la donnée. En l'absence de ce répertoire, le test annonce
+explicitement le saut plutôt que de laisser croire à une couverture complète.
+
+## Ce que cette PR ne prouve pas
+
+- **Pas le rejeu complet.** Aucune reconstruction de bout en bout depuis l'archive n'a
+  jamais été exécutée. Un parseur validé sur 7 fixtures n'est pas un pipeline rejoué.
+- **Pas la reproductibilité du périmètre de mars 2026.** La liste des « DLNR actifs » qui
+  pilote `load-t400-active.py` et `populate-source-linkages` n'est ni un fichier ni une
+  table figée : c'est une requête sur l'état vivant de la base. Un rejeu aujourd'hui ne
+  reconstituerait donc pas le même périmètre.
+- **Pas l'autorisation de supprimer quoi que ce soit.** Les ~110 Go de `tecdoc_raw` et
+  `source_linkages` restent intouchés, et le restent tant qu'un rejeu réel n'a pas été
+  prouvé. La disposition est owner-gated (invariant 9, DB destructive).
+- **Pas la fermeture des portes runtime.** Les 5 portes ouvertes sur les schémas
+  `tecdoc_*` — dont `__load_tecdoc_raw`, `SECURITY DEFINER` en écriture avec `EXECUTE`
+  à `PUBLIC` — sont hors périmètre et feront l'objet d'une PR sécurité dédiée.
+
+## Risque fermé par cette PR
+
+Le pipeline TecDoc ne dépend plus d'objets Git orphelins ni du seul disque de la machine
+DEV. Les 4 scripts et 4 documents sont désormais dans `main`, donc répliqués sur GitHub et
+sur chaque checkout. Un `git gc --prune` sur la machine DEV est redevenu une opération
+sans conséquence.

--- a/docs/audit/recovered-tecdoc-2026-09-07/runbook-reimport-tecdoc-images.md
+++ b/docs/audit/recovered-tecdoc-2026-09-07/runbook-reimport-tecdoc-images.md
@@ -1,0 +1,166 @@
+# Runbook : Re-import des images TecDoc fournisseur
+
+> Derniere mise a jour : 2026-04-11
+
+## Contexte
+
+Les images produit dans Supabase Storage (`rack-images/{DLNR}/`) proviennent du flux
+de donnees TecDoc. Chaque fournisseur (DLNR = Data Supplier Number) fournit ses images
+dans un package media standardise.
+
+En avril 2026, les images des produits inactifs ont ete supprimees pour reduire le
+stockage Supabase. Ce runbook explique comment re-importer les images si un fournisseur
+est reactive.
+
+## Architecture du pipeline images
+
+```
+TecDoc Media Package (PNG/JPG par fournisseur)
+    |
+    v
+tecdoc_doc.graphics_registry   (9.4M refs, 836 fournisseurs)
+    |  colonnes : source_dlnr, bildname, bildtype, width, height
+    |
+    v
+Script de projection : data/tecdoc/project-images.py
+    |  log : data/tecdoc/logs/project-images.log
+    |
+    v
+public.pieces_media_img         (refs fichier par piece)
+    |  colonnes : pmi_piece_id, pmi_folder (= DLNR), pmi_name (= filename)
+    |
+    v
+Supabase Storage bucket: rack-images/{DLNR}/{filename}
+    |
+    v
+Caddy proxy /img/rack-images/{DLNR}/{filename}  (cache 1 an)
+    |
+    v
+imgproxy /imgproxy/...  (conversion WebP a la volee, optionnel)
+```
+
+## Procedure de re-import pour un fournisseur
+
+### Pre-requis
+
+- Acces au package media TecDoc pour le fournisseur
+- Acces service_role Supabase
+- Le fournisseur doit avoir des pieces actives (`piece_display = true`)
+
+### Etapes
+
+1. **Verifier les pieces actives du fournisseur**
+
+```sql
+-- Remplacer XXX par le DLNR du fournisseur
+SELECT count(*) as active_pieces
+FROM pieces_media_img pmi
+JOIN pieces p ON p.piece_id = pmi.pmi_piece_id::int
+WHERE pmi.pmi_folder = 'XXX'
+  AND p.piece_display = true;
+```
+
+2. **Lister les images manquantes**
+
+```sql
+-- Images referencees en DB mais absentes du Storage
+SELECT pmi.pmi_name
+FROM pieces_media_img pmi
+JOIN pieces p ON p.piece_id = pmi.pmi_piece_id::int
+WHERE pmi.pmi_folder = 'XXX'
+  AND p.piece_display = true
+  AND NOT EXISTS (
+    SELECT 1 FROM storage.objects so
+    WHERE so.bucket_id = 'rack-images'
+      AND so.name = 'XXX/' || pmi.pmi_name
+  );
+```
+
+3. **Extraire les images du package TecDoc**
+
+```bash
+# Les packages TecDoc sont distribues par fournisseur
+# Format habituel : {DLNR}_{bildname}.{ext}
+# Extraire les fichiers necessaires depuis le package media
+```
+
+4. **Convertir en WebP (format actuel)**
+
+```bash
+# Installer cwebp si necessaire : apt install webp
+# Convertir chaque image
+for f in *.PNG *.JPG *.png *.jpg; do
+  cwebp -q 80 "$f" -o "${f%.*}.webp"
+done
+```
+
+5. **Uploader vers Supabase Storage**
+
+```python
+from supabase import create_client
+
+supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+# Upload par batch
+for filepath in webp_files:
+    filename = os.path.basename(filepath)
+    with open(filepath, 'rb') as f:
+        supabase.storage.from_('rack-images').upload(
+            f'{dlnr}/{filename}',
+            f.read(),
+            {'content-type': 'image/webp'}
+        )
+```
+
+6. **Mettre a jour les references DB**
+
+```sql
+-- Mettre a jour pmi_name pour pointer vers le WebP
+UPDATE pieces_media_img
+SET pmi_name = regexp_replace(pmi_name, '\.(PNG|JPG|JPEG|png|jpg|jpeg)$', '.webp')
+WHERE pmi_folder = 'XXX'
+  AND pmi_name ~ '\.(PNG|JPG|JPEG|png|jpg|jpeg)$';
+```
+
+7. **Verifier**
+
+```bash
+# Tester une image sur le site
+curl -I https://www.automecanik.com/img/rack-images/XXX/example.webp
+# Doit retourner 200 avec content-type: image/webp
+```
+
+## Fournisseurs actifs (reference avril 2026)
+
+62 folders actifs dans rack-images. Les principaux (par taille) :
+
+| DLNR | Taille | Fichiers actifs | Fournisseur |
+|------|--------|-----------------|-------------|
+| 161  | 12 GB  | 25,165          | -           |
+| 16   | 8.6 GB | 5,946           | -           |
+| 123  | 7.8 GB | 35,313          | -           |
+| 13   | 7.2 GB | 35,857          | -           |
+| 65   | 5.2 GB | 16,719          | -           |
+| 101  | 5.0 GB | 37,540          | -           |
+
+Total images actives : ~586,690 fichiers.
+
+## Format des images
+
+- **Avant avril 2026** : PNG/JPG (format original TecDoc)
+- **Apres avril 2026** : WebP (qualite 80)
+- imgproxy est configure pour servir du WebP a la volee si necessaire
+- Le code backend (`backend/src/modules/catalog/utils/image-urls.utils.ts`) gere les deux formats
+
+## Scripts utiles
+
+| Script | Description |
+|--------|-------------|
+| `scripts/cleanup-inactive-rack-images-v2.py` | Nettoyage images inactives (dry-run/commit) |
+| `data/tecdoc/project-images.py` | Pipeline de projection TecDoc → pieces_media_img |
+| `scripts/verify-supabase-images.js` | Verification images Supabase |
+
+## Contact
+
+Pour obtenir les packages media TecDoc, contacter le support TecDoc
+ou utiliser le portail TecDoc Alliance.

--- a/docs/audit/recovered-tecdoc-2026-09-07/tecdoc-apply-mapping.md
+++ b/docs/audit/recovered-tecdoc-2026-09-07/tecdoc-apply-mapping.md
@@ -1,0 +1,138 @@
+# TecDoc Apply Mapping — Document B
+
+> **Version** : 1.0.0
+> **Date** : 2026-03-15
+> **Pre-requis** : E5 SAFE_TO_UPSERT confirme, Document A (tecdoc-source-mapping.md)
+> **Scope** : Phase 1 (t001, t100, t200, t209, t210)
+
+---
+
+## Principe
+
+Ce document definit comment les donnees TecDoc normalisees (`tecdoc_norm`) sont appliquees aux tables de production AutoMecanik. Aucun apply sans ce mapping valide.
+
+## Cle d'UPSERT principale
+
+| Source TecDoc | Table AutoMecanik | Cle UPSERT | Evidence |
+|--------------|-------------------|------------|----------|
+| (ARTNR, DLNR) | `pieces` | `(piece_ref, piece_pm_id)` | E5 SAFE_TO_UPSERT, UNIQUE constraint en place |
+
+---
+
+## t200 → pieces (articles principaux)
+
+| Colonne TecDoc | Colonne AutoMecanik | Type AM | Overwrite | Null handling | Notes |
+|---------------|--------------------|---------|-----------|----|-------|
+| ARTNR | piece_ref | VARCHAR | NEVER_OVERWRITE | — | Cle UPSERT, jamais modifie |
+| DLNR | piece_pm_id | SMALLINT | NEVER_OVERWRITE | — | Cle UPSERT, jamais modifie |
+| BEZNR | piece_des | VARCHAR | UPDATE_IF_DIFFERENT | KEEP_EXISTING | Description, via table 030 |
+| KZSB | — | — | IGNORE | — | Self-service packing, pas utilise |
+| KZMAT | — | — | IGNORE | — | Certification materiau, pas utilise |
+| KZAT | — | — | IGNORE | — | Piece remanufacturee, pas utilise |
+| KZZUB | — | — | IGNORE | — | Accessoire, pas utilise |
+| LOSGR1 | piece_qty_pack | SMALLINT | UPDATE_IF_DIFFERENT | KEEP_EXISTING | Taille lot |
+| LOSGR2 | — | — | IGNORE | — | Taille lot 2, pas utilise |
+| LOSCH_FLAG | — | — | Voir politique LOSCH_FLAG | — | Soft delete |
+
+**Colonnes AutoMecanik NON alimentees par TecDoc** (a preserver) :
+- `piece_id` — ID interne, JAMAIS touche
+- `piece_ref_clean` — genere par le backend
+- `piece_name`, `piece_name_comp`, `piece_name_side` — enrichissement interne
+- `piece_fil_id`, `piece_fil_name` — famille interne
+- `piece_ga_id`, `piece_pg_id`, `piece_pg_pid` — mappings internes (via t211/t320)
+- `piece_qty_sale` — logique commerciale interne
+- `piece_weight_kgm` — poids (source separee)
+- `piece_has_oem`, `piece_has_img` — flags calcules
+- `piece_year` — annee (logique interne)
+- `piece_display` — visibilite (gere par LOSCH_FLAG)
+- `piece_sort` — tri interne
+- `piece_update` — flag update interne
+- `piece_psf_id` — filtre cote
+- `search_vector` — tsvector genere
+
+---
+
+## t100 → pieces_marque (fournisseurs)
+
+| Colonne TecDoc | Colonne AutoMecanik | Overwrite | Null handling | Notes |
+|---------------|--------------------|-----------|----|-------|
+| HERNR | pm_id | NEVER_OVERWRITE | — | Cle UPSERT |
+| HKZ | pm_code | UPDATE_IF_DIFFERENT | KEEP_EXISTING | Code court |
+| LBEZNR | — | IGNORE | — | Ref description (table 012) |
+| PKW/NKW/VGL/... | — | IGNORE | — | Flags type fabricant |
+
+**Cle UPSERT** : `pm_id` = HERNR (a confirmer par audit)
+
+---
+
+## t209 → pieces_ref_ean (codes EAN)
+
+| Colonne TecDoc | Colonne AutoMecanik | Overwrite | Null handling | Notes |
+|---------------|--------------------|-----------|----|-------|
+| ARTNR+DLNR | pre_piece_id | — | — | Resolu via lookup pieces (ARTNR,DLNR) → piece_id |
+| EANNR | pre_code_ean | ALWAYS | — | Code EAN |
+| LOSCH_FLAG | — | Voir politique LOSCH_FLAG | — | |
+
+**Cle UPSERT** : `(pre_piece_id, pre_code_ean)` — PK existante.
+**Lookup obligatoire** : ARTNR+DLNR → piece_id via `pieces`.
+
+---
+
+## t210 → pieces_criteria (criteres article)
+
+| Colonne TecDoc | Colonne AutoMecanik | Overwrite | Null handling | Notes |
+|---------------|--------------------|-----------|----|-------|
+| ARTNR+DLNR | pc_piece_id | — | — | Resolu via lookup pieces |
+| KRITNR | pc_cri_id | ALWAYS | — | Numero critere |
+| KRITWERT | pc_cri_value | ALWAYS | — | Valeur critere |
+| SORTNR | pc_sort | UPDATE_IF_DIFFERENT | KEEP_EXISTING | Ordre affichage |
+| LOSCH_FLAG | — | Voir politique LOSCH_FLAG | — | |
+
+**Cle UPSERT** : `(pc_piece_id, pc_cri_id)` ou `(pc_piece_id, pc_sort)` — a confirmer.
+**Lookup obligatoire** : ARTNR+DLNR → piece_id via `pieces`.
+
+---
+
+## t001 — Header (pas d'apply direct)
+
+La table t001 sert uniquement a :
+- Identifier la version du lot fournisseur
+- Determiner si c'est un envoi complet ou delta
+- Documenter le manifest
+
+**Pas d'apply vers une table AutoMecanik.** Les donnees restent dans `tecdoc_norm.t001` pour reference.
+
+---
+
+## Politique LOSCH_FLAG
+
+| LOSCH_FLAG | Action | Condition |
+|-----------|--------|-----------|
+| 0 | UPSERT normal | — |
+| 1 (article sans commande active) | `piece_display = false` | Soft delete |
+| 1 (article avec commande active) | **REVIEW** — journal dans `__tecdoc_losch_log` | Pas de soft delete automatique |
+| 1 (article avec contenu SEO) | **REVIEW** — journal | Pas de soft delete automatique |
+
+**Journal LOSCH_FLAG** : table `__tecdoc_losch_log` (artnr, dlnr, table_id, action, batch_id, created_at).
+
+---
+
+## Ordre d'apply (respect des FK)
+
+1. `pieces_marque` (t100) — pas de FK entrantes
+2. `pieces` (t200) — cible de toutes les FK
+3. `pieces_ref_ean` (t209) — FK vers pieces
+4. `pieces_criteria` (t210) — FK vers pieces
+
+> t001 n'est pas applique en production.
+
+---
+
+## Regles de securite apply
+
+1. **Jamais de TRUNCATE** — toujours UPSERT
+2. **Jamais de modification de piece_id** — ID interne preservee
+3. **Jamais de DELETE reel** — LOSCH_FLAG = soft delete uniquement
+4. **Lookup ARTNR+DLNR → piece_id** obligatoire avant toute ecriture satellite
+5. **Articles nouveaux** (pas de match) : INSERT avec nouveau piece_id auto-genere
+6. **ANALYZE apres chaque table** appliquee

--- a/docs/audit/recovered-tecdoc-2026-09-07/tecdoc-ingestion-rootcause-2026-04-13.md
+++ b/docs/audit/recovered-tecdoc-2026-09-07/tecdoc-ingestion-rootcause-2026-04-13.md
@@ -1,0 +1,138 @@
+# Root cause — Pipeline TecDoc → `pieces_media_img` — 2026-04-13
+
+> **Statut** : `SCOPE_SCANNED — ROOT_CAUSE_CONFIRMED`.
+> **Objectif** : identifier exactement le script et la ligne de code qui ont introduit les 4 996 429 lignes fantômes dans `pieces_media_img`.
+
+## 1. Script fautif identifié
+
+**Fichier** : [`scripts/tecdoc-project-core.py`](../../scripts/tecdoc-project-core.py)
+**Date de dernière modification** : 2026-03-26 18:45
+**Fonction** : `project_image_chunk(dlnr)` aux lignes 94-117
+**Statement INSERT fautif** : lignes 100-110
+
+```python
+def project_image_chunk(dlnr):
+    """Project one DLNR chunk of t232 → pieces_media_img."""
+    conn = psycopg2.connect(CONN_STR, options='-c statement_timeout=120000')
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_media_img (pmi_piece_id, pmi_pm_id, pmi_folder, pmi_name, pmi_sort, pmi_display, pmi_piece_id_i)
+        SELECT
+          ar.piece_id::text, %s, '', gr.bildname, t232.sortnr, '1', ar.piece_id
+        FROM tecdoc_raw.t232 t232
+        JOIN tecdoc_map.article_registry ar ON ar.source_artnr = t232.artnr AND ar.source_dlnr = t232.dlnr::int
+        JOIN tecdoc_doc.graphics_registry gr ON gr.source_bildnr = t232.bildnr::int AND gr.source_dlnr = t232.dlnr::int
+        WHERE ar.piece_id IS NOT NULL AND t232.losch_flag != '1' AND gr.bildname IS NOT NULL
+          AND t232.dlnr = %s
+        ON CONFLICT (pmi_piece_id, pmi_name) DO NOTHING
+        """, (dlnr, dlnr))
+```
+
+## 2. Défauts du statement (ligne par ligne)
+
+### 2.1 `pmi_folder = ''` en dur
+```sql
+SELECT ar.piece_id::text, %s, '', gr.bildname, ...
+                              ^^
+```
+Le 3e champ de la liste SELECT (qui correspond à `pmi_folder`) est la chaîne vide **littérale**. Le script projette 9M+ lignes avec `pmi_folder=''`, créant directement les fantômes de l'audit §1.
+
+L'intention du développeur originel était probablement : *"je mets vide en attendant qu'un script secondaire remplisse avec le `dlnr`"*. Le script secondaire n'a jamais été écrit — ou bien `recover-tecdoc-images.py` (qui utilise `pmi_folder=eq.{dlnr}`) attendait une table déjà remplie et n'a jamais pu s'exécuter.
+
+### 2.2 `pmi_name = gr.bildname` brut
+```sql
+SELECT ..., gr.bildname, ...
+```
+`graphics_registry.bildname` contient les noms TecDoc **bruts** : parfois des références produit (`fdb4180_1100025`), parfois des noms techniques (`KIT3P`, `TECH BULLETIN ACT - TS 04 -19`), **sans extension de fichier**.
+
+Conséquences :
+- Impossible de construire une URL valide (pas d'extension).
+- Certains `bildname` ne désignent pas des images (TSBs, guides de montage, bulletins techniques). Ces lignes polluent la table même sémantiquement — elles ne correspondront **jamais** à un fichier image.
+
+### 2.3 `pmi_display = '1'` systématique
+```sql
+SELECT ..., t232.sortnr, '1', ...
+                         ^^^
+```
+Toutes les lignes sont marquées `display='1'` sans vérifier que leur pendant visuel existe. Cela contamine directement toutes les RPCs qui se basent sur ce flag.
+
+### 2.4 Aucune validation d'existence Storage
+Le script fait `JOIN` uniquement sur les tables TecDoc (`t232`, `article_registry`, `graphics_registry`) et n'interroge **jamais** `storage.objects`. Aucune vérification que `bildname` correspond à un fichier réellement uploadé dans le bucket `rack-images`.
+
+### 2.5 `ON CONFLICT DO NOTHING`
+```sql
+ON CONFLICT (pmi_piece_id, pmi_name) DO NOTHING
+```
+La contrainte d'unicité `(pmi_piece_id, pmi_name)` empêche les doublons mais **ne corrige rien** : si une ligne fantôme a été insérée en premier (`folder=''`), une ligne valide future avec le même `(piece_id, name)` sera ignorée. C'est un amplificateur de dette : plus on relance le script, plus on verrouille les fantômes.
+
+### 2.6 Pas de contrainte DB en amont
+La table `pieces_media_img` n'a **aucune contrainte** qui bloquerait l'insertion de lignes cassées : pas de `CHECK (pmi_folder ~ '^[0-9]+$')`, pas de `CHECK (pmi_name ~* '\.(jpg|jpeg|...)$')`, pas de `FOREIGN KEY` vers `storage.objects`. Le script peut donc insérer n'importe quoi sans résistance.
+
+## 3. Script de "recovery" prévu mais non fonctionnel
+
+Le fichier [`scripts/recover-tecdoc-images.py`](../../scripts/recover-tecdoc-images.py) (513 lignes) existe et implémente la chaîne Playwright → CDN TecAlliance → upload Supabase. Mais :
+
+- Ligne 110 et 162 : il **filtre** sur `pmi_folder=eq.{dlnr}`, donc ne traite que les lignes déjà remplies. **Les lignes fantômes `pmi_folder=''` sont invisibles pour ce script**.
+- Il suppose que la table est déjà cohérente, ce qui n'est jamais le cas.
+
+Le design complet (projection → recovery) n'a jamais été exécuté dans l'ordre prévu, et la boucle de récupération ne peut pas se déclencher sur les 5 millions de lignes fantômes.
+
+## 4. Note sécurité — secrets en clair
+
+[`scripts/recover-tecdoc-images.py:50-51`](../../scripts/recover-tecdoc-images.py) :
+```python
+TECDOC_EMAIL = "<EXPURGE 2026-09-07>"
+TECDOC_PASS = "<EXPURGE 2026-09-07>"
+```
+
+Credentials en clair dans le fichier source, versionné dans le repo. **À remonter séparément comme dette de sécurité** (rotation du mot de passe + migration vers `backend/.env`). Hors scope de la remédiation `pieces_media_img`.
+
+## 5. Autres scripts touchant `pieces_media_img`
+
+| Fichier | Rôle | Problème |
+|---|---|---|
+| `scripts/tecdoc-project-core.py` | Projection TecDoc → DB | **Source unique de la pollution** (ligne 103) |
+| `scripts/recover-tecdoc-images.py` | Télécharge depuis CDN TecAlliance | Ne voit pas les lignes fantômes |
+| `scripts/convert-rack-images-webp.py` | Renomme en .webp | Ignore les lignes fantômes |
+| `scripts/cleanup-inactive-rack-images-v2.py` | Supprime les fichiers Storage orphelins | ⚠️ **Script fautif de l'incident 2026-04-11** — bug de pagination a effacé 80k fichiers actifs |
+
+## 6. Chronologie reconstituée
+
+| Date | Événement | Impact |
+|---|---|---|
+| ≤ mars 2026 | Anciennes pièces avec images valides, Storage cohérent | Affichage OK |
+| 2026-03-26 | Création/modification de `tecdoc-project-core.py` | Injection de ~5M lignes fantômes (`folder=''`) |
+| Mars-avril 2026 | Le script tourne, la table se pollue progressivement | Les RPCs génèrent des URLs `rack-images//xxx` (404) |
+| 2026-04-11 | Incident `cleanup-inactive-rack-images-v2.py` : 80 374 fichiers Storage supprimés, dont 100 % du dossier `21/` (Valeo) et 2/3 du dossier `62/` (Ferodo) | Les pièces qui marchaient encore passent en 404 |
+| 2026-04-13 | Migration `20260413_fix_broken_images_in_listing.sql` : filtre défensif `pmi_folder ~ '^[0-9]+$'` ajouté à `get_listing_products_extended` | Les 404 deviennent des `no.png` silencieux → symptôme visible (utilisateur remonte le problème) |
+| 2026-04-13 | Signalement utilisateur des pages Megane + Mercedes | Déclenchement de cet audit |
+
+## 7. Corrections requises (hors scope de cet audit)
+
+À planifier dans l'ADR-011 :
+
+1. **Réécriture de `project_image_chunk`** avec :
+   - `pmi_folder = %s` (le `dlnr` passé en paramètre), pas `''`
+   - `pmi_name = gr.bildname || '.jpg'` (ou équivalent détecté via une colonne extension si elle existe dans `graphics_registry`)
+   - Vérification `EXISTS (SELECT 1 FROM storage.objects WHERE bucket_id='rack-images' AND name = dlnr || '/' || bildname || '.jpg')` avant INSERT
+   - Alternative plus robuste : faire la projection en deux étapes (stage table → upload → validation → insert final)
+2. **Contraintes DB** : `CHECK` sur format `pmi_folder` et `pmi_name`, trigger `BEFORE INSERT/UPDATE` qui bloque toute ligne sans contrepartie Storage.
+3. **Rotation des credentials TecDoc** dans `recover-tecdoc-images.py`.
+4. **Purge des lignes fantômes existantes** selon la classification du rapport de réconciliation.
+
+## 8. Exit contract
+
+| Champ | Valeur |
+|---|---|
+| `scope_requested` | Identifier le script et le mécanisme qui ont pollué `pieces_media_img` |
+| `scope_actually_scanned` | 4 scripts Python `scripts/tecdoc-*.py` + `scripts/recover-tecdoc-images.py` + `scripts/cleanup-inactive-rack-images-v2.py` |
+| `files_read_count` | 5 scripts (`tecdoc-project-core.py`, `recover-tecdoc-images.py`, `convert-rack-images-webp.py`, `cleanup-inactive-rack-images-v2.py`, `tecdoc-import.py`) |
+| `excluded_paths` | Autres chemins d'écriture de `pieces_media_img` (edge functions, backend services) — non trouvés dans le backend NestJS actif |
+| `corrections_proposed` | Décrit en §7 (hors scope audit) |
+| `validation_executed` | 0 |
+| `remaining_unknowns` | — Confirmé que les écritures passent uniquement par `tecdoc-project-core.py` pour le volume massif. Vérification complémentaire backend à faire si des routes admin écrivent aussi. |
+| `final_status` | `SCOPE_SCANNED — ROOT_CAUSE_CONFIRMED` |
+
+La cause racine est **confirmée avec certitude** : le statement SQL des lignes 100-110 de `scripts/tecdoc-project-core.py` insère systématiquement `pmi_folder=''` et `pmi_name` sans extension, sans validation Storage. C'est le point unique d'injection de la pollution.

--- a/docs/audit/recovered-tecdoc-2026-09-07/tecdoc-source-mapping.md
+++ b/docs/audit/recovered-tecdoc-2026-09-07/tecdoc-source-mapping.md
@@ -1,0 +1,119 @@
+# TecDoc Source Mapping — Document A
+
+> **Version** : 1.0.0
+> **Date** : 2026-03-15
+> **Source** : `CreateTablesTAF24.sql` (TAF 2.7)
+> **Scope** : Phase 1 (t001, t100, t200, t209, t210)
+
+---
+
+## Convention
+
+- **DLNR** = Data Supplier Number (identifie le fournisseur, ex: 730 = Bosch)
+- **ARTNR** = Article Number (reference article chez le fournisseur)
+- **SA** = constante table (toujours = numero de table)
+- **LOSCH_FLAG** = 1 = marque pour suppression (delta delivery)
+- **BEZNR** = numero de description (jointure vers table 030 pour textes multilingues)
+- **LKZ** = Country Code
+- **PK source** = cle primaire dans le schema TecDoc MySQL
+
+---
+
+## t001 — Header (version fournisseur)
+
+| Colonne | Type MySQL | Sens metier | PK | Nullable |
+|---------|-----------|-------------|-----|----------|
+| DLNR | smallint(4) | Fournisseur ID | **PK** | NOT NULL |
+| SA | smallint(3) | Constante = 1 | — | NOT NULL |
+| DATA_RELEASE | smallint(4) | Version (format xxyy) | — | NOT NULL |
+| DATUM | int(8) | Date version YYYYMMDD | — | NOT NULL |
+| KZVOLL | tinyint(1) | 1 = livraison complete | — | NOT NULL |
+| KHERNR | mediumint(6) | Numero constructeur vehicule | — | NOT NULL |
+| MARKE | varchar(20) | Marque (TecDoc) | — | NOT NULL |
+| REFERENZDATEN | mediumint(4) | Version reference data (xxyy) | — | NOT NULL |
+| VORVERSION | mediumint(4) | Version precedente (delta) | — | NULL |
+| FORMAT | varchar(3) | Version format (2.x) | — | NOT NULL |
+| LOSCH_FLAG | tinyint(1) | 1 = supprimer tous les articles de la marque | — | NOT NULL |
+
+**Role** : 1 ligne par fournisseur. Indique la version de ses donnees et si c'est un envoi complet ou delta.
+
+---
+
+## t100 — Manufacturers (fournisseurs)
+
+| Colonne | Type MySQL | Sens metier | PK | Nullable |
+|---------|-----------|-------------|-----|----------|
+| DLNR | smallint(4) | Constante = 9999 | — | NOT NULL |
+| SA | smallint(3) | Constante = 100 | — | NOT NULL |
+| HERNR | mediumint(6) | Numero fabricant unique | **PK** | NOT NULL |
+| HKZ | varchar(10) | Code court fabricant | — | NOT NULL |
+| LBEZNR | int(9) | Description (→ 012) | — | NOT NULL |
+| PKW | tinyint(1) | Fabricant auto | — | NOT NULL |
+| NKW | tinyint(1) | Fabricant poids lourd | — | NOT NULL |
+| VGL | tinyint(1) | Fabricant comparatif | — | NOT NULL |
+| ACHSE | tinyint(1) | Fabricant essieux | — | NOT NULL |
+| MOTOR | tinyint(1) | Fabricant moteurs | — | NOT NULL |
+| GETRIEBE | tinyint(1) | Fabricant transmissions | — | NOT NULL |
+| TRANSPORTER | tinyint(1) | Fabricant utilitaires | — | NOT NULL |
+| DELETE | tinyint(1) | 1 = propose pour suppression | — | NOT NULL |
+
+**Role** : referentiel des fabricants (Bosch, Valeo, TRW, etc.). HERNR = cle unique.
+
+---
+
+## t200 — Main Articles
+
+| Colonne | Type MySQL | Sens metier | PK | Nullable |
+|---------|-----------|-------------|-----|----------|
+| ARTNR | varchar(22) | Reference article fournisseur | **PK** | NOT NULL |
+| DLNR | smallint(4) | Fournisseur ID | **PK** | NOT NULL |
+| SA | smallint(3) | Constante = 200 | — | NOT NULL |
+| BEZNR | int(9) | Description (→ 030) | — | NULL |
+| KZSB | tinyint(1) | Self-service packing | — | NULL |
+| KZMAT | tinyint(1) | Certification materiau obligatoire | — | NULL |
+| KZAT | tinyint(1) | Piece remanufacturee | — | NULL |
+| KZZUB | tinyint(1) | Accessoire | — | NULL |
+| LOSGR1 | mediumint(5) | Taille lot 1 | — | NULL |
+| LOSGR2 | mediumint(5) | Taille lot 2 | — | NULL |
+| LOSCH_FLAG | tinyint(1) | 1 = supprimer | — | NOT NULL |
+
+**Role** : table principale des articles. PK = (ARTNR, DLNR).
+**Mapping AutoMecanik** : `piece_ref` = ARTNR, `piece_pm_id` = DLNR.
+
+---
+
+## t209 — EAN List
+
+| Colonne | Type MySQL | Sens metier | PK | Nullable |
+|---------|-----------|-------------|-----|----------|
+| ARTNR | varchar(22) | Reference article | **PK** | NOT NULL |
+| DLNR | smallint(4) | Fournisseur ID | **PK** | NOT NULL |
+| SA | smallint(3) | Constante = 209 | — | NOT NULL |
+| LKZ | varchar(3) | Country Code | — | NULL |
+| EANNR | varchar(14) | Code EAN | **PK** | NOT NULL |
+| EXCLUDE | tinyint(1) | 1 = exclusion pays | — | NULL |
+| LOSCH_FLAG | tinyint(1) | 1 = supprimer | — | NOT NULL |
+
+**Role** : codes barres EAN par article. PK = (ARTNR, DLNR, EANNR).
+**Mapping AutoMecanik** : `pieces_ref_ean.pre_piece_id` (via ARTNR+DLNR), `pre_code_ean` = EANNR.
+
+---
+
+## t210 — Fixed Article Criteria
+
+| Colonne | Type MySQL | Sens metier | PK | Nullable |
+|---------|-----------|-------------|-----|----------|
+| ARTNR | varchar(22) | Reference article | **PK** | NOT NULL |
+| DLNR | smallint(4) | Fournisseur ID | **PK** | NOT NULL |
+| SA | smallint(3) | Constante = 210 | — | NOT NULL |
+| RESERVIERT | varchar(5) | Ancien GenArtNr (obsolete) | — | NULL |
+| LKZ | varchar(3) | Country Code | — | NULL |
+| SORTNR | smallint(3) | Ordre affichage | **PK** | NOT NULL |
+| KRITNR | smallint(4) | Numero critere (KT 050) | — | NOT NULL |
+| KRITWERT | varchar(20) | Valeur critere | — | NOT NULL |
+| ANZSOFORT1 | tinyint(1) | Afficher = 1 | — | NULL |
+| EXCLUDE | tinyint(1) | 1 = exclusion pays | — | NULL |
+| LOSCH_FLAG | tinyint(1) | 1 = supprimer | — | NOT NULL |
+
+**Role** : criteres techniques fixes par article (dimensions, specifications). PK = (ARTNR, DLNR, SORTNR).
+**Mapping AutoMecanik** : `pieces_criteria.pc_piece_id` (via ARTNR+DLNR), `pc_cri_id` = KRITNR.

--- a/scripts/recover-tecdoc-images.py
+++ b/scripts/recover-tecdoc-images.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""
+Recovery script: telecharge les images manquantes depuis le CDN TecAlliance public.
+
+Etape 1: Via Playwright, recherche chaque article sur le catalogue TecDoc
+         et capture les URLs d'images du CDN digital-assets.tecalliance.services
+Etape 2: Telecharge les images depuis le CDN public (sans auth)
+Etape 3: Re-uploade vers Supabase Storage
+
+Usage:
+  python3 recover-tecdoc-images.py --dlnr 86 --dry-run     # Test sur 1 fournisseur
+  python3 recover-tecdoc-images.py --dlnr 86 --commit       # Execution reelle
+  python3 recover-tecdoc-images.py --all --commit            # Tous les fournisseurs
+
+Securite:
+  - Rythme humain : 5-10 secondes entre chaque recherche
+  - CDN public pour le telechargement (pas d'auth)
+  - Progression sauvegardee pour reprise
+"""
+
+import asyncio
+import os
+import sys
+import json
+import time
+import random
+import logging
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from io import BytesIO
+
+try:
+    from playwright.async_api import async_playwright
+except ImportError:
+    print("pip install playwright required")
+    sys.exit(1)
+
+try:
+    from supabase import create_client
+    import requests
+except ImportError:
+    print("pip install supabase requests required")
+    sys.exit(1)
+
+# --- Config ---
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "https://cxpojprgwgubzjyqzmoq.supabase.co")
+SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+BUCKET = "rack-images"
+# [EXPURGE 2026-09-07 a la recuperation] Le fichier d'origine portait ici les
+# identifiants du portail TecDoc en clair. Ils sont retires : ce depot ne doit pas
+# les recevoir. Meme idiome que SUPABASE_KEY ci-dessus (env, puis backend/.env).
+# Le mot de passe d'origine DOIT etre considere comme compromis et tourne.
+TECDOC_EMAIL = os.environ.get("TECDOC_EMAIL", "")
+TECDOC_PASS = os.environ.get("TECDOC_PASS", "")
+CDN_BASE = "https://digital-assets.tecalliance.services/images"
+LOG_DIR = Path(__file__).parent / "logs"
+PROGRESS_FILE = LOG_DIR / "recover-images-progress.json"
+
+# Rate limits (secondes)
+SEARCH_DELAY_MIN = 5
+SEARCH_DELAY_MAX = 10
+DOWNLOAD_DELAY = 0.5
+
+if not SUPABASE_KEY:
+    env_path = Path(__file__).parent.parent / "backend" / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith("SUPABASE_SERVICE_ROLE_KEY="):
+                SUPABASE_KEY = line.split("=", 1)[1].strip()
+
+if not SUPABASE_KEY:
+    print("ERROR: SUPABASE_SERVICE_ROLE_KEY not found")
+    sys.exit(1)
+
+# --- Logging ---
+LOG_DIR.mkdir(exist_ok=True)
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+log_file = LOG_DIR / f"recover-images-{timestamp}.log"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.FileHandler(log_file), logging.StreamHandler()]
+)
+logger = logging.getLogger(__name__)
+
+
+def load_progress():
+    if PROGRESS_FILE.exists():
+        return json.loads(PROGRESS_FILE.read_text())
+    return {"recovered": {}, "failed": {}, "cdn_mappings": {}}
+
+
+def save_progress(progress):
+    PROGRESS_FILE.write_text(json.dumps(progress, indent=2))
+
+
+def get_missing_images(dlnr: str) -> list:
+    """Recupere la liste des images manquantes pour un DLNR depuis la DB."""
+    headers = {
+        "apikey": SUPABASE_KEY,
+        "Authorization": f"Bearer {SUPABASE_KEY}",
+    }
+
+    # Utiliser une RPC ou requete directe
+    # On doit faire le cross-ref manuellement via PostgREST
+    # D'abord recuperer tous les pmi_name actifs pour ce folder
+    all_names = set()
+    offset = 0
+    while True:
+        url = (
+            f"{SUPABASE_URL}/rest/v1/pieces_media_img"
+            f"?pmi_folder=eq.{dlnr}"
+            f"&select=pmi_name,pmi_piece_id"
+            f"&limit=1000&offset={offset}"
+        )
+        resp = requests.get(url, headers=headers)
+        if resp.status_code != 200 or not resp.json():
+            break
+
+        rows = resp.json()
+        # Verifier quels pieces sont actifs
+        piece_ids = list({r["pmi_piece_id"] for r in rows})
+        active_ids = set()
+        for i in range(0, len(piece_ids), 200):
+            batch = piece_ids[i:i+200]
+            ids_str = ",".join(str(pid) for pid in batch)
+            p_url = f"{SUPABASE_URL}/rest/v1/pieces?piece_id=in.({ids_str})&piece_display=eq.true&select=piece_id"
+            p_resp = requests.get(p_url, headers=headers)
+            if p_resp.status_code == 200:
+                for p in p_resp.json():
+                    active_ids.add(str(p["piece_id"]))
+
+        for r in rows:
+            if str(r.get("pmi_piece_id", "")) in active_ids:
+                all_names.add(r["pmi_name"])
+
+        if len(rows) < 1000:
+            break
+        offset += 1000
+
+    # Verifier lesquels manquent dans Storage
+    missing = []
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+    # Lister les fichiers existants dans le folder
+    existing = set()
+    list_offset = 0
+    while True:
+        files = supabase.storage.from_(BUCKET).list(dlnr, {"limit": 1000, "offset": list_offset})
+        if not files:
+            break
+        for f in files:
+            existing.add(f["name"])
+        if len(files) < 1000:
+            break
+        list_offset += 1000
+
+    # Recuperer aussi le piece_ref pour chaque pmi_name (la vraie ref TecDoc)
+    name_to_ref = {}
+    offset2 = 0
+    while True:
+        url = (
+            f"{SUPABASE_URL}/rest/v1/pieces_media_img"
+            f"?pmi_folder=eq.{dlnr}"
+            f"&select=pmi_name,pmi_piece_id"
+            f"&limit=1000&offset={offset2}"
+        )
+        resp = requests.get(url, headers=headers)
+        if resp.status_code != 200 or not resp.json():
+            break
+        rows = resp.json()
+        piece_ids_batch = list({r["pmi_piece_id"] for r in rows})
+        # Recuperer les piece_ref pour ces piece_ids
+        for i in range(0, len(piece_ids_batch), 200):
+            batch = piece_ids_batch[i:i+200]
+            ids_str = ",".join(str(pid) for pid in batch)
+            p_url = f"{SUPABASE_URL}/rest/v1/pieces?piece_id=in.({ids_str})&select=piece_id,piece_ref"
+            p_resp = requests.get(p_url, headers=headers)
+            if p_resp.status_code == 200:
+                for p in p_resp.json():
+                    for r in rows:
+                        if str(r.get("pmi_piece_id","")) == str(p["piece_id"]):
+                            name_to_ref[r["pmi_name"]] = p.get("piece_ref", "")
+        if len(rows) < 1000:
+            break
+        offset2 += 1000
+
+    for name in all_names:
+        if name not in existing:
+            # Utiliser piece_ref (la vraie reference TecDoc) pour la recherche
+            artnr = name_to_ref.get(name, "")
+            if not artnr:
+                # Fallback: extraire depuis le nom de fichier
+                artnr = name.rsplit("_", 1)[0] if "_" in name else name.rsplit(".", 1)[0]
+            missing.append({"pmi_name": name, "artnr": artnr})
+
+    return missing
+
+
+async def login_tecdoc(page):
+    """Se connecter au catalogue TecDoc."""
+    await page.goto('https://web.tecalliance.net/tecdoc/fr/home', wait_until='networkidle', timeout=45000)
+
+    if 'login' in page.url:
+        await page.wait_for_selector('input[name="identifier"]', timeout=10000)
+        await page.fill('input[name="identifier"]', TECDOC_EMAIL)
+        await page.wait_for_timeout(500)
+        await page.click('input[type="submit"]')
+        await page.wait_for_timeout(3000)
+        await page.wait_for_selector('input[name="credentials.passcode"]', timeout=10000)
+        await page.fill('input[name="credentials.passcode"]', TECDOC_PASS)
+        await page.wait_for_timeout(500)
+        await page.click('input[type="submit"]')
+        await page.wait_for_timeout(10000)
+
+    return 'login' not in page.url
+
+
+async def search_article_images(page, artnr: str, dlnr: str) -> list:
+    """Recherche un article via API Pegasus et extrait le mapping fileName → CDN URL pour le bon DLNR.
+
+    Retourne une liste de dicts: [{"fileName": "ZS177_1501700.JPG", "url": "https://...800/hash.jpg"}, ...]
+    """
+    matched = []
+
+    async def on_response(response):
+        url = response.url
+        if 'pegasus' in url and 'TecdocToCat' in url:
+            try:
+                body = await response.json()
+                if 'articles' in body:
+                    for art in body['articles']:
+                        if str(art.get('dataSupplierId', '')) == str(dlnr):
+                            for img in art.get('images', []):
+                                fn = img.get('fileName', '')
+                                cdn_url = (img.get('imageURL1600') or img.get('imageURL800')
+                                          or img.get('imageURL400') or img.get('imageURL200', ''))
+                                if fn and cdn_url:
+                                    matched.append({"fileName": fn, "url": cdn_url})
+            except:
+                pass
+
+    page.on('response', on_response)
+
+    try:
+        search = page.locator('input[placeholder="Recherche par numéro quelconque"]')
+        await search.clear()
+        await search.fill(artnr.strip())
+        await page.wait_for_timeout(300)
+        await search.press('Enter')
+        await page.wait_for_timeout(6000)
+    except Exception as e:
+        logger.warning(f"  Search error for {artnr}: {e}")
+    finally:
+        page.remove_listener('response', on_response)
+
+    return matched
+
+
+def download_from_cdn(url: str) -> bytes | None:
+    """Telecharge une image depuis le CDN public TecAlliance."""
+    try:
+        # Prendre la version 800px (meilleure qualite)
+        url_800 = url.replace('/images/100/', '/images/800/').replace('/images/200/', '/images/800/').replace('/images/400/', '/images/800/')
+        resp = requests.get(url_800, timeout=30)
+        if resp.status_code == 200 and 'image' in resp.headers.get('content-type', ''):
+            return resp.content
+        # Fallback sur l'URL originale
+        resp = requests.get(url, timeout=30)
+        if resp.status_code == 200:
+            return resp.content
+    except Exception as e:
+        logger.error(f"  CDN download error: {e}")
+    return None
+
+
+def upload_to_supabase(supabase, dlnr: str, filename: str, data: bytes) -> bool:
+    """Uploade une image vers Supabase Storage."""
+    try:
+        path = f"{dlnr}/{filename}"
+        content_type = 'image/jpeg' if filename.lower().endswith('.jpg') or filename.lower().endswith('.jpeg') else 'image/png'
+        supabase.storage.from_(BUCKET).upload(path, data, {"content-type": content_type})
+        return True
+    except Exception as e:
+        if "already exists" in str(e).lower() or "Duplicate" in str(e):
+            return True
+        logger.error(f"  Upload error {dlnr}/{filename}: {e}")
+        return False
+
+
+async def recover_dlnr(dlnr: str, dry_run: bool = True):
+    """Recupere les images manquantes pour un DLNR."""
+    logger.info(f"=== Recovery DLNR {dlnr} ===")
+
+    progress = load_progress()
+
+    # 1. Obtenir la liste des images manquantes
+    logger.info(f"  Getting missing images for DLNR {dlnr}...")
+    missing = get_missing_images(dlnr)
+    logger.info(f"  Missing images: {len(missing)}")
+
+    if not missing:
+        logger.info(f"  Nothing to recover for DLNR {dlnr}")
+        return {"recovered": 0, "failed": 0}
+
+    # Filtrer les deja recuperes
+    recovered_key = f"{dlnr}"
+    already_done = set(progress.get("recovered", {}).get(recovered_key, []))
+    missing = [m for m in missing if m["pmi_name"] not in already_done]
+    logger.info(f"  After filtering already recovered: {len(missing)}")
+
+    if dry_run:
+        logger.info(f"  [DRY-RUN] Would attempt to recover {len(missing)} images")
+        for m in missing[:5]:
+            logger.info(f"    {dlnr}/{m['pmi_name']} (ARTNR: {m['artnr']})")
+        return {"recovered": 0, "failed": 0}
+
+    # 2. Lancer Playwright pour obtenir les URLs
+    stats = {"recovered": 0, "failed": 0}
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context(
+            user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
+        )
+        page = await context.new_page()
+
+        # Login
+        logger.info("  Logging in to TecDoc...")
+        if not await login_tecdoc(page):
+            logger.error("  Login failed!")
+            await browser.close()
+            return stats
+        logger.info("  Login OK")
+
+        # Grouper par ARTNR unique (plusieurs images par article)
+        artnr_to_files = {}
+        for m in missing:
+            artnr_to_files.setdefault(m["artnr"], []).append(m["pmi_name"])
+
+        logger.info(f"  Unique articles to search: {len(artnr_to_files)}")
+
+        for i, (artnr, filenames) in enumerate(artnr_to_files.items()):
+            logger.info(f"  [{i+1}/{len(artnr_to_files)}] Searching ARTNR: {artnr} ({len(filenames)} images)...")
+
+            # Rechercher l'article
+            cdn_urls = await search_article_images(page, artnr, dlnr)
+
+            if cdn_urls:
+                logger.info(f"    Found {len(cdn_urls)} CDN images with fileName mapping")
+
+                # Matcher les fileNames du CDN avec les pmi_name manquants
+                for needed_file in filenames:
+                    # Chercher un match exact dans les resultats API
+                    cdn_match = next((m for m in cdn_urls if m["fileName"] == needed_file), None)
+                    if cdn_match:
+                        data = download_from_cdn(cdn_match["url"])
+                        if data:
+                            if upload_to_supabase(supabase, dlnr, needed_file, data):
+                                stats["recovered"] += 1
+                                if recovered_key not in progress.get("recovered", {}):
+                                    progress.setdefault("recovered", {})[recovered_key] = []
+                                progress["recovered"][recovered_key].append(needed_file)
+                                logger.info(f"    OK: {dlnr}/{needed_file} ({len(data)} bytes)")
+                            else:
+                                stats["failed"] += 1
+                        else:
+                            stats["failed"] += 1
+                        time.sleep(DOWNLOAD_DELAY)
+                    else:
+                        logger.warning(f"    No match for {needed_file} in API response")
+                        stats["failed"] += 1
+            else:
+                logger.warning(f"    No CDN images found for ARTNR {artnr}")
+                for fn in filenames:
+                    stats["failed"] += 1
+
+            # Sauvegarder progression regulierement
+            if i % 10 == 0:
+                save_progress(progress)
+
+            # Delai humain entre les recherches
+            delay = random.uniform(SEARCH_DELAY_MIN, SEARCH_DELAY_MAX)
+            await page.wait_for_timeout(int(delay * 1000))
+
+        await browser.close()
+
+    save_progress(progress)
+    logger.info(f"  DONE DLNR {dlnr}: recovered={stats['recovered']}, failed={stats['failed']}")
+    return stats
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Recover missing TecDoc images")
+    parser.add_argument("--dlnr", type=str, help="Process a single DLNR")
+    parser.add_argument("--dry-run", action="store_true", default=True)
+    parser.add_argument("--commit", action="store_true")
+    args = parser.parse_args()
+
+    dry_run = not args.commit
+    mode = "DRY-RUN" if dry_run else "COMMIT"
+
+    logger.info(f"{'='*60}")
+    logger.info(f"=== TecDoc Image Recovery [{mode}] ===")
+    logger.info(f"{'='*60}")
+
+    if args.dlnr:
+        await recover_dlnr(args.dlnr, dry_run)
+    else:
+        # Traiter tous les DLNR impactes, du plus petit au plus grand
+        dlnrs = ['86','67','95','83','6','11','38','31','4','113','159','15',
+                 '114','42','43','39','33','16','134','110','10','85','65',
+                 '3','140','62','89','123','101','13','30']
+        for dlnr in dlnrs:
+            await recover_dlnr(dlnr, dry_run)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/tecdoc-batch-load.py
+++ b/scripts/tecdoc-batch-load.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+TecDoc batch loader — CSV → tecdoc_raw via Supabase REST API.
+
+Usage:
+  python3 tecdoc-batch-load.py --table 200 --csv /path/to/200.4330.csv
+  python3 tecdoc-batch-load.py --table 200 --csv /path/to/200.4330.csv --chunk 200 --dry-run
+
+Features:
+  - Streaming: reads CSV in chunks, never loads full file in memory
+  - Batch INSERT via Supabase postgrest RPC (execute_sql)
+  - NULL marker '__PG_NULL__' → SQL NULL
+  - Journal par chunk: rows_sent, status, duration
+  - Dry-run mode: parse + validate without loading
+"""
+
+import csv
+import sys
+import os
+import time
+import json
+import requests
+import argparse
+
+NULL_MARKER = '__PG_NULL__'
+
+# Column definitions per table (must match tecdoc_raw schema)
+TABLE_COLUMNS = {
+    '200': ['artnr', 'dlnr', 'sa', 'beznr', 'kzsb', 'kzmat', 'kzat', 'kzzub',
+            'losgr1', 'losgr2', 'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+    '207': ['artnr', 'dlnr', 'sa', 'lkz', 'gebrnr', 'exclude', 'anzsofort', 'sortnr',
+            'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+    '100': ['dlnr', 'haession', 'marke', 'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+    '209': ['artnr', 'dlnr', 'ean', 'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+    '210': ['artnr', 'dlnr', 'sa', 'reserviert', 'lkz', 'sortnr', 'kritnr', 'kritwert',
+            'anzsofort1', 'exclude', 'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+    '211': ['artnr', 'dlnr', 'sa', 'genartnr', 'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+    '001': ['tab', 'beession', 'bez', 'sprach_id', 'losch_flag',
+            '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'],
+}
+
+
+def escape_sql_value(val):
+    """Escape a value for SQL INSERT."""
+    if val == NULL_MARKER or val == '':
+        return 'NULL'
+    # Escape single quotes
+    escaped = val.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def build_insert_sql(table_id, columns, rows):
+    """Build a multi-row INSERT statement."""
+    col_list = ','.join(columns)
+    value_rows = []
+    for row in rows:
+        vals = [escape_sql_value(v) for v in row]
+        value_rows.append(f"({','.join(vals)})")
+    values_str = ','.join(value_rows)
+    return f"INSERT INTO tecdoc_raw.t{table_id} ({col_list}) VALUES {values_str};"
+
+
+def execute_sql(supabase_url, service_key, sql):
+    """Execute SQL via Supabase Management API."""
+    # Use the postgrest RPC or direct SQL endpoint
+    # For raw SQL, use the pg-meta endpoint
+    url = f"{supabase_url}/rest/v1/rpc/__exec_sql"
+
+    # Actually, Supabase doesn't expose raw SQL via REST.
+    # We need to use the database connection directly.
+    # Alternative: use supabase-py with a custom RPC function.
+
+    # Best approach: use the Supabase project ID to call the management API
+    # But that requires the management API key, not the service role key.
+
+    # Simplest reliable approach: use psycopg2 or pg8000 for direct connection
+    try:
+        import psycopg2
+        return execute_via_psycopg2(sql)
+    except ImportError:
+        pass
+
+    try:
+        import pg8000
+        return execute_via_pg8000(sql)
+    except ImportError:
+        pass
+
+    # Fallback: use subprocess with psql
+    return execute_via_psql(sql)
+
+
+def get_db_connection_string():
+    """Build connection string from env vars."""
+    host = os.environ.get('SUPABASE_DB_HOST', 'aws-0-eu-west-3.pooler.supabase.com')
+    password = os.environ.get('SUPABASE_DB_PASSWORD', '')
+    port = os.environ.get('SUPABASE_DB_PORT', '6543')
+    user = os.environ.get('SUPABASE_DB_USER', 'postgres.cxpojprgwgubzjyqzmoq')
+    dbname = os.environ.get('SUPABASE_DB_NAME', 'postgres')
+
+    if not password:
+        # Try to read from .env file
+        env_path = os.path.join(os.path.dirname(__file__), '..', 'backend', '.env')
+        if os.path.exists(env_path):
+            with open(env_path) as f:
+                for line in f:
+                    if line.startswith('SUPABASE_DB_PASSWORD='):
+                        password = line.strip().split('=', 1)[1]
+                    elif line.startswith('SUPABASE_DB_HOST='):
+                        host = line.strip().split('=', 1)[1]
+    return host, port, user, password, dbname
+
+
+def execute_via_psycopg2(sql):
+    """Execute SQL via psycopg2."""
+    import psycopg2
+    host, port, user, password, dbname = get_db_connection_string()
+    conn = psycopg2.connect(host=host, port=port, user=user, password=password, dbname=dbname)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(sql)
+    affected = cur.rowcount
+    cur.close()
+    conn.close()
+    return affected
+
+
+def execute_via_pg8000(sql):
+    """Execute SQL via pg8000."""
+    import pg8000
+    host, port, user, password, dbname = get_db_connection_string()
+    conn = pg8000.connect(host=host, port=int(port), user=user, password=password, database=dbname)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(sql)
+    affected = cur.rowcount
+    cur.close()
+    conn.close()
+    return affected
+
+
+def execute_via_psql(sql):
+    """Execute SQL via psql subprocess."""
+    import subprocess
+    host, port, user, password, dbname = get_db_connection_string()
+    env = os.environ.copy()
+    env['PGPASSWORD'] = password
+    result = subprocess.run(
+        ['psql', '-h', host, '-p', port, '-U', user, '-d', dbname, '-c', sql],
+        capture_output=True, text=True, env=env, timeout=120
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"psql error: {result.stderr}")
+    return 0
+
+
+def stream_csv_chunks(csv_path, chunk_size):
+    """Generator that yields chunks of rows from CSV."""
+    with open(csv_path, 'r', encoding='utf-8') as f:
+        reader = csv.reader(f)
+        chunk = []
+        for row in reader:
+            chunk.append(row)
+            if len(chunk) >= chunk_size:
+                yield chunk
+                chunk = []
+        if chunk:
+            yield chunk
+
+
+def main():
+    parser = argparse.ArgumentParser(description='TecDoc batch loader')
+    parser.add_argument('--table', required=True, help='Table ID (e.g. 200)')
+    parser.add_argument('--csv', required=True, help='Path to CSV file')
+    parser.add_argument('--chunk', type=int, default=100, help='Rows per INSERT batch (default: 100)')
+    parser.add_argument('--dry-run', action='store_true', help='Parse and validate without loading')
+    parser.add_argument('--output-sql', help='Directory to write SQL chunks (for MCP execution)')
+    args = parser.parse_args()
+
+    if args.table not in TABLE_COLUMNS:
+        print(f"ERROR: Unknown table {args.table}. Known: {list(TABLE_COLUMNS.keys())}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(args.csv):
+        print(f"ERROR: CSV file not found: {args.csv}", file=sys.stderr)
+        sys.exit(1)
+
+    columns = TABLE_COLUMNS[args.table]
+    supabase_url = os.environ.get('SUPABASE_URL', 'https://cxpojprgwgubzjyqzmoq.supabase.co')
+    service_key = os.environ.get('SUPABASE_SERVICE_ROLE_KEY', '')
+
+    total_rows = 0
+    total_chunks = 0
+    total_errors = 0
+    start_time = time.monotonic()
+
+    print(f"Loading {args.csv} → tecdoc_raw.t{args.table} (chunk={args.chunk})", file=sys.stderr)
+
+    for chunk in stream_csv_chunks(args.csv, args.chunk):
+        total_chunks += 1
+        chunk_start = time.monotonic()
+
+        # Validate column count
+        for i, row in enumerate(chunk):
+            if len(row) != len(columns):
+                print(f"ERROR chunk {total_chunks} row {i}: expected {len(columns)} cols, got {len(row)}", file=sys.stderr)
+                total_errors += 1
+                continue
+
+        if args.dry_run:
+            total_rows += len(chunk)
+            duration_ms = int((time.monotonic() - chunk_start) * 1000)
+            print(f"DRY-RUN chunk {total_chunks}: {len(chunk)} rows ({duration_ms}ms)", file=sys.stderr)
+            continue
+
+        # Build and execute INSERT
+        sql = build_insert_sql(args.table, columns, chunk)
+
+        try:
+            if args.output_sql:
+                # Write SQL to file for MCP execution
+                sql_path = os.path.join(args.output_sql, f'chunk_{total_chunks:04d}.sql')
+                with open(sql_path, 'w', encoding='utf-8') as sf:
+                    sf.write(sql)
+                total_rows += len(chunk)
+                duration_ms = int((time.monotonic() - chunk_start) * 1000)
+                print(f"WRITTEN chunk {total_chunks}: {len(chunk)} rows → {sql_path} ({duration_ms}ms)", file=sys.stderr)
+            else:
+                execute_sql(supabase_url, service_key, sql)
+                total_rows += len(chunk)
+                duration_ms = int((time.monotonic() - chunk_start) * 1000)
+                print(f"OK chunk {total_chunks}: {len(chunk)} rows ({duration_ms}ms)", file=sys.stderr)
+        except Exception as e:
+            total_errors += 1
+            print(f"ERROR chunk {total_chunks}: {e}", file=sys.stderr)
+
+    total_duration = int((time.monotonic() - start_time) * 1000)
+
+    # Summary
+    summary = {
+        'table': f't{args.table}',
+        'csv': args.csv,
+        'total_rows': total_rows,
+        'total_chunks': total_chunks,
+        'total_errors': total_errors,
+        'chunk_size': args.chunk,
+        'duration_ms': total_duration,
+        'dry_run': args.dry_run
+    }
+    print(json.dumps(summary), file=sys.stderr)
+
+    # Also print summary line for easy parsing
+    mode = "DRY-RUN" if args.dry_run else "LOADED"
+    print(f"SUMMARY|{mode}|t{args.table}|rows={total_rows}|chunks={total_chunks}|errors={total_errors}|{total_duration}ms")
+
+    sys.exit(1 if total_errors > 0 else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-batch-load.sh
+++ b/scripts/tecdoc-batch-load.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# TecDoc Batch Loader — Safe & Robust
+# Usage: ./tecdoc-batch-load.sh <TABLE_ID> [BATCH_ID]
+# Example: ./tecdoc-batch-load.sh 200 batch_2026_03_15
+#
+# Consumes a pre-generated file-list, processes one file at a time:
+# extract → parse → load → log → purge
+
+set -euo pipefail
+
+TABLE_ID="${1:?Usage: tecdoc-batch-load.sh <TABLE_ID> [BATCH_ID]}"
+BATCH_ID="${2:-batch_$(date +%Y%m%d_%H%M%S)}"
+
+ARCHIVE="/opt/automecanik/app/.github/SQL-CONVERTED.7z"
+FILE_LIST="/opt/automecanik/data/tecdoc/filelists/${TABLE_ID}.txt"
+WORKDIR="/opt/automecanik/data/tecdoc/workdir"
+LOGDIR="/opt/automecanik/data/tecdoc/logs"
+PARSEUR="/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py"
+
+# Database connection (uses PGDATABASE, PGHOST, etc. from env or .pgpass)
+PSQL_CMD="psql -h db.cxpojprgwgubzjyqzmoq.supabase.co -U postgres -d postgres"
+
+# Verify prerequisites
+if [[ ! -f "$ARCHIVE" ]]; then echo "ERROR: Archive not found: $ARCHIVE"; exit 1; fi
+if [[ ! -f "$FILE_LIST" ]]; then echo "ERROR: File list not found: $FILE_LIST"; exit 1; fi
+if [[ ! -f "$PARSEUR" ]]; then echo "ERROR: Parser not found: $PARSEUR"; exit 1; fi
+
+mkdir -p "$WORKDIR" "$LOGDIR"
+
+TOTAL_FILES=$(wc -l < "$FILE_LIST")
+CURRENT=0
+TOTAL_LOADED=0
+TOTAL_ERRORS=0
+
+echo "=== TecDoc Batch Load ==="
+echo "Table: t${TABLE_ID}"
+echo "Batch: ${BATCH_ID}"
+echo "Files: ${TOTAL_FILES}"
+echo "Start: $(date -Iseconds)"
+echo "========================="
+
+while IFS= read -r FILE; do
+  CURRENT=$((CURRENT + 1))
+
+  # 0. Validate file prefix matches TABLE_ID
+  if [[ "$FILE" != ${TABLE_ID}.* ]]; then
+    echo "$(date -Iseconds)|${FILE}|SKIP|wrong_prefix" >> "$LOGDIR/batch_${TABLE_ID}.log"
+    echo "[$CURRENT/$TOTAL_FILES] SKIP $FILE (wrong prefix)"
+    continue
+  fi
+
+  echo -n "[$CURRENT/$TOTAL_FILES] $FILE ... "
+
+  # 1. Extract single file from 7z
+  7z e "$ARCHIVE" "$FILE" -o"$WORKDIR/" -y > /dev/null 2>&1
+  if [[ ! -f "$WORKDIR/$FILE" ]]; then
+    echo "$(date -Iseconds)|${FILE}|ERROR|extract_failed" >> "$LOGDIR/batch_${TABLE_ID}.log"
+    echo "EXTRACT FAILED"
+    TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+    continue
+  fi
+
+  # 2. Parse MySQL → CSV
+  CSV_FILE="$WORKDIR/${FILE%.sql}.csv"
+  META_FILE="$WORKDIR/${FILE%.sql}.meta"
+  python3 "$PARSEUR" "$WORKDIR/$FILE" -o "$CSV_FILE" 2>> "$LOGDIR/parse_${TABLE_ID}.log" || true
+
+  # Read counters from .meta
+  PARSED=0; EMITTED=0; REJECTED=0
+  if [[ -f "$META_FILE" ]]; then
+    PARSED=$(grep -oP 'rows_parsed=\K\d+' "$META_FILE" || echo 0)
+    EMITTED=$(grep -oP 'rows_emitted=\K\d+' "$META_FILE" || echo 0)
+    REJECTED=$(grep -oP 'rows_rejected=\K\d+' "$META_FILE" || echo 0)
+  fi
+
+  if [[ ! -f "$CSV_FILE" ]] || [[ "$EMITTED" -eq 0 ]]; then
+    echo "$(date -Iseconds)|${FILE}|${PARSED}|${EMITTED}|${REJECTED}|PARSE_EMPTY|0ms" >> "$LOGDIR/batch_${TABLE_ID}.log"
+    echo "EMPTY (0 rows emitted)"
+    rm -f "$WORKDIR/$FILE" "$CSV_FILE" "$META_FILE"
+    continue
+  fi
+
+  # 3. Load into tecdoc_raw
+  BEFORE=$(date +%s%N)
+  COPY_RESULT=$($PSQL_CMD -c "\copy tecdoc_raw.t${TABLE_ID} FROM '${CSV_FILE}' WITH (FORMAT csv, NULL '__PG_NULL__')" 2>&1) || true
+  LOAD_STATUS=$?
+  AFTER=$(date +%s%N)
+  DURATION_MS=$(( (AFTER - BEFORE) / 1000000 ))
+
+  if [[ $LOAD_STATUS -eq 0 ]]; then
+    echo "$(date -Iseconds)|${FILE}|${PARSED}|${EMITTED}|${REJECTED}|OK|${DURATION_MS}ms" >> "$LOGDIR/batch_${TABLE_ID}.log"
+    echo "OK (${EMITTED} rows, ${DURATION_MS}ms)"
+    TOTAL_LOADED=$((TOTAL_LOADED + EMITTED))
+  else
+    echo "$(date -Iseconds)|${FILE}|${PARSED}|${EMITTED}|${REJECTED}|LOAD_ERROR|${DURATION_MS}ms|${COPY_RESULT}" >> "$LOGDIR/batch_${TABLE_ID}.log"
+    echo "LOAD ERROR: ${COPY_RESULT}"
+    TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+  fi
+
+  # 5. Purge working files
+  rm -f "$WORKDIR/$FILE" "$CSV_FILE" "$META_FILE"
+
+done < "$FILE_LIST"
+
+echo "========================="
+echo "End: $(date -Iseconds)"
+echo "Total loaded: ${TOTAL_LOADED} rows"
+echo "Total errors: ${TOTAL_ERRORS}"
+echo "Log: ${LOGDIR}/batch_${TABLE_ID}.log"
+echo "========================="

--- a/scripts/tecdoc-mysql-to-csv.py
+++ b/scripts/tecdoc-mysql-to-csv.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+TecDoc MySQL INSERT → CSV PostgreSQL-safe converter.
+
+Usage:
+  python3 tecdoc-mysql-to-csv.py input.sql > output.csv
+  python3 tecdoc-mysql-to-csv.py input.sql -o output.csv
+  cat input.sql | python3 tecdoc-mysql-to-csv.py - > output.csv
+
+Rules:
+  - NULL MySQL → __PG_NULL__ (distingue de chaine vide)
+  - Chaines vides → chaines vides
+  - 0000-00-00 → conserve tel quel (nettoyage dans norm, pas raw)
+  - Backticks MySQL → supprimes
+  - Echappements \\' → '
+  - Sortie CSV PostgreSQL-safe (double-quote, RFC 4180)
+  - Calcule _raw_hash (MD5 des colonnes metier)
+  - Renseigne _source_row_no (compteur incremental)
+"""
+
+import sys
+import csv
+import hashlib
+import io
+import os
+import re
+from enum import Enum, auto
+
+NULL_MARKER = '__PG_NULL__'
+
+
+class ParserState(Enum):
+    SCANNING = auto()
+    IN_VALUES = auto()
+
+
+def parse_mysql_value(text: str, pos: int) -> tuple[str, int]:
+    """Parse a single MySQL value starting at pos. Returns (value, new_pos)."""
+    if pos >= len(text):
+        return ('', pos)
+
+    # NULL
+    if text[pos:pos+4].upper() == 'NULL':
+        return (NULL_MARKER, pos + 4)
+
+    # Quoted string
+    if text[pos] == "'":
+        pos += 1  # skip opening quote
+        result = []
+        while pos < len(text):
+            ch = text[pos]
+            if ch == '\\' and pos + 1 < len(text):
+                next_ch = text[pos + 1]
+                if next_ch == "'":
+                    result.append("'")
+                elif next_ch == '\\':
+                    result.append('\\')
+                elif next_ch == 'n':
+                    result.append('\n')
+                elif next_ch == 'r':
+                    result.append('\r')
+                elif next_ch == 't':
+                    result.append('\t')
+                elif next_ch == '0':
+                    result.append('\0')
+                else:
+                    result.append(next_ch)
+                pos += 2
+            elif ch == "'" and pos + 1 < len(text) and text[pos + 1] == "'":
+                # MySQL double-quote escape
+                result.append("'")
+                pos += 2
+            elif ch == "'":
+                pos += 1  # skip closing quote
+                return (''.join(result), pos)
+            else:
+                result.append(ch)
+                pos += 1
+        return (''.join(result), pos)
+
+    # Numeric value (unquoted)
+    start = pos
+    while pos < len(text) and text[pos] not in (',', ')', ' ', '\t', '\n', '\r'):
+        pos += 1
+    return (text[start:pos], pos)
+
+
+def parse_values_row(text: str, pos: int) -> tuple[list[str], int]:
+    """Parse one (val1, val2, ...) row. Returns (values_list, new_pos)."""
+    # Find opening paren
+    while pos < len(text) and text[pos] != '(':
+        pos += 1
+    if pos >= len(text):
+        return ([], pos)
+    pos += 1  # skip '('
+
+    values = []
+    while pos < len(text):
+        # Skip whitespace
+        while pos < len(text) and text[pos] in (' ', '\t', '\n', '\r'):
+            pos += 1
+        if pos >= len(text) or text[pos] == ')':
+            pos += 1  # skip ')'
+            break
+
+        value, pos = parse_mysql_value(text, pos)
+        values.append(value)
+
+        # Skip comma or closing paren
+        while pos < len(text) and text[pos] in (' ', '\t', '\n', '\r'):
+            pos += 1
+        if pos < len(text) and text[pos] == ',':
+            pos += 1
+        elif pos < len(text) and text[pos] == ')':
+            pos += 1
+            break
+
+    return (values, pos)
+
+
+def compute_raw_hash(values: list[str]) -> str:
+    """MD5 hash of business columns (all values joined)."""
+    content = '|'.join(values)
+    return hashlib.md5(content.encode('utf-8')).hexdigest()
+
+
+def process_file(input_path: str, output_file, source_filename: str):
+    """Process a MySQL INSERT SQL file and write CSV output."""
+    writer = csv.writer(output_file, quoting=csv.QUOTE_MINIMAL, lineterminator='\n')
+    row_no = 0
+    lines_parsed = 0
+    errors = 0
+
+    if input_path == '-':
+        f = sys.stdin
+    else:
+        f = open(input_path, 'r', encoding='utf-8', errors='replace')
+
+    try:
+        # Read entire file (MySQL INSERTs can span multiple lines)
+        content = f.read()
+    finally:
+        if input_path != '-':
+            f.close()
+
+    # Find all INSERT statements
+    # Pattern: INSERT INTO `tablename` VALUES (...),...;
+    insert_pattern = re.compile(
+        r'INSERT\s+(?:IGNORE\s+)?INTO\s+`?\w+`?\s*(?:\([^)]+\)\s*)?VALUES\s*',
+        re.IGNORECASE
+    )
+
+    for match in insert_pattern.finditer(content):
+        pos = match.end()
+
+        # Parse all value rows until semicolon
+        while pos < len(content):
+            # Skip whitespace
+            while pos < len(content) and content[pos] in (' ', '\t', '\n', '\r'):
+                pos += 1
+
+            if pos >= len(content) or content[pos] == ';':
+                break
+
+            if content[pos] == ',':
+                pos += 1
+                continue
+
+            if content[pos] == '(':
+                try:
+                    values, pos = parse_values_row(content, pos)
+                    if values:
+                        row_no += 1
+                        raw_hash = compute_raw_hash(values)
+                        # Append traceability columns: _source_filename, _batch_id, _loaded_at, _source_row_no, _raw_hash
+                        # _loaded_at is handled by DB default
+                        row = values + [source_filename, '', '', str(row_no), raw_hash]
+                        writer.writerow(row)
+                        lines_parsed += 1
+                except Exception as e:
+                    errors += 1
+                    print(f"ERROR line ~{row_no}: {e}", file=sys.stderr)
+                    # Try to skip to next row
+                    next_paren = content.find('(', pos)
+                    next_semi = content.find(';', pos)
+                    if next_semi != -1 and (next_paren == -1 or next_semi < next_paren):
+                        pos = next_semi
+                    elif next_paren != -1:
+                        pos = next_paren
+                    else:
+                        break
+            else:
+                pos += 1
+
+    # Summary to stderr
+    print(f"SUMMARY|{source_filename}|rows={lines_parsed}|errors={errors}", file=sys.stderr)
+    return lines_parsed, errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: tecdoc-mysql-to-csv.py <input.sql|-> [-o output.csv]", file=sys.stderr)
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    source_filename = os.path.basename(input_path) if input_path != '-' else 'stdin'
+
+    output_file = sys.stdout
+    if '-o' in sys.argv:
+        idx = sys.argv.index('-o')
+        if idx + 1 < len(sys.argv):
+            output_file = open(sys.argv[idx + 1], 'w', encoding='utf-8', newline='')
+
+    import time
+    start_time = time.monotonic()
+
+    try:
+        lines, errors = process_file(input_path, output_file, source_filename)
+    finally:
+        if output_file != sys.stdout:
+            output_file.close()
+
+    duration_ms = int((time.monotonic() - start_time) * 1000)
+
+    # Write .meta file
+    meta_path = None
+    if '-o' in sys.argv:
+        idx = sys.argv.index('-o')
+        if idx + 1 < len(sys.argv):
+            csv_path = sys.argv[idx + 1]
+            meta_path = csv_path.rsplit('.', 1)[0] + '.meta'
+    elif input_path != '-':
+        meta_path = input_path.rsplit('.', 1)[0] + '.meta'
+
+    if meta_path:
+        with open(meta_path, 'w') as mf:
+            mf.write(f"rows_parsed={lines + errors}\n")
+            mf.write(f"rows_emitted={lines}\n")
+            mf.write(f"rows_rejected={errors}\n")
+            mf.write(f"duration_ms={duration_ms}\n")
+
+    sys.exit(1 if errors > 0 else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-parser-fixtures/real-fixtures.sha256
+++ b/scripts/tecdoc-parser-fixtures/real-fixtures.sha256
@@ -1,0 +1,21 @@
+# Empreintes des 7 paires entree/sortie produites par le pipeline TecDoc reel
+# (mars 2026, /opt/automecanik/data/tecdoc/extract/). Les octets ne sont PAS
+# versionnes ici : ce sont des donnees TecDoc sous licence. Ce manifeste permet
+# de rejouer la validation sur une machine qui dispose du repertoire, sans
+# redistribuer la donnee. Genere le 2026-09-07.
+#
+# format : <sha256>  <nom>   (.dat.sql = entree, .csv = sortie attendue)
+b406b192bbfbfd1c80ab4a9fa782dfe48c5afa322b05b5137b2ed4aea686d1a6  012.dat.sql
+1c5db13278e489f96cd29bb1638f57ef08f1c6c75be9502f60383f121fa02f36  012.csv
+e64f54a4dc719f95412bb6c6a247acecb896a5e608938c689522db39a84bf769  140.dat.sql
+3cb038996c9252c2fddab062826b8dc1765d2efd85effaa50af94a35a2b5a95d  140.csv
+60f34bf1651cb5b5b04f6ce50c5ded90ac8d43eb5098b1137e1e4ffa2637236b  143.dat.sql
+3543bdf31b8990fa84820529d63998c3e12bd0f1aafa2cd482b7108e30b764ca  143.csv
+c7d25a31dd45e0908c1d954fa8f3debf6994f8c5a27c58006c933d65f8f39530  144.dat.sql
+957eff79cf9f4f9ce7042ebab1d85841b806e3fec17849d5a4f11ccdd3356aee  144.csv
+ea98b1db863539e158b4b9f52e105bf8fad1cb52559daa11a23e740a78d8f2fb  145.dat.sql
+538be56bbc4dbd351626b30b21d7dcabd7eae2e8f92ae5155379ed23f50d0a08  145.csv
+12549de6d3657900dc834f8e62829bf988c9bf457ad1f7737cdf6afe52cd7575  146.dat.sql
+3db2297bcda6c6c602d562065477541a0d0f5ddf022bbb44f5b93889f75959af  146.csv
+633ddfc7bde3080967ceb3012c456602ca6817633377c8257bf46528c4a8921f  147.dat.sql
+1ec59349929db4b6480a828946b7960877e6a3f333e76a11088c7dd052cb1085  147.csv

--- a/scripts/tecdoc-parser-fixtures/synthetic.dat.sql
+++ b/scripts/tecdoc-parser-fixtures/synthetic.dat.sql
@@ -1,0 +1,17 @@
+-- Fixture synthetique pour scripts/tecdoc-mysql-to-csv.py
+-- Aucune donnee TecDoc reelle : valeurs inventees, couvrant les cas limites du parseur.
+-- Cas couverts : NULL, chaine vide, apostrophe echappee par backslash, apostrophe
+-- doublee (echappement MySQL), backslash litteral, virgule dans une chaine (force le
+-- quoting CSV), guillemet double (force le quoting + doublement CSV), \n \r \t,
+-- date 0000-00-00 conservee telle quelle, valeurs numeriques non quotees,
+-- INSERT multi-lignes, second INSERT (le compteur _source_row_no ne repart pas a 1),
+-- variante INSERT IGNORE, et presence/absence de la liste de colonnes.
+INSERT IGNORE INTO `999` (`A`, `B`, `C`, `D`) VALUES
+(1, 'simple', '', NULL),
+(2, 'avec, une virgule', 'avec "guillemets"', 'fin'),
+(3, 'apostrophe\' backslash', 'double''''quote', 'x'),
+(4, 'anti\\slash', 'tab\there', 'nl\nici'),
+(5, '0000-00-00', 'retour\rchariot', NULL);
+INSERT INTO `999` VALUES
+(6, 'second statement', 'compteur continue', ''),
+(7, NULL, NULL, NULL);

--- a/scripts/tecdoc-parser-fixtures/synthetic.expected.csv
+++ b/scripts/tecdoc-parser-fixtures/synthetic.expected.csv
@@ -1,0 +1,8 @@
+1,simple,,__PG_NULL__,synthetic.dat.sql,,,1,4cb6334680ea7a14b997b3f7794e2d6d
+2,"avec, une virgule","avec ""guillemets""",fin,synthetic.dat.sql,,,2,751273e833082c3098cacc494a626003
+3,apostrophe' backslash,double''quote,x,synthetic.dat.sql,,,3,09ca29705057593df310414b75ca5e73
+4,anti\slash,tab	here,"nl
+ici",synthetic.dat.sql,,,4,e568d532e985073ed27fc69eb9174459
+5,0000-00-00,retourchariot,__PG_NULL__,synthetic.dat.sql,,,5,62ee59115bbb7b112180e340e87f3215
+6,second statement,compteur continue,,synthetic.dat.sql,,,6,54c5db6c4af832776865bfeb67806fff
+7,__PG_NULL__,__PG_NULL__,__PG_NULL__,synthetic.dat.sql,,,7,0bb31445376d07c0aa5ad0127a4d7469

--- a/scripts/test-tecdoc-mysql-to-csv.sh
+++ b/scripts/test-tecdoc-mysql-to-csv.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tests de non-regression du parseur TecDoc — scripts/tecdoc-mysql-to-csv.py
+#
+# Deux niveaux :
+#   1. FIXTURE SYNTHETIQUE (toujours executee) — aucune dependance : ni PROD, ni base,
+#      ni donnee TecDoc sous licence. C'est le test qui fait foi en CI.
+#   2. FIXTURES REELLES (executees seulement si le repertoire d'extraction existe) —
+#      les 7 paires produites par le pipeline de mars 2026. Verifie d'abord l'empreinte
+#      de l'entree, puis l'identite octet par octet de la sortie.
+#
+# Usage :  bash scripts/test-tecdoc-mysql-to-csv.sh [--with-large]
+#   --with-large  inclut 012 (640 Mo d'entree, 1,18 Go de sortie, ~2 min, ~2 Go de disque)
+#
+# Sortie : 0 si tout passe. Tout saut est annonce explicitement.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PARSER="$ROOT/scripts/tecdoc-mysql-to-csv.py"
+FIXDIR="$ROOT/scripts/tecdoc-parser-fixtures"
+REALDIR="${TECDOC_EXTRACT_DIR:-/opt/automecanik/data/tecdoc/extract}"
+WITH_LARGE=0
+[[ "${1:-}" == "--with-large" ]] && WITH_LARGE=1
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0; skip=0
+ok()   { echo "  PASS  $*"; pass=$((pass+1)); }
+ko()   { echo "  FAIL  $*"; fail=$((fail+1)); }
+sk()   { echo "  SKIP  $*"; skip=$((skip+1)); }
+
+[[ -f "$PARSER" ]] || { echo "FATAL: parseur introuvable: $PARSER"; exit 2; }
+echo "Parseur : $PARSER"
+echo "         sha256 $(sha256sum "$PARSER" | cut -d' ' -f1)"
+echo
+
+# ---------- 1. Fixture synthetique (obligatoire) ----------
+echo "1. Fixture synthetique (sans dependance externe)"
+if python3 "$PARSER" "$FIXDIR/synthetic.dat.sql" -o "$TMP/synthetic.csv" 2>"$TMP/synthetic.err"; then
+  if cmp -s "$TMP/synthetic.csv" "$FIXDIR/synthetic.expected.csv"; then
+    ok "synthetic.dat.sql -> sortie identique a synthetic.expected.csv"
+  else
+    ko "synthetic.dat.sql -> sortie DIFFERENTE de l'attendu"
+    diff "$FIXDIR/synthetic.expected.csv" "$TMP/synthetic.csv" | head -20
+  fi
+  # le resume va sur stderr, contrat consomme par tecdoc-batch-load.sh
+  if grep -q '^SUMMARY|synthetic.dat.sql|rows=7|errors=0$' "$TMP/synthetic.err"; then
+    ok "resume stderr conforme (SUMMARY|...|rows=7|errors=0)"
+  else
+    ko "resume stderr non conforme : $(cat "$TMP/synthetic.err")"
+  fi
+  # le parseur ecrit aussi un .meta a cote de la sortie ; duration_ms est non
+  # deterministe par construction, on n'assere que les trois champs stables.
+  if [[ -f "$TMP/synthetic.meta" ]]; then
+    got="$(grep -v '^duration_ms=' "$TMP/synthetic.meta" | tr '\n' ' ')"
+    if [[ "$got" == "rows_parsed=7 rows_emitted=7 rows_rejected=0 " ]]; then
+      ok ".meta conforme (rows_parsed/emitted/rejected ; duration_ms ignore)"
+    else
+      ko ".meta non conforme : $got"
+    fi
+  else
+    ko ".meta non genere a cote de la sortie"
+  fi
+else
+  ko "le parseur a echoue sur la fixture synthetique"
+fi
+echo
+
+# ---------- 2. Fixtures reelles (conditionnelles) ----------
+echo "2. Fixtures reelles du pipeline de mars 2026"
+if [[ ! -d "$REALDIR" ]]; then
+  sk "repertoire absent ($REALDIR) — les 7 paires reelles ne sont pas verifiees ici."
+  echo "        Ce n'est PAS une couverture complete : voir scripts/tecdoc-parser-fixtures/real-fixtures.sha256"
+else
+  MAN="$FIXDIR/real-fixtures.sha256"
+  for n in 140 143 144 145 146 147 012; do
+    if [[ "$n" == "012" && "$WITH_LARGE" -eq 0 ]]; then
+      sk "012 (640 Mo) — relancer avec --with-large pour l'inclure"
+      continue
+    fi
+    src="$REALDIR/$n.dat.sql"; ref="$REALDIR/$n.csv"
+    if [[ ! -f "$src" || ! -f "$ref" ]]; then sk "$n : paire absente du repertoire"; continue; fi
+    want_in="$(grep -E "  $n\.dat\.sql$" "$MAN" | cut -d' ' -f1)"
+    got_in="$(sha256sum "$src" | cut -d' ' -f1)"
+    if [[ -n "$want_in" && "$want_in" != "$got_in" ]]; then
+      ko "$n : l'ENTREE a change (sha256 $got_in != $want_in du manifeste) — test non concluant"
+      continue
+    fi
+    if python3 "$PARSER" "$src" -o "$TMP/$n.csv" 2>/dev/null && cmp -s "$TMP/$n.csv" "$ref"; then
+      ok "$n : sortie identique octet par octet ($(wc -l < "$ref") lignes)"
+    else
+      ko "$n : sortie DIFFERENTE de la reference"
+    fi
+    rm -f "$TMP/$n.csv"
+  done
+fi
+
+echo
+echo "----------------------------------------"
+echo "PASS=$pass  FAIL=$fail  SKIP=$skip"
+[[ "$fail" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
PR **strictement non destructive** : elle ne fait que remettre sous contrôle de version des fichiers retrouvés. Aucune base touchée, aucun `DROP`/`DELETE`/`TRUNCATE`/`VACUUM`, aucun resize, aucun changement de compute, aucune donnée supprimée.

Le pipeline d'import TecDoc ne tenait plus qu'à deux endroits fragiles : des objets Git **non atteignables** dans le dépôt de la machine DEV, et le disque de cette même machine. `git rev-list --objects --all --reflog` n'en retient **aucun** — un `git gc --prune` détruisait le parseur, et avec lui toute reconstruction de `tecdoc_raw`, donc de `source_linkages`.

Les audits antérieurs (`massdoc-c1-tecdoc-reproducibility-2026-09-02.md`, PR #1409) le déclaraient « absent du disque **et de git** ». La première moitié est vraie ; la seconde est fausse. `git log --all` ne voit pas les objets non atteignables — c'était l'instrument qui était faux, pas le fait.

### Artefacts récupérés

| fichier | chemin d'origine | blob Git (sha1) | rôle | statut |
|---|---|---|---|---|
| `scripts/tecdoc-mysql-to-csv.py` | _idem_ | `c4da30a15cf51fb10f2c77620502e0e7e421eaf9` | **le parseur** MySQL→CSV, maillon unique du pipeline | original, octet pour octet |
| `scripts/tecdoc-batch-load.sh` | _idem_ | `41ae2667d82a29c8451f59f0560a16614524a946` | orchestrateur `extract → parse → load → log → purge`, un shard à la fois | original, octet pour octet |
| `scripts/tecdoc-batch-load.py` | _idem_ | `cc3075bf8ef437debbd6cfdad7f6da7d8e00c59f` | chargeur Python (COPY par lots) | original, octet pour octet |
| `scripts/recover-tecdoc-images.py` | _idem_ | `c7a6e67f71f2d098c95270028a776e2e3ace7c7e` | récupération d'images depuis le portail TecDoc | original **puis expurgé** (§Sécurité) |
| `docs/audit/recovered-tecdoc-2026-09-07/tecdoc-source-mapping.md` | `.spec/00-canon/db-governance/` | `af25a1f2b8849a5ec71a646749c931b7ce2b458f` | correspondance source TecDoc → tables | document historique, octet pour octet |
| `docs/audit/recovered-tecdoc-2026-09-07/tecdoc-apply-mapping.md` | `.spec/00-canon/db-governance/` | `4ce4583694aca7c2abbb2e17bcccfff12ccfcdbb` | procédure d'application du mapping | document historique, octet pour octet |
| `docs/audit/recovered-tecdoc-2026-09-07/runbook-reimport-tecdoc-images.md` | `docs/` | `7e7d030bd307427aa54a242104ec0f65cdcf74f3` | runbook de ré-import images | document historique, octet pour octet |
| `docs/audit/recovered-tecdoc-2026-09-07/tecdoc-ingestion-rootcause-2026-04-13.md` | `.spec/reports/` | `f7530d825303b98b10a58051d9960ea32719817d` | root-cause d'ingestion du 2026-04-13 | document historique **puis expurgé** |

Récupération par `git cat-file -p <blob>`, puis **revérification par `git hash-object`** : les 6 fichiers non modifiés rendent exactement le sha1 attendu. Les 2 expurgés diffèrent volontairement, et c'est signalé comme tel.

**Sur les chemins.** Les 4 scripts sont à leur chemin d'origine — nécessité technique, sept appelants référencent le parseur en absolu. Les 4 documents sont regroupés sous `docs/audit/recovered-tecdoc-2026-09-07/` : deux venaient de `.spec/00-canon/`, et les y remettre rendrait à des documents **historiques** une apparence d'autorité canon courante, que le CLAUDE.md signale précisément comme dangereuse. Le canon vit au vault. Effet de bord utile : `docs/audit/**` est déjà couvert par un glob d'ownership, là où `.spec/00-canon/db-governance/**` et `.spec/reports/**` ne le sont pas — aucune édition de `ownership.yaml` (owner-only) n'est requise.

### Validation

`bash scripts/test-tecdoc-mysql-to-csv.sh --with-large` → **PASS=9 FAIL=0 SKIP=0**

```
Parseur : scripts/tecdoc-mysql-to-csv.py
         sha256 bde7657f851eccdb8146f1c12c5ab286dc45784575a15e018b13416bd46e01b7

1. Fixture synthetique (sans dependance externe)
  PASS  synthetic.dat.sql -> sortie identique a synthetic.expected.csv
  PASS  resume stderr conforme (SUMMARY|...|rows=7|errors=0)
  PASS  .meta conforme (rows_parsed/emitted/rejected ; duration_ms ignore)

2. Fixtures reelles du pipeline de mars 2026
  PASS  140 : sortie identique octet par octet (20874 lignes)
  PASS  143 : sortie identique octet par octet (9062 lignes)
  PASS  144 : sortie identique octet par octet (65122 lignes)
  PASS  145 : sortie identique octet par octet (334096 lignes)
  PASS  146 : sortie identique octet par octet (2920 lignes)
  PASS  147 : sortie identique octet par octet (16178 lignes)
  PASS  012 : sortie identique octet par octet (13336463 lignes)
```

Tests joués **depuis le fichier committé**, pas depuis un scratchpad. Le sha256 du parseur committé est celui du blob orphelin : le fichier versionné **est** l'original.

La fixture synthétique ne dépend de rien (ni PROD, ni base, ni donnée sous licence) et couvre `NULL` vs chaîne vide, `\'`, `''`, `\\`, virgule et guillemet (quoting RFC 4180), `\t`, `\r`, `\n` en champ multi-ligne, `0000-00-00`, et la continuité du compteur `_source_row_no` entre deux `INSERT`.

Les octets des 7 fixtures réelles ne sont **pas** versionnés — données TecDoc sous licence. `scripts/tecdoc-parser-fixtures/real-fixtures.sha256` en porte les empreintes, ce qui permet de rejouer la validation sans redistribuer la donnée. Sans ce répertoire, le test **annonce le saut** plutôt que de laisser croire à une couverture complète.

### Sécurité

Le scan a **échoué sur 2 des 8 fichiers** : `recover-tecdoc-images.py:50-51` portait les identifiants du portail TecDoc en clair, et le rapport root-cause les recopiait verbatim.

Deux constats ont décidé du traitement :

1. **Le secret n'est pas dans l'historique atteignable** — `git log --all` sur ce chemin ne rend rien. Le committer tel quel aurait été une **régression introduite par cette PR**.
2. **`gitleaks` ne le détecte pas** (`no leaks found` sur les 8 fichiers) : mot de passe court, sans préfixe reconnaissable. La garde CI serait verte et fausse ; la vérification est manuelle.

Les littéraux sont remplacés par une lecture d'environnement, sur le modèle que le fichier applique déjà à `SUPABASE_KEY`. C'est la **seule** modification de contenu de cette PR.

> ⚠️ **Action owner, hors PR** : les identifiants du portail TecDoc doivent être considérés comme **compromis et tournés**.

Aucun autre secret. Les valeurs par défaut restantes sont des hôtes publics et le project-ref, déjà présents dans 138 fichiers du dépôt dont `.gitleaks.toml`.

### Dette de portabilité — signalée, non corrigée

Aucun chemin absolu n'a été « corrigé », conformément au périmètre. Inventaire dans `audit/massdoc-tecdoc-artifact-recovery-2026-09-07.md`. Point notable : le parseur **lit le fichier entier en mémoire** (`f.read()`) — 640 Mo d'entrée → ~2 Go de RSS. À revoir avant tout rejeu de masse.

### Risque fermé

Le pipeline TecDoc ne dépend plus d'objets Git orphelins ni du seul disque de la machine DEV. Les 4 scripts et 4 documents sont dans `main`, donc répliqués sur GitHub et sur chaque checkout. Un `git gc --prune` sur DEV est redevenu une opération sans conséquence.

### Ce que cette PR ne prouve pas encore

- **Pas le rejeu complet TecDoc.** Aucune reconstruction de bout en bout depuis l'archive n'a jamais été exécutée. Un parseur validé sur 7 fixtures n'est pas un pipeline rejoué.
- **Pas la reproductibilité du périmètre DLNR de mars 2026.** La liste des « DLNR actifs » qui pilote `load-t400-active.py` et `populate-source-linkages` n'est ni un fichier ni une table figée : c'est une requête sur l'état vivant de la base. Un rejeu aujourd'hui ne reconstituerait pas le même périmètre.
- **Pas l'autorisation de supprimer les ~110 Go.** `tecdoc_raw` et `source_linkages` restent intouchés. Disposition owner-gated (invariant 9, DB destructive).
- **Pas la fermeture des portes runtime** sur les schémas `tecdoc_*`. La vérification adversariale menée en parallèle a prouvé empiriquement qu'elles sont ouvertes — `SET LOCAL ROLE service_role` puis `SELECT` sur `public.v_tecdoc_dlnr_reconciliation` rend des lignes, via une vue non-invoker appartenant à `postgres` qui lit `tecdoc_raw.t400` et `tecdoc_map.source_linkages`. La migration `20260422_views_invoker_special_cases.sql:19-33` documente ce choix comme délibéré. PR sécurité dédiée à suivre, `__load_tecdoc_raw` en priorité.

Hors périmètre volontaire, sans mélange : fermeture des 5 portes · suppression de `tecdoc_rebuild` · de `tecdoc_raw` · de `source_linkages` · correction des 82 101 pièces sans prix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
