### PR TITLE
feat(tecdoc): rapatrier les 16 scripts du pipeline et instrumenter le rejeu source-truth

### DIFF
--- a/audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md
+++ b/audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md
@@ -116,13 +116,64 @@ Cinq autres dérivent leur périmètre de `__tecdoc_supplier_mapping` sans filtr
 d'affichage. Le problème dépasse donc le périmètre fournisseur identifié en #1416 : la
 frontière de ce qui est reconstruit dépend, à chaque étage, de décisions de vitrine.
 
-### 2.2 Aucun script n'a d'appelant
+### 2.2 Aucun script ne sort jamais en erreur — 16 sur 16
+
+Sept des seize contiennent un `sys.exit(1)`. **Les sept sont précédés de
+`parser.print_help()`** : ils ne couvrent qu'un argument CLI manquant.
+
+```
+$ grep -B3 'sys.exit(1)' *.py | grep -c 'parser.print_help()'
+7      # sur 7
+```
+
+**Aucun des 16 ne propage un code non nul sur un échec de données.** Le seul moyen
+d'obtenir une sortie non nulle est d'oublier un drapeau.
+
+La passe de vérification adverse (32 agents, 16 analyses + 16 vérifications
+contradictoires) a relevé **44 mécanismes de faux succès** répartis sur les **16**
+scripts : exceptions avalées rendant `(dlnr, 0)`, `completed += 1` inconditionnel,
+lignes évincées par `ON CONFLICT DO NOTHING` comptées comme créées, seuils de
+journalisation rendant « 0 ligne » indiscernable du silence.
+
+Ce n'est pas un défaut isolé qu'on corrige : c'est la convention du lot. Elle explique
+pourquoi la perte de mars 2026 a pu rester invisible pendant cinq mois, et pourquoi la
+garde de complétude livrée ici doit être **bloquante** et non informative.
+
+**Preuve la plus nette, log à l'appui.** `activate-pieces-v1.py` construit son rapport
+final avec `WHERE wave = 1 ORDER BY created_at DESC LIMIT 20` (L125-131) — **sans aucun
+filtre sur le run courant**. Il somme donc l'historique et le présente comme le résultat
+de l'exécution. Dans `logs/activate-vague2a.log`, à la même seconde
+(2026-03-24 19:44:50) :
+
+```
+[2026-03-24 19:44:50]   Gammes: 0, Total candidates: 0
+  TOTAL ACTIVATED: 0
+[2026-03-24 19:44:50]   Gammes: 20
+[2026-03-24 19:44:50]   Candidates: 33
+[2026-03-24 19:44:50]   Activated: 33
+[2026-03-24 19:44:50]   Success rate: 100.0%
+```
+
+Un run à effet nul, rapporté comme un succès à 100 %.
+
+### 2.3 Un `DELETE` qui précède la lecture
+
+`load-vehicle-tables.py` exécute `DELETE FROM tecdoc_raw.{name}` en **L91**, puis ouvre
+le CSV en **L99** et lit sa première ligne en **L101**. Aucune garde de non-vacuité,
+aucune transaction englobante. Un fichier absent, vide ou illisible laisse donc la table
+de staging **vidée à 100 %** — et le script, dépourvu de sortie non nulle (§2.2), se
+termine par `print("\nDone.")`.
+
+Ce script est classé **REQUIS** : il charge les 7 tables véhicules dont dépend
+`create-vehicles-p4a.py`. C'est une raison de plus de ne pas le lancer tel quel.
+
+### 2.4 Aucun script n'a d'appelant
 
 Ni cron, ni unité systemd, ni wrapper shell, ni référence dans le dépôt. Vérifié sur les
 16. L'ordre d'exécution de mars 2026 n'existait que dans la tête de l'opérateur ; les
 dépendances documentées dans le README ont été reconstituées par lecture du code.
 
-### 2.3 Des chemins concurrents et contradictoires
+### 2.5 Des chemins concurrents et contradictoires
 
 - **Trois** scripts écrivent `pieces.piece_display` avec des critères d'éligibilité
   **différents et non réconciliés** (`activate-pieces-v1`, `populate-linkages-genartnr`,

--- a/audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md
+++ b/audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md
@@ -1,0 +1,484 @@
+# Pipeline TecDoc — rapatriement sous Git et préparation d'un rejeu source-truth
+
+> Mission lecture seule sur PROD. Aucune mutation, aucune suppression, aucun rejeu.
+> Base : PR #1416 mergée (`0a7999a1242bc76d0c599fdc1fbc0b48b2c7da74`).
+
+---
+
+## 0. Incident de sécurité découvert en cours de mission — action owner requise
+
+**Le mot de passe superutilisateur PostgreSQL de la PROD MassDoc est publié en clair sur
+GitHub depuis le 2026-03-27, et il est toujours valide.**
+
+| | |
+|---|---|
+| Emplacement | `scripts/fix-vehicles-massdoc.py:46`, sur `origin/main` |
+| Introduit par | commit `756e619c4`, 2026-03-27 21:32 |
+| Exposition | **dépôt public**, ~5,5 mois |
+| Compte | `postgres` sur `db.<project-ref>.supabase.co:5432`, connexion directe |
+| Toujours actif ? | **OUI** — l'empreinte SHA256 du littéral publié est identique à celle du `SUPABASE_DB_PASSWORD` courant de `backend/.env` (comparé sans afficher les valeurs) |
+
+### Pourquoi aucune garde n'a parlé — diagnostiqué, pas supposé
+
+Le job gitleaks existait depuis le 2026-02-22, soit **avant** la fuite. Mais le
+`.gitleaks.toml` de l'époque n'avait **pas** de bloc `[extend] useDefault = true`. Une
+configuration gitleaks personnalisée **remplace** le jeu de règles par défaut au lieu de
+l'étendre : le job tournait donc **sans aucune règle**. Même fichier, même binaire 8.21.2 :
+
+```
+config du 2026-03-27  →  no leaks found
+config actuelle       →  leaks found: 1   (generic-api-key, ligne 46, entropie 3.58)
+```
+
+`[extend] useDefault = true` a été ajouté le 2026-05-07 par #380. Le job était donc
+**vacant par construction** du 2026-02-22 au 2026-05-07, et la fuite tombe dans cette
+fenêtre. Depuis mai, la garde voit la fuite — mais le scan par PR est *incrémental* et ne
+re-scanne jamais un commit déjà mergé, et le scan hebdomadaire d'historique est
+`continue-on-error: true`. Son exécution du 2026-09-07 affiche **`leaks found: 394`** et
+se conclut en `success`.
+
+Ce n'est pas une exemption abusive : ni `.gitleaksignore` ni l'allowlist ne couvrent ce
+fichier. C'est une garde qui n'a jamais eu de règles, puis une garde qui mesure sans
+assurer.
+
+### Ce que cette PR fait, et ce qu'elle ne peut pas faire
+
+Le littéral est retiré du fichier et remplacé par une lecture d'environnement, sur le
+modèle déjà en place dans `scripts/tecdoc-batch-load.py`. **Cela ne réduit en rien
+l'exposition passée** : l'historique git public conserve la valeur. Seule une **rotation
+du credential** ferme la brèche. Elle n'a pas été faite — c'est une action owner.
+
+Deux suites, hors périmètre de cette PR :
+
+1. **Rotation du mot de passe `postgres`**, puis mise à jour de `backend/.env`, des
+   secrets GitHub Actions et de tout runtime qui l'utilise.
+2. **Triage des 394 findings** du scan hebdomadaire. Ce scan est non bloquant depuis sa
+   création ; personne ne lit son SARIF. Tant qu'il reste `continue-on-error: true` sans
+   revue, il ne protège de rien.
+
+---
+
+## 1. Réconciliation des 17 scripts historiques
+
+| script historique | sur DEV | dans Git | requis au rebuild | statut |
+|---|:-:|:-:|:-:|---|
+| `load-all-suppliers.py` | ✅ | ➕ cette PR | non | **DOUBLON** (v1 de v3) |
+| `load-all-suppliers-v2.py` | ✅ | ➕ cette PR | non | **DOUBLON** (v2 de v3) |
+| `load-all-suppliers-v3.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `load-t400-active.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `load-vehicle-tables.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `create-vehicles-p4a.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `register-and-create-pieces.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `populate-source-linkages.v2.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `populate-linkages-genartnr.py` | ✅ | ➕ cette PR | non | **OBSOLETE** |
+| `project-core-v2.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `project-new-data.py` | ✅ | ➕ cette PR | non | **OBSOLETE** (supplanté 2 h 16 plus tard) |
+| `project-enrichment.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `project-linkages-v3.py` | ✅ | ➕ cette PR | non | **OBSOLETE** (ignore `type_id_remap`) |
+| `project-linkages-retry.py` | ✅ | ➕ cette PR | non | **OBSOLETE** (reprise one-shot) |
+| `project-prt-remap-batch.py` | ✅ | ➕ cette PR | incertain | **VERSIONNÉ**, rôle à trancher |
+| `activate-pieces-v1.py` | ✅ | ➕ cette PR | **oui** | **VERSIONNÉ** |
+| `fix-vehicles-massdoc.py` | ✅ | déjà sur `main` | **oui** | **VERSIONNÉ** — copie DEV **OBSOLETE et dangereuse** |
+
+**16 rapatriés dans cette PR. 17/17 désormais sous Git. 0 manquant.**
+
+La copie DEV de `fix-vehicles-massdoc.py` (`4bd8d29f2f39`, 2026-03-26 19:29) est
+**antérieure** au commit `756e619c4` (2026-03-27 21:32) et contient
+`DROP TABLE IF EXISTS tecdoc_map.modele_id_remap` suivi d'un `CREATE` + `INSERT` qui
+réattribue les identifiants de modèle par `ROW_NUMBER`. La version versionnée a retiré
+cette phase — son en-tête dit *« PAS de remap modele_id »*. La copie DEV n'est donc pas
+rapatriée : ce serait réintroduire dans le dépôt un script qui détruit un registre
+d'identité que l'étape 8 déclare intouchable.
+
+Deux scripts gelés par `DO-NOT-RUN-FROZEN.md` ne sont pas rapatriés, le gel est respecté.
+À noter : le jumeau `tecdoc-project-core.py.frozen.20260413` et le rapport de pollution
+`.spec/reports/pieces-relation-type-pollution-2026-04-13.md` que la note référence
+**n'existent plus**, ni sur disque ni dans git. La note a survécu à ses preuves.
+
+---
+
+## 2. Ce que la lecture des 16 a établi
+
+Détail par script : [`scripts/tecdoc-pipeline/README.md`](../scripts/tecdoc-pipeline/README.md).
+
+### 2.1 Le pipeline entier est piloté par des drapeaux d'affichage marchand
+
+Neuf des seize lisent au moins un drapeau de visibilité **vivant** pour décider quoi faire :
+
+| drapeau | ce qu'il gouverne réellement | scripts |
+|---|---|---|
+| `pieces_marque.pm_display` | quels fournisseurs sont chargés/projetés | 5 direct + 1 via vue |
+| `auto_marque.marque_display` | quelles marques reçoivent des véhicules | 1 |
+| `auto_type.type_display` | quels véhicules reçoivent des liaisons | 4 |
+| `pieces.piece_display` | quelles pièces sont activées | 5 |
+
+Cinq autres dérivent leur périmètre de `__tecdoc_supplier_mapping` sans filtre
+d'affichage. Le problème dépasse donc le périmètre fournisseur identifié en #1416 : la
+frontière de ce qui est reconstruit dépend, à chaque étage, de décisions de vitrine.
+
+### 2.2 Aucun script n'a d'appelant
+
+Ni cron, ni unité systemd, ni wrapper shell, ni référence dans le dépôt. Vérifié sur les
+16. L'ordre d'exécution de mars 2026 n'existait que dans la tête de l'opérateur ; les
+dépendances documentées dans le README ont été reconstituées par lecture du code.
+
+### 2.3 Des chemins concurrents et contradictoires
+
+- **Trois** scripts écrivent `pieces.piece_display` avec des critères d'éligibilité
+  **différents et non réconciliés** (`activate-pieces-v1`, `populate-linkages-genartnr`,
+  `project-prt-remap-batch`). Un seul journalise dans `activation_log` et offre un
+  `--dry-run`.
+- **Trois** portent le même `INSERT` vers `pieces_relation_type`
+  (`project-linkages-v3`, `project-linkages-retry`, `project-prt-remap-batch`).
+
+Lequel fait autorité n'est écrit nulle part.
+
+---
+
+## 3. La perte de mars 2026 : mécanisme établi
+
+L'audit #1416 constatait la perte sans l'expliquer. Elle l'est maintenant, par une
+mesure sur `_source_row_no` — le numéro de ligne source, écrit par le parseur :
+
+| DLNR | marque | émis par le parseur | en base | plage `_source_row_no` | contigu |
+|---:|---|---:|---:|---|:-:|
+| 123 | NISSENS | 790 974 | **100** | 1 → 100 | ✅ |
+| 30 | BOSCH | 9 357 752 | **69 000** | 1 → 69 000 | ✅ |
+| 113 | PAYEN | 1 259 429 | **1 085 500** | 1 → 1 085 500 | ✅ |
+
+**Les lignes chargées sont un préfixe contigu à partir de la ligne 1, sans trou.** Ce
+n'est ni un filtrage métier, ni un échantillonnage, ni une déduplication.
+
+Le mécanisme se déduit du code (`load-t400-active.py:124-165`) :
+
+1. Les 100 lignes de NISSENS sont **inférieures** à `CHUNK_SIZE = 50000` : elles ne
+   peuvent provenir que du *flush* final, placé **après** la boucle.
+2. Ce flush est **à l'intérieur** du `try` : il n'est atteint que si la boucle s'est
+   terminée **sans exception**.
+3. Le `.meta` du parseur déclare pourtant `rows_emitted=790974`, `rows_rejected=0`.
+
+Donc : la boucle a lu le fichier **entier, sans erreur**, et seules les 100 premières
+lignes ont franchi le filtre `if len(row) >= 8` de la ligne 140. Ce filtre n'a **ni
+`else`, ni compteur, ni log**. Les 790 874 lignes restantes ont été jetées en silence, et
+le script est sorti en code 0.
+
+Trois candidats expliquent le décrochage du parsing à cette ligne précise — fin de ligne
+non neutralisée (`open()` sans `newline=''`, L135), limite de champ `csv` de 131 072
+octets, ou octet NUL restitué par le parseur. **Départager les trois exigerait de
+re-parser le shard**, ce que cette mission ne fait pas.
+
+**L'amplificateur, lui, est certain** : le saut « déjà chargé » (L69 + L230-231) est à la
+granularité du DLNR. Dès qu'une seule ligne existe, le shard est réputé complet et ne
+sera jamais rechargé. C'est ce qui a rendu la perte permanente et invisible.
+
+### 3.1 La comptabilité existait déjà — elle n'a jamais été comparée
+
+Le parseur écrit un sidecar `.meta` (`rows_parsed`, `rows_emitted`, `rows_rejected`) et
+imprime `SUMMARY|<fichier>|rows=N|errors=E` sur stderr. **Le chargeur ne lit rien de tout
+cela** : il ne consulte que `returncode` (L114), et se contente de le journaliser avant de
+charger le CSV quand même.
+
+La garde livrée ici ne crée donc pas une capacité nouvelle : elle ferme une boucle qui
+était déjà à moitié construite.
+
+---
+
+## 4. Décision source-truth — confirmée et inscrite
+
+```
+NISSENS → source complète
+BOSCH   → source complète
+FEBI    → source complète
+RIDEX   → source complète
+PAYEN   → source complète
+```
+
+Le futur pipeline reproduit la **source TecDoc**, jamais l'état tronqué de `t400`.
+`t400` reste la vérité **forensique** de ce qui s'est passé ; il n'est pas la vérité
+**fonctionnelle** du rebuild. Aucune troncature volontaire ne sera introduite pour imiter
+l'état actuel.
+
+Conséquence mécanique, portée par `tecdoc_reconcile.py` : le rejeu produira **plus** de
+lignes que la PROD. L'invariant vérifié est donc `PROD ⊆ REBUILD`, pas `PROD == REBUILD`.
+
+---
+
+## 5. Ce que la PR livre — instrumenté et testé, pas appliqué
+
+Séparation **RÉCUPÉRATION / MODERNISATION** demandée à l'étape 3 : les 16 scripts sont
+rapatriés **verbatim** (16/16 SHA256 identiques à l'original), et les modules qu'un futur
+rejeu devra utiliser sont écrits et testés, **sans être câblés**.
+
+| besoin | module | garantie |
+|---|---|---|
+| périmètre figé, modes disjoints | `scripts/tecdoc_scope.py` (étendu) | `--scope-mode historical` exige l'artefact scellé ; **aucun repli** vers `current` |
+| perte de lignes impossible | `scripts/tecdoc_load_guard.py` | `émis == chargées + dédoublonnées + rejets motivés`, sinon STOP |
+| identités jamais réattribuées | `scripts/tecdoc_identity_guard.py` | dérive, réemploi, collision refusés |
+| patrimoine intact | `scripts/tecdoc_preservation.py` | 9 ensembles comparés au manifeste scellé |
+| données neuves en quarantaine | `scripts/tecdoc_reconcile.py` | `NEW_FROM_SOURCE` / `CONFLICT` jamais activés |
+| sceau unique | `scripts/tecdoc_seal.py` | une seule canonicalisation, partagée |
+
+`tecdoc_seal.py` extrait une logique qui existait déjà en trois exemplaires (lecteur de
+périmètre, deux générateurs) et était sur le point d'en avoir une quatrième. La
+règle-de-trois est franchie ; l'extraction réduit l'entropie au lieu de l'augmenter.
+
+### 5.1 Une dérivation devinée, prise en défaut puis remplacée
+
+Le vérificateur de conservation construisait d'abord ses requêtes en dérivant la forme
+documentée dans le manifeste. Confrontée à la base, cette dérivation **échouait sur
+`gamme_registry`** : ordonner par l'expression texte `pg_id_source||'>'||pg_id` donne
+`64816aa0…`, alors que le manifeste porte `0a2ef785…`, obtenu en ordonnant par
+`pg_id_source` **numérique** — un tri texte place « 1000 » avant « 2 ». Même cardinal
+(9 702), empreinte différente.
+
+Sur `type_id_remap`, la dérivation tombait juste **par accident** : tous les `old_id` ont
+six chiffres, donc ordre texte == ordre numérique.
+
+Une requête devinée qui tombe juste sur 8 cas sur 9 est plus dangereuse qu'une table
+écrite : elle aurait un jour fait échouer un contrôle de conservation sur une base
+pourtant intacte, et l'écart aurait été imputé à la donnée. La dérivation est donc
+remplacée par **9 requêtes explicites, chacune vérifiée contre la PROD le 2026-09-08**.
+
+---
+
+## 6. Preuves d'exécution
+
+### Scope figé, deux modes disjoints
+
+```
+$ bash scripts/test-tecdoc-scope.sh
+  PASS  historical + artefact = les 110 projetes
+  PASS  historical + selection charges = les 149
+  PASS  historical SANS scope-file est REFUSE
+  PASS  historical sur artefact altere est REFUSE
+  PASS  current + scope-file est REFUSE (sources contradictoires)
+  PASS  un mode inconnu est REFUSE
+PASS=24  FAIL=0
+```
+
+### Gardes chargement / identité / conservation / quarantaine
+
+```
+$ bash scripts/test-tecdoc-guards.sh
+=== garde de completude du chargement ===
+  PASS  emis == charges : accepte
+  PASS  perte massive (BOSCH mars 2026) : REFUSE
+  PASS  perte d'UNE seule ligne : REFUSE
+  PASS  dedoublonnage explicitement compte : accepte
+  PASS  rejets motives et comptes : accepte
+  PASS  rejet non explique (categorie fourre-tout) : REFUSE
+  PASS  rejet a raison vide : REFUSE
+  PASS  plus de lignes chargees qu'emises : REFUSE
+  PASS  rapport a zero lot n'est pas un succes
+=== garde d'identite ===
+  PASS  mapping conserve + cle nouvelle : accepte
+  PASS  un identifiant existant qui change : REFUSE
+  PASS  un identifiant existant donne a une AUTRE cle : REFUSE
+  PASS  rejeu partiel : identite intacte, absences signalees
+=== conservation applicative (sur le manifeste reel, sans base) ===
+  PASS  avant == apres : conservation intacte (exit 0)
+  PASS  suppression simulee d'une gamme : REFUSE (exit 7)
+  PASS  suppression simulee d'un vehicule : REFUSE (exit 7)
+  PASS  suppression simulee d'une piece : REFUSE (exit 7)
+  PASS  un ensemble non mesure est un ECHEC, pas un saut (exit 7)
+  PASS  manifeste altere : REFUSE (exit 2)
+=== reconciliation et quarantaine ===
+  PASS  source-truth qui AJOUTE (cas BOSCH) : inclusion respectee
+  PASS  les ajouts partent en quarantaine, pas en activation
+  PASS  a_activer ne rend que EXISTING_PROD
+  PASS  activer la quarantaine : REFUSE
+  PASS  une cle servie en PROD que le rejeu perd : inclusion ROMPUE
+  PASS  une valeur qui diverge : CONFLICT, inclusion ROMPUE
+  PASS  valeur manquante d'un cote : UNKNOWN, jamais activee
+PASS=26  FAIL=0
+```
+
+Les cas négatifs sont le cœur de ces suites : **une garde qu'on n'a jamais vue refuser
+n'a pas été testée, elle a seulement été vue se taire**.
+
+### Conservation vérifiée contre la PROD du jour
+
+Les 9 requêtes d'empreinte rejouées en lecture seule le 2026-09-08 reproduisent
+**exactement** les 9 empreintes scellées dans le manifeste de #1416 :
+
+```
+$ python3 scripts/tecdoc_preservation.py \
+    --manifest audit/massdoc-tecdoc-preservation-manifest-2026-03.json \
+    --mesures  mesures-prod-2026-09-08.json
+conservation intacte — 9 ensembles applicatifs identiques au manifeste.
+```
+
+Les 23 457 véhicules, 7 088 modèles, 119 702 pièces, 876 gammes, 23 457 mappings
+d'identité, 43 484 cibles de liaison et le rollup des 3 240 177 articles sont donc
+**inchangés** entre le 2026-09-08 (mesure #1416) et aujourd'hui.
+
+### Aucun secret dans le lot rapatrié
+
+```
+$ gitleaks dir scripts/tecdoc-pipeline --config .gitleaks.toml
+INF scan completed  ·  INF no leaks found
+```
+
+Les 16 scripts lisent tous leur mot de passe depuis `backend/.env` — aucun n'en contient
+en dur. Ils codent en dur des identifiants d'infrastructure (hôte, port, référence de
+projet), ce qui est la convention déjà en vigueur dans `scripts/tecdoc-batch-load.py`
+et une valeur explicitement déclarée non-secrète dans `.gitleaks.toml`.
+
+---
+
+## 7. Idempotence — état réel, par étape
+
+Aucune étape n'est idempotente au sens fort. Le tableau dit ce qui est protégé, et ce qui
+ne l'est pas.
+
+| étape | doublons | réattribution d'ID | reprise après échec partiel | verdict |
+|---|---|---|---|---|
+| extract (7z) | s.o. | s.o. | code retour de `7z` **jamais lu** | **non protégé** |
+| parse | s.o. | s.o. | `.meta` + `SUMMARY` émis, **jamais lus** | **non protégé** |
+| load raw | `copy_from` sans `ON CONFLICT` ni clé unique ; seule protection = le saut « déjà chargé » | non | **impossible** : ≥ 1 ligne ⇒ shard réputé complet à jamais | **NON IDEMPOTENT** |
+| source_linkages | clé métier sha256 + `ON CONFLICT DO NOTHING` + `DISTINCT` | non | **impossible** : même saut DLNR-granulaire | **partiel** — sûr à la ligne, pas à la reprise |
+| project relations | `ON CONFLICT DO NOTHING` | `project-linkages-v3` **ignore `type_id_remap`** | dépend d'un run antérieur | **partiel** |
+| project enrichments | `ON CONFLICT DO NOTHING` (une cible non spécifiée) | non | aucune | **partiel** |
+
+Trois défauts transverses :
+
+- **`ON CONFLICT` nu**, sans cible, dans plusieurs scripts : il absorbe les conflits de
+  *n'importe quelle* contrainte d'unicité, y compris plus étroite que la clé métier. Un
+  effondrement massif de lignes serait invisible, `cur.rowcount` ne comptant que l'inséré.
+- **Le snapshot « déjà chargé » est pris une seule fois** avant le pool de workers, sans
+  verrou d'avis : deux exécutions concurrentes chargeraient les mêmes shards en doublon.
+- **Le périmètre dépend de l'état vivant** : même `t400`, autre jour, autre volume, sans
+  aucune trace de l'écart.
+
+Ce que le futur pipeline doit fournir, et qui n'existe nulle part aujourd'hui : une
+reprise fondée sur **complétude prouvée** (compte attendu par shard, via l'artefact
+scellé et le `.meta`) plutôt que sur la présence d'au moins une ligne.
+
+---
+
+## 8. Identités et conservation — ce qui est garanti
+
+`tecdoc_identity_guard.py` refuse les trois interdits — **dérive** (une clé mappée change
+de valeur), **réemploi** (un identifiant pris est donné à une autre clé), **collision**.
+Une clé nouvelle recevant un identifiant libre reste légitime : c'est ainsi qu'un rejeu
+source-truth ajoute ce que mars avait perdu.
+
+Registres couverts : `type_id_remap`, `article_registry`, `linkage_target_registry`,
+`pg_id_remap`, `modele_id_remap`.
+
+`tecdoc_preservation.py` couvre les 11 tables applicatives via les 9 ensembles scellés,
+et **échoue** si un ensemble n'est pas mesuré — ne pas mesurer n'est pas conserver.
+
+Rappel inscrit dans les deux modules : la campagne a créé **876 gammes**, dont 18
+seulement portent « TecDoc » dans leur nom. Le manifeste les identifie par **bande
+d'identifiants** (`pg_id >= 60000`), jamais par libellé.
+
+---
+
+## 9. Nouvelles données — quarantaine, quatre catégories
+
+| catégorie | définition | activation |
+|---|---|---|
+| `EXISTING_PROD` | même clé, même valeur des deux côtés | **automatique** |
+| `NEW_FROM_SOURCE` | clé absente de la PROD | **quarantaine** |
+| `CONFLICT` | même clé, valeurs différentes | **quarantaine** — arbitrage humain |
+| `UNKNOWN` | valeur manquante d'un côté | **quarantaine** |
+
+`a_activer()` ne rend que `EXISTING_PROD`. Le drapeau `inclure_quarantaine=True` existe
+uniquement pour que la demande soit **écrite dans le code appelant et visible en revue** —
+il lève systématiquement.
+
+Une cinquième grandeur est rapportée à part : `absentes_du_rejeu`, les clés servies en
+PROD que le rejeu ne reproduit pas. Ce n'est pas une catégorie de quarantaine mais le
+signal qui rend `inclusion_respectee` faux.
+
+---
+
+## 10. Rejeu hors PROD et sauvegarde forensique — plans, non exécutés
+
+### Chaîne de rejeu isolée
+
+```
+SQL-CONVERTED.7z (6,1 Go, hors git, machine DEV)
+   ↓ parse            scripts/tecdoc-mysql-to-csv.py  (versionné)
+   ↓ load raw         → schéma tecdoc_replay_<date>   (JAMAIS tecdoc_raw)
+   ↓ source_linkages  → schéma tecdoc_replay_<date>
+   ↓ projections      → schéma tecdoc_replay_<date>
+   ↓ comparaison      tecdoc_reconcile.py vs manifeste PROD (lecture seule)
+```
+
+`populate-source-linkages.v2.py` accepte déjà `--target-schema`, ce qui rend l'isolation
+possible sans le modifier. **Piège identifié** : `--dlnr-only` court-circuite le périmètre
+**et écrit par défaut dans `tecdoc_map`** — un mode « test » qui vise la cible réelle.
+À corriger avant tout essai.
+
+Aucun essai n'a été lancé dans cette mission : la cible isolée n'existe pas, et la créer
+sur la base partagée serait une mutation PROD.
+
+### Sauvegarde forensique avant tout futur DROP
+
+Tailles réelles mesurées le 2026-09-08 :
+
+| objet | lignes | taille |
+|---|---:|---:|
+| `tecdoc_map.source_linkages` | 339 249 945 (exact) | **90 Go** |
+| `tecdoc_raw.t400` | 138 815 762 (exact) | **17 Go** |
+| `tecdoc_raw.t232` | 14 498 915 (exact) | 1 770 Mo |
+| `tecdoc_rebuild.source_linkages` | ~2 608 718 | 662 Mo |
+| `tecdoc_map.source_linkage_criteria` | ~1 614 421 | 356 Mo |
+| `tecdoc_rebuild.pieces_relation_type` | ~2 225 804 | 284 Mo |
+| **total** | | **≈ 110 Go** |
+
+Format proposé : `COPY … TO PROGRAM 'zstd -19'` en CSV, un fichier par table, shardé par
+DLNR pour `t400` et `source_linkages` afin qu'une restitution partielle reste possible.
+Compression attendue 8–12× sur ce type de données très répétitives, soit **9 à 14 Go**.
+Chaque shard accompagné de son SHA256 et d'un manifeste listant compte, bornes et
+empreinte — le même contrat que le manifeste de conservation, pour que la restitution
+soit **vérifiable** et pas seulement possible.
+
+Emplacement : **hors** de la base et hors du disque DEV (occupé à 74 %). La destination
+n'est pas décidée — c'est une décision owner, avec un coût de stockage.
+
+**Non exécuté** : un dump de 110 Go n'est pas nécessaire dans cette PR, et le lancer
+consommerait de l'I/O sur la base de production.
+
+---
+
+## 11. Verdicts
+
+### Rejeu complet possible maintenant ? — **NON**
+
+Raison principale unique : **aucun environnement isolé n'existe**, et les scripts
+rapatriés ne sont pas câblés aux gardes. Ils sont sous git — c'est ce qui bloquait avant
+— mais les lancer aujourd'hui reproduirait le défaut de mars : périmètre vivant,
+comptabilité absente, saut « déjà chargé » qui fige toute perte.
+
+### DROP des ~110 Go autorisable ? — **NON**
+
+```
+[x] scope figé et scellé                      #1416
+[x] sources présentes et vérifiées            149/149 shards, CRC32
+[x] parseur sous git                          scripts/tecdoc-mysql-to-csv.py
+[x] scripts du pipeline sous git              17/17 — CETTE PR
+[x] décision source-truth tranchée            owner, 2026-09-08
+[x] gardes chargement/identité/conservation   50 assertions vertes
+[x] conservation vérifiée contre la PROD      9/9 empreintes identiques
+[ ] scripts câblés aux gardes                 MODERNISATION, non faite
+[ ] rejeu complet hors PROD exécuté           jamais tenté
+[ ] comparaison rebuild/PROD conforme         sans objet tant que 9 est rouge
+[ ] dump de sécurité effectué                 planifié, non exécuté
+[ ] mot de passe PROD tourné                  ACTION OWNER — §0
+```
+
+7 vertes, 5 rouges. Le `DROP` reste interdit.
+
+### Prochaine action unique
+
+**Tourner le mot de passe `postgres` de la PROD MassDoc.** Ce n'est pas la suite logique
+du chantier TecDoc, et c'est pourtant la seule action dont le report coûte quelque chose
+chaque jour : un superutilisateur de la base de production est lisible publiquement depuis
+5,5 mois. Tout le reste du chantier peut attendre ; cela, non.
+
+L'action suivante, une fois la rotation faite : câbler `load-t400-active.py` aux gardes
+comme implémentation de référence, et prouver le patch sur un DLNR minuscule dans un
+schéma jetable.

--- a/log.md
+++ b/log.md
@@ -476,3 +476,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-pipeline-recovery`
 - **Décision** : feat(tecdoc): rapatrier les 16 scripts du pipeline et instrumenter le rejeu source-truth
 - **Sortie** : PR #1417 | commits ae0871d03
+
+## 2026-09-08 — feat/tecdoc-pipeline-recovery (auto)
+
+- **Branche** : `feat/tecdoc-pipeline-recovery`
+- **Décision** : docs(tecdoc): consigner le piege latent de derivation du DLNR par str.replace (+2 other commits)
+- **Sortie** : PR #1417 | commits 9c4b7640f b1dd9aa25 ae0871d03

--- a/log.md
+++ b/log.md
@@ -470,3 +470,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `security/tecdoc-api-surface-lockdown`
 - **Décision** : chore(registry): resync L1+L3 projections (+1 other commit)
 - **Sortie** : PR #1414 | commits 6343b3f5e 297d6c3b3
+
+## 2026-09-08 — feat/tecdoc-pipeline-recovery (auto)
+
+- **Branche** : `feat/tecdoc-pipeline-recovery`
+- **Décision** : feat(tecdoc): rapatrier les 16 scripts du pipeline et instrumenter le rejeu source-truth
+- **Sortie** : PR #1417 | commits ae0871d03

--- a/scripts/fix-vehicles-massdoc.py
+++ b/scripts/fix-vehicles-massdoc.py
@@ -38,12 +38,44 @@ except ImportError:
     sys.exit(1)
 
 # ─── Config ───────────────────────────────────────────────
+# Le mot de passe etait ici EN CLAIR depuis le commit 756e619c4 (2026-03-27), sur un
+# depot PUBLIC. Il est desormais lu dans l'environnement, comme le fait deja
+# scripts/tecdoc-batch-load.py. Retirer la valeur du fichier ne reduit PAS l'exposition
+# passee : l'historique git public la conserve. Seule une rotation du credential ferme
+# la breche — voir audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md.
+
+
+def _db_password() -> str:
+    """Rend le mot de passe DB, ou sort en erreur. Jamais de valeur par defaut.
+
+    Un mot de passe par defaut redonnerait au fichier le role qu'on lui retire.
+    """
+    pw = os.environ.get('SUPABASE_DB_PASSWORD')
+    if not pw:
+        env = os.environ.get('SUPABASE_ENV_FILE', '/opt/automecanik/app/backend/.env')
+        try:
+            with open(env) as f:
+                for ligne in f:
+                    if ligne.startswith('SUPABASE_DB_PASSWORD='):
+                        pw = ligne.split('=', 1)[1].strip().strip('"').strip("'")
+                        break
+        except OSError:
+            pw = None
+    if not pw:
+        sys.exit(
+            "SUPABASE_DB_PASSWORD absent de l'environnement et de "
+            f"{os.environ.get('SUPABASE_ENV_FILE', '/opt/automecanik/app/backend/.env')}. "
+            "Refus de se connecter."
+        )
+    return pw
+
+
 DB_DIRECT = {
-    'host': 'db.cxpojprgwgubzjyqzmoq.supabase.co',
-    'port': 5432,
-    'dbname': 'postgres',
-    'user': 'postgres',
-    'password': 'T7qrnbWg7MwqkF7v',
+    'host': os.environ.get('SUPABASE_DB_HOST_DIRECT', 'db.cxpojprgwgubzjyqzmoq.supabase.co'),
+    'port': int(os.environ.get('SUPABASE_DB_PORT_DIRECT', '5432')),
+    'dbname': os.environ.get('SUPABASE_DB_NAME', 'postgres'),
+    'user': os.environ.get('SUPABASE_DB_USER_DIRECT', 'postgres'),
+    'password': _db_password(),
     'options': '-c statement_timeout=0',
 }
 

--- a/scripts/tecdoc-pipeline/README.md
+++ b/scripts/tecdoc-pipeline/README.md
@@ -83,7 +83,17 @@ dangereuse pour l'état actuel de la base :
    réconciliés** ; trois autres portent le même `INSERT` vers `pieces_relation_type`.
    Lequel fait autorité n'est écrit nulle part.
 
-6. **Aucun ordonnancement.** Aucun des 16 n'a d'appelant : ni cron, ni unité systemd, ni
+6. **Un piège latent sur le nom de shard.** `load-t400-active.py:90` dérive le DLNR par
+   `fname.replace('400.', '')`, qui remplace **toutes** les occurrences, pas seulement le
+   préfixe. Pour un DLNR **400** ou **1400**, `400.0400.sql` et `400.1400.sql` donnent
+   `'0sql'` et `'1sql'` → `ValueError` → `except ValueError: pass` → **le shard est
+   ignoré en silence**, sans log ni compteur.
+
+   Vérifié sur le périmètre réel : **0 des 149 DLNR** de mars 2026 déclenche le défaut.
+   Il est donc latent, pas actif — mais un périmètre futur contenant l'un de ces
+   identifiants perdrait son shard sans le moindre signal.
+
+7. **Aucun ordonnancement.** Aucun des 16 n'a d'appelant : ni cron, ni unité systemd, ni
    wrapper shell, ni référence dans le dépôt. L'ordre d'exécution de mars 2026 n'existait
    que dans la tête de l'opérateur. Les dépendances reconstituées ci-dessus viennent de
    la lecture du code, pas d'un orchestrateur.

--- a/scripts/tecdoc-pipeline/README.md
+++ b/scripts/tecdoc-pipeline/README.md
@@ -1,0 +1,158 @@
+# Pipeline TecDoc — scripts rapatriés, **en quarantaine**
+
+> **Ne lancez aucun script de ce répertoire en l'état.** Ils sont ici pour cesser
+> d'exister uniquement sur un disque, pas pour être exécutés. Lire §« Pourquoi la
+> quarantaine » avant toute tentative.
+
+## Ce que contient ce répertoire
+
+Les 16 scripts qui ont réalisé la campagne d'import TecDoc de mars 2026, rapatriés
+**verbatim** depuis `/opt/automecanik/data/tecdoc/` le 2026-09-08. Aucun octet modifié :
+chaque fichier a le SHA256 de son original, vérifié à la copie (16/16 identiques).
+
+La fidélité prime ici sur la propreté. Ces scripts sont la seule description exécutable
+de ce qui a produit l'état actuel de la base ; les corriger en les rapatriant aurait
+détruit leur valeur de preuve, et la campagne de mars ne serait plus reconstituable.
+La correction est une phase distincte — voir §« Récupération ≠ modernisation ».
+
+Un dix-septième script du même répertoire DEV, `fix-vehicles-massdoc.py`, n'est **pas**
+ici : il est déjà versionné sous `scripts/fix-vehicles-massdoc.py`, dans une version
+**postérieure** à la copie DEV. Voir §« Le cas fix-vehicles-massdoc ».
+
+## Inventaire
+
+| script | étape | SHA256 (12) | modifié | statut |
+|---|---|---|---|---|
+| `load-all-suppliers.py` | 1 · RAW | `3f0ae0006e29` | 2026-03-21 | **OBSOLÈTE** — v1, supplanté par v3 |
+| `load-all-suppliers-v2.py` | 1 · RAW | `b9b973c386bf` | 2026-03-21 | **OBSOLÈTE** — v2, supplanté par v3 |
+| `load-all-suppliers-v3.py` | 1 · RAW | `ba905d4e361e` | 2026-03-22 | **REQUIS** — chargeur RAW générique des 32 shards |
+| `load-t400-active.py` | 1 · RAW | `9861e9e20bcd` | 2026-03-23 | **REQUIS** — chargeur du shard 400 (liaisons) |
+| `load-vehicle-tables.py` | 1 · RAW | `9a118a074d65` | 2026-03-23 | **REQUIS** — charge les 7 tables véhicules |
+| `create-vehicles-p4a.py` | 2 · véhicules | `6a0f28430235` | 2026-03-23 | **REQUIS** — crée `auto_modele` / `auto_type` |
+| `register-and-create-pieces.py` | 3 · pièces | `d4f3af483633` | 2026-03-23 | **REQUIS** — `article_registry` + `pieces` |
+| `populate-source-linkages.v2.py` | 4 · staging | `a5d01433e62a` | 2026-04-13 | **REQUIS** — v2 corrective (voir §pollution) |
+| `populate-linkages-genartnr.py` | 4 · staging | `5b4a54800701` | 2026-03-26 | **OBSOLÈTE** — héritage GENARTNR, 3ᵉ chemin d'activation |
+| `project-core-v2.py` | 5 · projection | `fd0c48cba4d0` | 2026-03-22 | **REQUIS** — projection cœur 4 phases |
+| `project-new-data.py` | 5 · projection | `35d0b93d4379` | 2026-03-22 | **OBSOLÈTE** — supplanté 2 h 16 plus tard par `project-core-v2` |
+| `project-enrichment.py` | 5 · projection | `423d46c433eb` | 2026-04-12 | **REQUIS** — OEM, refs, médias, critères |
+| `project-linkages-v3.py` | 5 · projection | `de3a06004263` | 2026-03-24 | **OBSOLÈTE** — ignore `type_id_remap` |
+| `project-linkages-retry.py` | 5 · projection | `4536d237b138` | 2026-03-22 | **OBSOLÈTE** — reprise one-shot de 17 chunks |
+| `project-prt-remap-batch.py` | 5 · projection | `f08b10468c69` | 2026-03-28 | **INCERTAIN** — dernier écrivain connu de `pieces_relation_type` |
+| `activate-pieces-v1.py` | 6 · activation | `7c840b61e43b` | 2026-03-24 | **REQUIS** — bascule `pieces.piece_display` |
+
+Provenance : `/opt/automecanik/data/tecdoc/<nom>.py`, machine DEV. Dates = `mtime` du
+fichier source. `git log` ne peut rien en dire : aucun n'a jamais été versionné.
+
+## Pourquoi la quarantaine
+
+Six défauts structurels, constatés dans le code, rendent une exécution telle quelle
+dangereuse pour l'état actuel de la base :
+
+1. **Le comportement se recalcule à chaque exécution, depuis des drapeaux d'affichage
+   marchand.** Ce n'est pas seulement le périmètre fournisseur : **9 des 16** lisent au
+   moins un drapeau de visibilité vivant pour décider quoi traiter.
+
+   | drapeau | ce qu'il gouverne réellement | scripts |
+   |---|---|---|
+   | `pieces_marque.pm_display` | quels fournisseurs sont chargés/projetés | 5 en direct + 1 via `v_projection_scope_*` |
+   | `auto_marque.marque_display` | quelles marques reçoivent des véhicules | 1 |
+   | `auto_type.type_display` | quels véhicules reçoivent des liaisons | 4 |
+   | `pieces.piece_display` | quelles pièces sont activées | 5 |
+
+   Cinq autres scripts dérivent leur périmètre de `__tecdoc_supplier_mapping` sans filtre
+   d'affichage — donc du contenu vivant de cette table, lui aussi muable.
+
+   Conséquence : le résultat de mars 2026 n'est pas reproductible. La même commande,
+   aujourd'hui, traite 109 fournisseurs au lieu des 110 projetés en mars — et un
+   changement de vitrine sur une marque suffit à déplacer la frontière, sans trace.
+
+2. **Aucune comptabilité lu/écrit.** Aucun script ne compare ce qu'il a lu à ce qu'il a
+   écrit, ni ne compte ses rejets. `load-t400-active.py` additionne les lignes *envoyées*
+   au `COPY` sans jamais lire `cur.rowcount`, et sort toujours en code 0.
+
+3. **Un chargement partiel devient définitif.** Le saut « déjà chargé » est à la
+   granularité du DLNR : dès qu'une seule ligne existe, le shard est réputé complet et
+   ne sera jamais rechargé. C'est ce qui a rendu permanente la perte de 99,99 % des
+   lignes NISSENS.
+
+4. **Les preuves sont détruites après coup.** `load-t400-active.py` supprime les `.sql`
+   et `.csv` intermédiaires même après un chargement partiel.
+
+5. **Des chemins concurrents et contradictoires.** Trois scripts écrivent le même booléen
+   `pieces.piece_display` avec des critères d'éligibilité **différents et non
+   réconciliés** ; trois autres portent le même `INSERT` vers `pieces_relation_type`.
+   Lequel fait autorité n'est écrit nulle part.
+
+6. **Aucun ordonnancement.** Aucun des 16 n'a d'appelant : ni cron, ni unité systemd, ni
+   wrapper shell, ni référence dans le dépôt. L'ordre d'exécution de mars 2026 n'existait
+   que dans la tête de l'opérateur. Les dépendances reconstituées ci-dessus viennent de
+   la lecture du code, pas d'un orchestrateur.
+
+## Récupération ≠ modernisation
+
+Cette PR fait la **récupération**. La **modernisation** est instrumentée mais non
+appliquée : les modules qu'un futur rejeu devra utiliser existent, sont testés, et
+attendent d'être câblés.
+
+| besoin | module | garantie |
+|---|---|---|
+| périmètre figé, deux modes disjoints | [`scripts/tecdoc_scope.py`](../tecdoc_scope.py) | `--scope-mode historical` exige l'artefact scellé ; aucun repli vers `current` |
+| perte de lignes impossible | [`scripts/tecdoc_load_guard.py`](../tecdoc_load_guard.py) | `émis == chargées + dédoublonnées + rejets motivés`, sinon STOP |
+| identités jamais réattribuées | [`scripts/tecdoc_identity_guard.py`](../tecdoc_identity_guard.py) | dérive, réemploi et collision refusés |
+| patrimoine applicatif intact | [`scripts/tecdoc_preservation.py`](../tecdoc_preservation.py) | 9 ensembles comparés au manifeste scellé |
+| données neuves en quarantaine | [`scripts/tecdoc_reconcile.py`](../tecdoc_reconcile.py) | `NEW_FROM_SOURCE` et `CONFLICT` jamais activés |
+| sceau unique | [`scripts/tecdoc_seal.py`](../tecdoc_seal.py) | une seule définition de la canonicalisation |
+
+Tests : `bash scripts/test-tecdoc-scope.sh` (24) et `bash scripts/test-tecdoc-guards.sh` (26).
+
+Le patch type, à appliquer script par script lors de la phase de modernisation :
+
+```python
+# AVANT — le périmètre dépend d'un drapeau d'affichage marchand, muable
+def get_active_dlnrs():
+    cur.execute("""
+    SELECT sm.dlnr FROM __tecdoc_supplier_mapping sm
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    ORDER BY sm.dlnr""")
+    return [r[0] for r in cur.fetchall()]
+
+# APRÈS — le mode est explicite, l'artefact est vérifié, aucun repli n'est possible
+from tecdoc_scope import ajouter_arguments_perimetre, resoudre_dlnr
+
+ajouter_arguments_perimetre(parser)              # --scope-mode / --scope-file
+dlnrs = resoudre_dlnr(args.scope_mode, args.scope_file,
+                      selection=args.scope_selection)
+```
+
+## Le cas `fix-vehicles-massdoc.py`
+
+La copie DEV (`4bd8d29f2f39`, 2026-03-26 19:29) est **antérieure** à la version
+versionnée (commit `756e619c4`, 2026-03-27 21:32) et **plus dangereuse** : elle contient
+`DROP TABLE IF EXISTS tecdoc_map.modele_id_remap` suivi d'un `CREATE` + `INSERT` qui
+réattribue les identifiants de modèle par `ROW_NUMBER`. La version versionnée a retiré
+cette phase — son en-tête le dit explicitement : *« PAS de remap modele_id »*.
+
+La copie DEV n'est donc **pas** rapatriée : elle serait une régression, et
+`tecdoc_map.modele_id_remap` fait partie des registres d'identité intouchables.
+
+La version versionnée portait par ailleurs un mot de passe de base de production en
+clair, depuis le 2026-03-27, sur un dépôt public. Il a été retiré dans cette PR et
+remplacé par une lecture d'environnement. **Retirer la valeur du fichier ne réduit pas
+l'exposition passée** : l'historique git public la conserve. Voir
+[`audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md`](../../audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md).
+
+## La pollution de 2026-04-13
+
+`/opt/automecanik/data/tecdoc/DO-NOT-RUN-FROZEN.md` gèle deux scripts responsables de
+~219 M lignes fantômes dans `pieces_relation_type` (60 % de la table), pour avoir casté
+`t400.col_6::int` directement en `target_internal_id` sans passer par
+`tecdoc_map.vehicle_registry`. `populate-source-linkages.v2.py`, présent ici, est la
+version corrective : il résout via `linkage_target_registry`.
+
+Deux constats sur ce gel, vérifiés le 2026-09-08 :
+
+- le script gelé `populate-source-linkages.py.frozen.20260413` existe toujours sur DEV
+  et n'est **pas** rapatrié ici — le gel est respecté ;
+- son jumeau `tecdoc-project-core.py.frozen.20260413` et le rapport de pollution
+  `.spec/reports/pieces-relation-type-pollution-2026-04-13.md` que la note référence
+  **n'existent plus**, ni sur disque ni dans git. La note de gel a survécu à ses preuves.

--- a/scripts/tecdoc-pipeline/README.md
+++ b/scripts/tecdoc-pipeline/README.md
@@ -66,24 +66,40 @@ dangereuse pour l'état actuel de la base :
    aujourd'hui, traite 109 fournisseurs au lieu des 110 projetés en mars — et un
    changement de vitrine sur une marque suffit à déplacer la frontière, sans trace.
 
-2. **Aucune comptabilité lu/écrit.** Aucun script ne compare ce qu'il a lu à ce qu'il a
+2. **Aucun script ne sort jamais en erreur.** Sept des seize contiennent un
+   `sys.exit(1)` — et **les sept sont précédés de `parser.print_help()`**. Ils ne
+   couvrent qu'un argument CLI manquant. Aucun des 16 ne propage un code non nul sur un
+   échec de données : le seul moyen d'obtenir une sortie non nulle est d'oublier un
+   drapeau.
+
+   ```
+   $ grep -B3 'sys.exit(1)' *.py | grep -c 'parser.print_help()'   →  7 sur 7
+   ```
+
+   La vérification adverse a relevé **44 mécanismes de faux succès** répartis sur les
+   **16** scripts : exceptions avalées rendant `(dlnr, 0)`, `completed += 1`
+   inconditionnel, `ON CONFLICT DO NOTHING` comptés comme créations, seuils de
+   journalisation qui rendent « 0 ligne » indiscernable du silence. Ce n'est pas un
+   défaut isolé, c'est la convention du lot.
+
+3. **Aucune comptabilité lu/écrit.** Aucun script ne compare ce qu'il a lu à ce qu'il a
    écrit, ni ne compte ses rejets. `load-t400-active.py` additionne les lignes *envoyées*
    au `COPY` sans jamais lire `cur.rowcount`, et sort toujours en code 0.
 
-3. **Un chargement partiel devient définitif.** Le saut « déjà chargé » est à la
+4. **Un chargement partiel devient définitif.** Le saut « déjà chargé » est à la
    granularité du DLNR : dès qu'une seule ligne existe, le shard est réputé complet et
    ne sera jamais rechargé. C'est ce qui a rendu permanente la perte de 99,99 % des
    lignes NISSENS.
 
-4. **Les preuves sont détruites après coup.** `load-t400-active.py` supprime les `.sql`
+5. **Les preuves sont détruites après coup.** `load-t400-active.py` supprime les `.sql`
    et `.csv` intermédiaires même après un chargement partiel.
 
-5. **Des chemins concurrents et contradictoires.** Trois scripts écrivent le même booléen
+6. **Des chemins concurrents et contradictoires.** Trois scripts écrivent le même booléen
    `pieces.piece_display` avec des critères d'éligibilité **différents et non
    réconciliés** ; trois autres portent le même `INSERT` vers `pieces_relation_type`.
    Lequel fait autorité n'est écrit nulle part.
 
-6. **Un piège latent sur le nom de shard.** `load-t400-active.py:90` dérive le DLNR par
+7. **Un piège latent sur le nom de shard.** `load-t400-active.py:90` dérive le DLNR par
    `fname.replace('400.', '')`, qui remplace **toutes** les occurrences, pas seulement le
    préfixe. Pour un DLNR **400** ou **1400**, `400.0400.sql` et `400.1400.sql` donnent
    `'0sql'` et `'1sql'` → `ValueError` → `except ValueError: pass` → **le shard est
@@ -93,7 +109,13 @@ dangereuse pour l'état actuel de la base :
    Il est donc latent, pas actif — mais un périmètre futur contenant l'un de ces
    identifiants perdrait son shard sans le moindre signal.
 
-7. **Aucun ordonnancement.** Aucun des 16 n'a d'appelant : ni cron, ni unité systemd, ni
+8. **Un `DELETE` qui précède la lecture.** `load-vehicle-tables.py:91` exécute
+   `DELETE FROM tecdoc_raw.{name}` **avant** d'ouvrir le CSV (L99) et de lire la première
+   ligne (L101), sans garde de non-vacuité. Un fichier absent, vide ou illisible laisse
+   donc la table de staging **vidée à 100 %** — et le script, dépourvu de sortie non
+   nulle (point 2), se termine par `print("\nDone.")`.
+
+9. **Aucun ordonnancement.** Aucun des 16 n'a d'appelant : ni cron, ni unité systemd, ni
    wrapper shell, ni référence dans le dépôt. L'ordre d'exécution de mars 2026 n'existait
    que dans la tête de l'opérateur. Les dépendances reconstituées ci-dessus viennent de
    la lecture du code, pas d'un orchestrateur.

--- a/scripts/tecdoc-pipeline/activate-pieces-v1.py
+++ b/scripts/tecdoc-pipeline/activate-pieces-v1.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Activate pieces Vague 1 — controlled activation with full logging.
+
+Activates pieces from v_tecdoc_activation_candidates by gamme (pg_alias).
+Logs every batch to tecdoc_map.activation_log.
+
+Usage:
+  python3 activate-pieces-v1.py --dry-run                          # Count all gammes
+  python3 activate-pieces-v1.py --dry-run --gammes amortisseur     # Count specific gammes
+  python3 activate-pieces-v1.py --execute --gammes amortisseur filtre-a-huile
+  python3 activate-pieces-v1.py --execute --all                    # All gammes (USE WITH CAUTION)
+"""
+import psycopg2, time, sys, argparse, json, uuid
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+PW = get_pw()
+
+def get_conn():
+    """Direct connection port 5432 for writes."""
+    conn = psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=PW, dbname='postgres')
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("SET statement_timeout = '300s'")
+    cur.close()
+    return conn
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def get_gamme_candidates(cur, pg_alias=None):
+    """Get activation candidates grouped by gamme."""
+    if pg_alias:
+        cur.execute("""
+        SELECT pg_alias, count(*) as nb,
+          count(*) FILTER (WHERE has_image) as with_image,
+          round(avg(nb_linkages)) as avg_link
+        FROM v_tecdoc_activation_candidates
+        WHERE pg_alias = ANY(%s)
+        GROUP BY pg_alias ORDER BY nb DESC
+        """, (pg_alias,))
+    else:
+        cur.execute("""
+        SELECT pg_alias, count(*) as nb,
+          count(*) FILTER (WHERE has_image) as with_image,
+          round(avg(nb_linkages)) as avg_link
+        FROM v_tecdoc_activation_candidates
+        GROUP BY pg_alias ORDER BY nb DESC
+        """)
+    return cur.fetchall()
+
+
+def activate_gamme(cur, pg_alias, wave=1, dry_run=True):
+    """Activate all candidate pieces for a given gamme."""
+    batch_id = str(uuid.uuid4())
+
+    # Get candidate piece_ids
+    cur.execute("""
+    SELECT piece_id FROM v_tecdoc_activation_candidates
+    WHERE pg_alias = %s
+    """, (pg_alias,))
+    candidates = [r[0] for r in cur.fetchall()]
+    candidates_count = len(candidates)
+
+    if candidates_count == 0:
+        log(f"  {pg_alias}: 0 candidates, skipping")
+        return 0
+
+    if dry_run:
+        # Count by supplier
+        cur.execute("""
+        SELECT pm_name, count(*) as nb
+        FROM v_tecdoc_activation_candidates
+        WHERE pg_alias = %s
+        GROUP BY pm_name ORDER BY nb DESC LIMIT 5
+        """, (pg_alias,))
+        top_suppliers = cur.fetchall()
+        suppliers_str = ', '.join(f"{s[0]}({s[1]})" for s in top_suppliers)
+        log(f"  DRY-RUN {pg_alias}: {candidates_count} candidates — {suppliers_str}")
+        return candidates_count
+
+    # Execute activation in chunks
+    activated = 0
+    chunk_size = 1000
+    rejection_reasons = {}
+
+    for i in range(0, len(candidates), chunk_size):
+        chunk = candidates[i:i+chunk_size]
+        cur.execute("""
+        UPDATE pieces SET piece_display = true
+        WHERE piece_id = ANY(%s)
+          AND piece_display = false
+          AND piece_year = 2025
+        """, (chunk,))
+        activated += cur.rowcount
+
+    rejected = candidates_count - activated
+    if rejected > 0:
+        rejection_reasons['already_active_or_wrong_year'] = rejected
+
+    # Log to activation_log
+    cur.execute("""
+    INSERT INTO tecdoc_map.activation_log
+      (batch_id, wave, pg_alias, candidates_count, activated_count, rejected_count, rejection_reasons)
+    VALUES (%s, %s, %s, %s, %s, %s, %s)
+    """, (batch_id, wave, pg_alias, candidates_count, activated, rejected,
+          json.dumps(rejection_reasons)))
+
+    log(f"  ACTIVATED {pg_alias}: {activated}/{candidates_count} (rejected: {rejected})")
+    return activated
+
+
+def post_activation_report(cur):
+    """Generate post-activation mini-report."""
+    cur.execute("""
+    SELECT pg_alias, candidates_count, activated_count, rejected_count, rejection_reasons
+    FROM tecdoc_map.activation_log
+    WHERE wave = 1
+    ORDER BY created_at DESC
+    LIMIT 20
+    """)
+    rows = cur.fetchall()
+    if not rows:
+        log("  No activation records found")
+        return
+
+    total_candidates = sum(r[1] for r in rows)
+    total_activated = sum(r[2] for r in rows)
+    total_rejected = sum(r[3] for r in rows)
+
+    log(f"\n=== POST-ACTIVATION REPORT (Vague 1) ===")
+    log(f"  Gammes: {len(rows)}")
+    log(f"  Candidates: {total_candidates}")
+    log(f"  Activated: {total_activated}")
+    log(f"  Rejected: {total_rejected}")
+    log(f"  Success rate: {total_activated/total_candidates*100:.1f}%" if total_candidates > 0 else "  N/A")
+
+    for pg, cand, act, rej, reasons in rows:
+        status = '✅' if rej == 0 else f'⚠️ {rej} rejected'
+        log(f"    {pg}: {act}/{cand} {status}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Activate pieces Vague 1')
+    parser.add_argument('--dry-run', action='store_true', help='Count only, no writes')
+    parser.add_argument('--execute', action='store_true', help='Activate pieces')
+    parser.add_argument('--gammes', nargs='+', help='Specific gammes to activate')
+    parser.add_argument('--all', action='store_true', help='All gammes (use with caution)')
+    parser.add_argument('--analyze', action='store_true', help='Run ANALYZE + refresh after activation')
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.execute:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.execute and not args.gammes and not args.all:
+        log("ERROR: --execute requires --gammes or --all")
+        sys.exit(1)
+
+    conn = get_conn()
+    cur = conn.cursor()
+
+    log("=== Activate Pieces Vague 1 ===")
+    log(f"  Mode: {'DRY-RUN' if args.dry_run else 'EXECUTE'}")
+
+    # Get candidates
+    gamme_filter = args.gammes if args.gammes else None
+    gammes = get_gamme_candidates(cur, gamme_filter)
+
+    log(f"  Gammes: {len(gammes)}, Total candidates: {sum(g[1] for g in gammes)}")
+    log("")
+
+    if args.dry_run:
+        for pg_alias, nb, with_img, avg_link in gammes:
+            img_pct = f"{with_img/nb*100:.0f}%" if nb > 0 else "0%"
+            log(f"  {pg_alias}: {nb} pieces, {img_pct} with image, avg {avg_link} linkages")
+        log(f"\n  TOTAL: {sum(g[1] for g in gammes)} candidates across {len(gammes)} gammes")
+        cur.close()
+        conn.close()
+        return
+
+    # Execute activation
+    total_activated = 0
+    for pg_alias, nb, with_img, avg_link in gammes:
+        activated = activate_gamme(cur, pg_alias, wave=1, dry_run=False)
+        total_activated += activated
+
+    log(f"\n  TOTAL ACTIVATED: {total_activated}")
+
+    # Post-activation report
+    post_activation_report(cur)
+
+    # Optional ANALYZE + refresh
+    if args.analyze:
+        log("\n--- Post-activation: ANALYZE + refresh ---")
+        cur.execute("ANALYZE pieces")
+        log("  ANALYZE pieces ✓")
+        cur.execute("SELECT refresh_gamme_aggregates(NULL)")
+        log("  refresh_gamme_aggregates ✓")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/create-vehicles-p4a.py
+++ b/scripts/tecdoc-pipeline/create-vehicles-p4a.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+P4a — Create missing auto_modele + auto_type for active constructeurs, post-2010.
+V2 — Conventions massdoc verifiees en DB (2026-03-23).
+
+Conventions massdoc:
+  modele_id = KMODNR TecDoc directement (PAS marque*1000+seq)
+  type_id   = KTYPNR TecDoc directement
+  modele_name     = t012 FR brut, tronque a 40 chars
+  modele_name_url = regex nettoyage codes chassis (...), tronque a 40 chars
+  modele_alias    = slugify(name_url), tronque a 40 chars
+  modele_ful_name = MARQUE_NAME + " " + modele_name, tronque a 255 chars
+  type_name       = t012 FR brut
+  type_name_url   = copie de type_name (reecriture editoriale manuelle ulterieurement)
+  type_name_meta  = copie de type_name
+  type_alias      = slugify(type_name_url)
+  type_liter      = col13 directement (deja en centilitres dans t120)
+  type_power_ps   = CH direct (t120.col10)
+  type_power_kw   = kW direct (t120.col9)
+  display = 0 partout (validation manuelle avant activation)
+
+Gates:
+  - ON CONFLICT DO NOTHING sur tous les INSERT
+  - JAMAIS toucher aux URLs/alias existants
+  - display = 0, relfollow = 0, sitemap = 0
+
+Usage:
+  python3 create-vehicles-p4a.py --dry-run    # Audit + rapport
+  python3 create-vehicles-p4a.py --execute    # Creer les vehicules
+"""
+import psycopg2, time, sys, argparse, re, unicodedata
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+PW = get_pw()
+
+def get_conn(timeout=600000):
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com', port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq', password=PW, dbname='postgres',
+        options=f'-c statement_timeout={timeout}')
+    conn.autocommit = True
+    return conn
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    print(f"[{ts}] {msg}", flush=True)
+
+
+# ============ Slugify ============
+
+def slugify(text):
+    """Slugify massdoc: lowercase, accents->ascii, espaces/points/slashs -> tirets, max 40 chars."""
+    if not text:
+        return ''
+    # Normalize unicode (e -> e, etc.)
+    text = unicodedata.normalize('NFKD', text).encode('ascii', 'ignore').decode('ascii')
+    text = text.lower().strip()
+    # Replace . / spaces with -
+    text = re.sub(r'[\s./]+', '-', text)
+    # Remove anything not alphanumeric or -
+    text = re.sub(r'[^a-z0-9-]', '', text)
+    # Collapse multiple -
+    text = re.sub(r'-+', '-', text).strip('-')
+    return text[:40]
+
+
+def clean_modele_name_url(name):
+    """Remove chassis codes in parentheses: (E90), (8VA, 8VF), (B904), etc."""
+    if not name:
+        return ''
+    # Remove (...) containing uppercase letters/numbers/commas/spaces
+    cleaned = re.sub(r'\s*\([A-Z0-9,_ ./-]+\)\s*', ' ', name).strip()
+    # Remove trailing body qualifiers that are sometimes stripped in massdoc
+    # Keep as-is for now — manual review will handle edge cases
+    return cleaned[:40]
+
+
+# ============ Fuel mapping ============
+
+FUEL_MAP = {
+    '1': ('Essence', 'Essence'),
+    '2': ('Diesel', 'Diesel'),
+    '3': ('GPL/GNV', 'GPL/GNV'),
+    '4': ('Essence', 'Essence'),
+    '5': ('Diesel', 'Diesel'),
+    '6': ('Diesel', 'Diesel'),
+    '40': ('Electrique', 'Electrique'),
+    '46': ('Essence-Electrique', 'Hybride'),
+    '47': ('Essence-Electrique', 'Hybride'),
+    '48': ('Diesel-Electrique', 'Hybride'),
+    '49': ('Essence-Electrique', 'Hybride'),
+}
+
+
+# ============ Step 1: Build HERNR -> marque_id mapping ============
+
+def build_hernr_map(cur):
+    """Build HERNR->marque_id + marque_name mapping from existing data."""
+    cur.execute("""
+    SELECT DISTINCT t110.col5::int as hernr, am.marque_id, am.marque_name
+    FROM auto_type at2
+    JOIN auto_marque am ON am.marque_id = at2.type_marque_id::int AND am.marque_display = 1
+    JOIN tecdoc_raw.t120 t120 ON t120.col3 = at2.type_id
+    JOIN tecdoc_raw.t110 t110 ON t110.col3 = t120.col5
+    """)
+    hernr_map = {}
+    marque_names = {}
+    for hernr, marque_id, marque_name in cur.fetchall():
+        hernr_map[hernr] = marque_id
+        marque_names[marque_id] = marque_name
+    log(f"  HERNR->marque_id: {len(hernr_map)} mappings, {len(marque_names)} marques actives")
+    return hernr_map, marque_names
+
+
+# ============ Step 2: Build MUSTER -> body type mapping ============
+
+def build_body_map(cur):
+    """Build MUSTER->type_body from existing auto_type + t145."""
+    cur.execute("""
+    SELECT t145.muster, at2.type_body, count(*) as cnt
+    FROM tecdoc_raw.t145 t145
+    JOIN auto_type at2 ON at2.type_id = t145.ktypnr::text
+    WHERE t145.sortnr = 1
+    GROUP BY t145.muster, at2.type_body
+    ORDER BY t145.muster, count(*) DESC
+    """)
+    body_map = {}
+    for muster, body, cnt in cur.fetchall():
+        if muster not in body_map:
+            body_map[muster] = body
+    log(f"  MUSTER->body: {len(body_map)} mappings")
+    return body_map
+
+
+# ============ Step 3: Find missing modeles ============
+
+def find_missing_modeles(cur, hernr_map):
+    """Find KMODNR that are in t110 (active HERNR, post-2010 types) but not in auto_modele."""
+    cur.execute("""
+    SELECT DISTINCT t110.col3::int as kmodnr, t110.col5::int as hernr,
+      t110.col4 as lbeznr, t110.col7 as bjvon, t110.col8 as bjbis
+    FROM tecdoc_raw.t120 t120
+    JOIN tecdoc_raw.t110 t110 ON t110.col3 = t120.col5
+    WHERE t120.col30 != '1'
+      AND t120.col7::int >= 201001
+      AND t110.col5::int = ANY(%s)
+      AND NOT EXISTS (SELECT 1 FROM auto_modele am WHERE am.modele_id = t110.col3::int)
+    ORDER BY t110.col5::int, kmodnr
+    """, (list(hernr_map.keys()),))
+    rows = cur.fetchall()
+    log(f"  Missing modeles: {len(rows)}")
+    return rows
+
+
+# ============ Step 4: Resolve names from t012 in bulk ============
+
+def resolve_names_bulk(cur, lbeznr_list):
+    """Resolve LBEZNR -> French name from t012 (SPRACHNR=6)."""
+    if not lbeznr_list:
+        return {}
+    # Deduplicate
+    unique = list(set(int(x) for x in lbeznr_list if x and str(x).isdigit()))
+    if not unique:
+        return {}
+    cur.execute("""
+    SELECT lbeznr, bez FROM tecdoc_raw.t012
+    WHERE lbeznr = ANY(%s) AND sprachnr = 6
+    """, (unique,))
+    return {r[0]: r[1] for r in cur.fetchall()}
+
+
+# ============ Step 5: Create modeles ============
+
+def create_modeles(cur, hernr_map, marque_names, dry_run=True):
+    """Create missing auto_modele entries. modele_id = KMODNR."""
+    missing = find_missing_modeles(cur, hernr_map)
+    if not missing:
+        return 0
+
+    # Resolve all names in bulk
+    lbeznr_list = [r[2] for r in missing]
+    name_map = resolve_names_bulk(cur, lbeznr_list)
+
+    if dry_run:
+        log(f"  DRY-RUN: {len(missing)} modeles would be created")
+        # Show examples
+        for kmodnr, hernr, lbeznr, bjvon, bjbis in missing[:10]:
+            lb = int(lbeznr) if lbeznr and str(lbeznr).isdigit() else None
+            name = name_map.get(lb, f"Modele {kmodnr}")[:40]
+            name_url = clean_modele_name_url(name)
+            alias = slugify(name_url)
+            marque_id = hernr_map.get(hernr, '?')
+            marque_name = marque_names.get(marque_id, '?')
+            log(f"    KMODNR={kmodnr} HERNR={hernr} marque={marque_name} "
+                f"name='{name}' name_url='{name_url}' alias='{alias}'")
+        if len(missing) > 10:
+            log(f"    ... et {len(missing) - 10} de plus")
+        return len(missing)
+
+    # Execute
+    created = 0
+    skipped = 0
+    for kmodnr, hernr, lbeznr_ref, bjvon, bjbis in missing:
+        marque_id = hernr_map.get(hernr)
+        if not marque_id:
+            skipped += 1
+            continue
+
+        # Resolve name
+        lb = int(lbeznr_ref) if lbeznr_ref and str(lbeznr_ref).isdigit() else None
+        modele_name = name_map.get(lb, '')[:40]
+        if not modele_name:
+            modele_name = f"Modele {kmodnr}"[:40]
+
+        name_url = clean_modele_name_url(modele_name)
+        alias = slugify(name_url)
+        marque_name = marque_names.get(marque_id, '')
+        ful_name = f"{marque_name} {modele_name}"[:255]
+
+        # Parse dates
+        bjvon_s = str(bjvon) if bjvon else ''
+        bjbis_s = str(bjbis) if bjbis and str(bjbis) != '0' else ''
+        year_from = int(bjvon_s[:4]) if len(bjvon_s) >= 4 else 0
+        month_from = int(bjvon_s[4:6]) if len(bjvon_s) >= 6 else 0
+        year_to = int(bjbis_s[:4]) if len(bjbis_s) >= 4 else 0
+        month_to = int(bjbis_s[4:6]) if len(bjbis_s) >= 6 else 0
+
+        cur.execute("""
+        INSERT INTO auto_modele (modele_id, modele_parent, modele_marque_id, modele_mdg_id,
+          modele_alias, modele_name, modele_name_url, modele_name_meta, modele_ful_name,
+          modele_month_from, modele_year_from, modele_month_to, modele_year_to,
+          modele_body, modele_pic, modele_relfollow, modele_sitemap,
+          modele_display, modele_display_v1, modele_sort, modele_is_new)
+        VALUES (%s, 0, %s, 0, %s, %s, %s, %s, %s, %s, %s, %s, %s, '', '', 0, 0, 0, 0, 0, 1)
+        ON CONFLICT (modele_id) DO NOTHING
+        """, (kmodnr, marque_id, alias, modele_name, name_url, modele_name, ful_name,
+              month_from, year_from, month_to, year_to))
+        created += 1
+
+        if created % 200 == 0:
+            log(f"  Progress: {created} modeles created")
+
+    log(f"  Created {created} modeles, skipped {skipped}")
+    return created
+
+
+# ============ Step 6: Find missing vehicles ============
+
+def find_missing_vehicles(cur, hernr_map):
+    """Find KTYPNR in t120 (active HERNR, post-2010) not in auto_type."""
+    cur.execute("""
+    SELECT t120.col3::int as ktypnr, t120.col4 as lbeznr, t120.col5::int as kmodnr,
+      t110.col5::int as hernr,
+      t120.col7 as bjvon, t120.col8 as bjbis,
+      t120.col9 as kw, t120.col10 as ps, t120.col13 as hubraum, t120.col20 as fuel_code
+    FROM tecdoc_raw.t120 t120
+    JOIN tecdoc_raw.t110 t110 ON t110.col3 = t120.col5
+    WHERE t120.col30 != '1'
+      AND t120.col7::int >= 201001
+      AND t110.col5::int = ANY(%s)
+      AND NOT EXISTS (SELECT 1 FROM auto_type at2 WHERE at2.type_id = t120.col3)
+    ORDER BY t110.col5::int, t120.col3::int
+    """, (list(hernr_map.keys()),))
+    rows = cur.fetchall()
+    log(f"  Missing vehicles: {len(rows)}")
+    return rows
+
+
+# ============ Step 7: Create vehicles ============
+
+def create_vehicles(cur, hernr_map, marque_names, body_map, dry_run=True):
+    """Create missing auto_type entries. type_id = KTYPNR."""
+    missing = find_missing_vehicles(cur, hernr_map)
+    if not missing:
+        return 0
+
+    # Resolve names in bulk
+    lbeznr_list = [r[1] for r in missing]
+    name_map = resolve_names_bulk(cur, lbeznr_list)
+
+    # Get body types for new vehicles
+    ktypnr_list = [r[0] for r in missing]
+    cur.execute("""
+    SELECT ktypnr, muster FROM tecdoc_raw.t145
+    WHERE ktypnr = ANY(%s) AND sortnr = 1
+    """, (ktypnr_list,))
+    ktypnr_body = {r[0]: r[1] for r in cur.fetchall()}
+
+    # Check which KMODNR exist in auto_modele (after our create_modeles step)
+    kmodnr_list = list(set(r[2] for r in missing))
+    cur.execute("SELECT modele_id FROM auto_modele WHERE modele_id = ANY(%s)", (kmodnr_list,))
+    existing_modeles = {r[0] for r in cur.fetchall()}
+
+    if dry_run:
+        no_modele = sum(1 for r in missing if r[2] not in existing_modeles)
+        log(f"  DRY-RUN: {len(missing)} vehicles would be created, {no_modele} would be skipped (no modele)")
+        for row in missing[:10]:
+            ktypnr, lbeznr_ref, kmodnr, hernr, bjvon, bjbis, kw, ps, hubraum, fuel_code = row
+            lb = int(lbeznr_ref) if lbeznr_ref and str(lbeznr_ref).isdigit() else None
+            type_name = name_map.get(lb, f"Type {ktypnr}")
+            liter = str(int(hubraum)) if hubraum and str(hubraum).isdigit() and int(hubraum) > 0 else ''
+            alias = slugify(type_name)
+            fuel_label = FUEL_MAP.get(fuel_code or '', ('', ''))[0]
+            marque_id = hernr_map.get(hernr, '?')
+            has_modele = '✓' if kmodnr in existing_modeles else '✗'
+            log(f"    KTYPNR={ktypnr} KMODNR={kmodnr}({has_modele}) name='{type_name}' "
+                f"alias='{alias}' {ps}ch {liter}cl {fuel_label}")
+        if len(missing) > 10:
+            log(f"    ... et {len(missing) - 10} de plus")
+        return len(missing)
+
+    # Execute
+    created = 0
+    skipped = 0
+    batch_values = []
+
+    for ktypnr, lbeznr_ref, kmodnr, hernr, bjvon, bjbis, kw, ps, hubraum, fuel_code in missing:
+        marque_id = hernr_map.get(hernr)
+        if not marque_id or kmodnr not in existing_modeles:
+            skipped += 1
+            continue
+
+        # Resolve type_name
+        lb = int(lbeznr_ref) if lbeznr_ref and str(lbeznr_ref).isdigit() else None
+        type_name = name_map.get(lb, '')
+        if not type_name:
+            # Fallback: construct from engine data
+            cyl = f"{int(hubraum)/1000:.1f}" if hubraum and str(hubraum).isdigit() and int(hubraum) > 0 else ''
+            fuel_label = FUEL_MAP.get(fuel_code or '', ('', ''))[0]
+            type_name = f"{cyl} {fuel_label}".strip() or f"Type {ktypnr}"
+
+        # Convention massdoc: type_name_url = copie de type_name (reecriture manuelle ulterieure)
+        type_name_url = type_name
+        type_name_meta = type_name
+        alias = slugify(type_name_url)
+
+        # Parse dates
+        bjvon_s = str(bjvon) if bjvon else ''
+        bjbis_s = str(bjbis) if bjbis and str(bjbis) != '0' else ''
+        year_from = bjvon_s[:4] if len(bjvon_s) >= 4 else ''
+        month_from = str(int(bjvon_s[4:6])) if len(bjvon_s) >= 6 else ''
+        year_to = bjbis_s[:4] if len(bjbis_s) >= 4 else ''
+        month_to = str(int(bjbis_s[4:6])) if len(bjbis_s) >= 6 else ''
+
+        # Fuel
+        fuel_label, engine_label = FUEL_MAP.get(fuel_code or '', ('', ''))
+
+        # Body type via t145
+        muster = ktypnr_body.get(ktypnr, '')
+        type_body = body_map.get(muster, '')
+
+        # Convention massdoc: type_liter = cm3 / 10
+        liter = str(int(hubraum)) if hubraum and str(hubraum).isdigit() and int(hubraum) > 0 else ''
+
+        # Shadow _i columns
+        year_from_i = int(year_from) if year_from else None
+        month_from_i = int(month_from) if month_from else None
+        year_to_i = int(year_to) if year_to else None
+        month_to_i = int(month_to) if month_to else None
+
+        batch_values.append((
+            str(ktypnr), '1', alias, str(kmodnr), str(marque_id),
+            type_name, type_name_url, type_name_meta,
+            engine_label, fuel_label, ps or '', kw or '', liter,
+            month_from, year_from, month_to, year_to,
+            type_body, '0', '0', '0',
+            ktypnr, 1, kmodnr, marque_id,
+            month_from_i, year_from_i, month_to_i, year_to_i
+        ))
+
+        if len(batch_values) >= 200:
+            _insert_batch(cur, batch_values)
+            created += len(batch_values)
+            batch_values = []
+            if created % 1000 == 0:
+                log(f"  Progress: {created} created, {skipped} skipped")
+
+    if batch_values:
+        _insert_batch(cur, batch_values)
+        created += len(batch_values)
+
+    log(f"  Created {created} vehicles, skipped {skipped}")
+    return created
+
+
+def _insert_batch(cur, batch):
+    """Insert a batch of auto_type rows with parameterized query."""
+    values = []
+    for v in batch:
+        vals = []
+        for x in v:
+            if x is None or x == '':
+                vals.append('NULL')
+            elif isinstance(x, int):
+                vals.append(str(x))
+            else:
+                vals.append("'" + str(x).replace("'", "''") + "'")
+        values.append('(' + ','.join(vals) + ')')
+
+    sql = """INSERT INTO auto_type (
+      type_id, type_tmf_id, type_alias, type_modele_id, type_marque_id,
+      type_name, type_name_url, type_name_meta,
+      type_engine, type_fuel, type_power_ps, type_power_kw, type_liter,
+      type_month_from, type_year_from, type_month_to, type_year_to,
+      type_body, type_relfollow, type_display, type_sort,
+      type_id_i, type_tmf_id_i, type_modele_id_i, type_marque_id_i,
+      type_month_from_i, type_year_from_i, type_month_to_i, type_year_to_i
+    ) VALUES """ + ','.join(values) + " ON CONFLICT (type_id) DO NOTHING"
+    cur.execute(sql)
+
+
+# ============ Main ============
+
+def main():
+    parser = argparse.ArgumentParser(description='P4a — Create missing vehicles (massdoc conventions)')
+    parser.add_argument('--dry-run', action='store_true', help='Audit + rapport, no writes')
+    parser.add_argument('--execute', action='store_true', help='Create modeles + vehicles')
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.execute:
+        parser.print_help()
+        sys.exit(1)
+
+    conn = get_conn()
+    cur = conn.cursor()
+
+    log("=== P4a V2: Create missing vehicles (post-2010, active constructeurs, massdoc conventions) ===")
+    log(f"  Mode: {'DRY-RUN' if args.dry_run else 'EXECUTE'}")
+
+    # Step 1: Build mappings
+    log("\n--- Step 1: Build mappings ---")
+    hernr_map, marque_names = build_hernr_map(cur)
+    body_map = build_body_map(cur)
+
+    # Step 2: Create missing modeles (modele_id = KMODNR)
+    log("\n--- Step 2: Modeles (modele_id = KMODNR) ---")
+    modeles = create_modeles(cur, hernr_map, marque_names, dry_run=args.dry_run)
+
+    # Step 3: Create missing vehicles (type_id = KTYPNR)
+    log("\n--- Step 3: Vehicles (type_id = KTYPNR) ---")
+    vehicles = create_vehicles(cur, hernr_map, marque_names, body_map, dry_run=args.dry_run)
+
+    log(f"\n=== BILAN ===")
+    log(f"  Modeles: {modeles}")
+    log(f"  Vehicles: {vehicles}")
+    log(f"  Mode: {'DRY-RUN' if args.dry_run else 'EXECUTE'}")
+    log(f"  Conventions: modele_id=KMODNR, type_id=KTYPNR, type_liter=cm3/10, display=0")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/load-all-suppliers-v2.py
+++ b/scripts/tecdoc-pipeline/load-all-suppliers-v2.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Load ALL remaining DLNR — tables + DLNR en parallele, 8 workers total."""
+import psycopg2, subprocess, os, csv, time, sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+ARCHIVE = '/opt/automecanik/app/.github/SQL-CONVERTED.7z'
+WORKDIR = '/opt/automecanik/data/tecdoc/workdir'
+PARSER = '/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py'
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/load-all-v2.log'
+
+def get_conn():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                pw = line.strip().split('=',1)[1]
+    return psycopg2.connect(f'postgresql://postgres.cxpojprgwgubzjyqzmoq:{pw}@aws-0-eu-west-3.pooler.supabase.com:6543/postgres')
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+def load_one(table_id, dlnr):
+    dlnr_pad = str(dlnr).zfill(4)
+    filename = f"{table_id}.{dlnr_pad}.sql"
+    filepath = os.path.join(WORKDIR, filename)
+    csvpath = filepath.replace('.sql', '.csv')
+    metapath = csvpath.replace('.csv', '.meta')
+    try:
+        if not os.path.exists(filepath):
+            subprocess.run(['7z', 'e', ARCHIVE, filename, f'-o{WORKDIR}/', '-y'], capture_output=True, timeout=120)
+        if not os.path.exists(filepath):
+            return ('skip', table_id, dlnr, 0)
+        subprocess.run(['python3', PARSER, filepath, '-o', csvpath], capture_output=True, timeout=300)
+        if not os.path.exists(csvpath):
+            return ('skip', table_id, dlnr, 0)
+        with open(csvpath) as f:
+            first = next(csv.reader(f))
+            ncols = len(first)
+        c = get_conn()
+        c.autocommit = True
+        cu = c.cursor()
+        rows = 0
+        with open(csvpath) as f:
+            batch = []
+            for row in csv.reader(f):
+                batch.append([None if v in ('__PG_NULL__', '') else v for v in row])
+                if len(batch) >= 500:
+                    ph = ','.join(['%s'] * ncols)
+                    args = ','.join(cu.mogrify(f"({ph})", b).decode() for b in batch)
+                    cu.execute(f"INSERT INTO tecdoc_raw.t{table_id} VALUES {args}")
+                    rows += len(batch)
+                    batch = []
+            if batch:
+                ph = ','.join(['%s'] * ncols)
+                args = ','.join(cu.mogrify(f"({ph})", b).decode() for b in batch)
+                cu.execute(f"INSERT INTO tecdoc_raw.t{table_id} VALUES {args}")
+                rows += len(batch)
+        cu.close()
+        c.close()
+        return ('ok', table_id, dlnr, rows)
+    except Exception as e:
+        return ('error', table_id, dlnr, str(e)[:80])
+    finally:
+        for f in [filepath, csvpath, metapath]:
+            if f and os.path.exists(f):
+                try: os.remove(f)
+                except: pass
+
+def main():
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT dlnr FROM __tecdoc_supplier_mapping WHERE dlnr IS NOT NULL AND mapping_confidence = 'high' ORDER BY dlnr")
+    all_dlnr = [r[0] for r in cur.fetchall()]
+    log(f"Active DLNR: {len(all_dlnr)}")
+
+    TABLES = ['035', '042', '043', '203', '205', '206', '222', '228', '231', '232', '233']
+    
+    # Build ALL tasks (table, dlnr) across ALL tables
+    all_tasks = []
+    for t in TABLES:
+        try:
+            cur.execute(f"SELECT DISTINCT CASE WHEN dlnr ~ '^\\d+$' THEN dlnr::int ELSE NULL END FROM tecdoc_raw.t{t}")
+            loaded = set(r[0] for r in cur.fetchall() if r[0])
+        except:
+            conn.rollback()
+            loaded = set()
+        missing = [d for d in all_dlnr if d not in loaded]
+        if missing:
+            for d in missing:
+                all_tasks.append((t, d))
+            log(f"  t{t}: {len(loaded)} loaded, {len(missing)} remaining")
+        else:
+            log(f"  t{t}: all loaded ✅")
+    
+    cur.close()
+    conn.close()
+    
+    log(f"\nTotal tasks: {len(all_tasks)} (table, DLNR) pairs")
+    log(f"Running with 8 workers...\n")
+    
+    # Process ALL tasks with 8 workers in parallel
+    start = time.monotonic()
+    total_rows = 0
+    total_errors = 0
+    completed = 0
+    
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {executor.submit(load_one, t, d): (t, d) for t, d in all_tasks}
+        for future in as_completed(futures):
+            result = future.result()
+            completed += 1
+            if result[0] == 'ok':
+                total_rows += result[3]
+            elif result[0] == 'error':
+                total_errors += 1
+            
+            # Log every 100 completed
+            if completed % 100 == 0:
+                elapsed = int((time.monotonic() - start) / 60)
+                log(f"  Progress: {completed}/{len(all_tasks)} ({elapsed}min, +{total_rows:,} rows, {total_errors} errors)")
+    
+    duration = int((time.monotonic() - start) / 60)
+    log(f"\n=== DONE ===")
+    log(f"  Total tasks: {len(all_tasks)}")
+    log(f"  Completed: {completed}")
+    log(f"  Rows loaded: {total_rows:,}")
+    log(f"  Errors: {total_errors}")
+    log(f"  Duration: {duration} minutes")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/load-all-suppliers-v3.py
+++ b/scripts/tecdoc-pipeline/load-all-suppliers-v3.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Load ALL remaining DLNR for ALL supplier-sharded tables.
+v3 — complete loading: t200, t204, t207, t209, t210, t211, t212 + tables déjà partielles.
+8 workers, cleanup après chaque fichier, skip si déjà chargé.
+
+Usage:
+  python3 load-all-suppliers-v3.py                    # toutes les tables
+  python3 load-all-suppliers-v3.py --tables 200 211   # tables spécifiques
+  python3 load-all-suppliers-v3.py --workers 6        # 6 workers
+"""
+import psycopg2, subprocess, os, csv, time, sys, argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+ARCHIVE = '/opt/automecanik/app/.github/SQL-CONVERTED.7z'
+WORKDIR = '/opt/automecanik/data/tecdoc/workdir'
+PARSER = '/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py'
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/load-all-v3.log'
+ERRFILE = '/opt/automecanik/data/tecdoc/logs/load-all-v3-errors.log'
+
+# TOUTES les tables shardées par DLNR dans l'archive
+ALL_SHARDED_TABLES = [
+    '200', '201', '202', '203', '204', '205', '206', '207', '208', '209',
+    '210', '211', '212', '213', '215', '217',
+    '222', '228', '231', '232', '233',
+    '030', '035', '040', '042', '043',
+    '400', '401', '403', '404', '410', '432',
+]
+
+# Tables prioritaires pour la création de nouvelles pièces
+PRIORITY_TABLES = ['200', '211', '210', '204', '207', '209', '212']
+
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+
+PW = get_pw()
+
+
+def get_conn():
+    return psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com',
+        port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq',
+        password=PW,
+        dbname='postgres'
+    )
+
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def log_error(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    with open(ERRFILE, 'a') as f:
+        f.write(f"[{ts}] {msg}\n")
+
+
+def ensure_table_exists(table_id, sample_csv_path):
+    """Create table in tecdoc_raw if it doesn't exist, based on CSV column count."""
+    conn = get_conn()
+    conn.autocommit = True
+    cur = conn.cursor()
+
+    # Check if table exists
+    cur.execute("""SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'tecdoc_raw' AND table_name = %s""", (f't{table_id}',))
+    if cur.fetchone():
+        cur.close()
+        conn.close()
+        return True
+
+    # Table doesn't exist — create with generic columns from CSV
+    try:
+        with open(sample_csv_path) as f:
+            first_row = next(csv.reader(f))
+            ncols = len(first_row)
+
+        cols = ', '.join([f'col_{i+1} TEXT' for i in range(ncols)])
+        cur.execute(f"CREATE TABLE IF NOT EXISTS tecdoc_raw.t{table_id} ({cols})")
+        log(f"  Created tecdoc_raw.t{table_id} ({ncols} columns)")
+        cur.close()
+        conn.close()
+        return True
+    except Exception as e:
+        log_error(f"CREATE TABLE t{table_id}: {str(e)[:200]}")
+        cur.close()
+        conn.close()
+        return False
+
+
+def load_one(table_id, dlnr):
+    """Extract .sql from archive, parse to CSV, load into DB."""
+    dlnr_pad = str(dlnr).zfill(4)
+    filename = f"{table_id}.{dlnr_pad}.sql"
+    filepath = os.path.join(WORKDIR, filename)
+    csvpath = filepath.replace('.sql', '.csv')
+    metapath = csvpath.replace('.csv', '.meta')
+
+    try:
+        # Extract from archive
+        if not os.path.exists(filepath):
+            subprocess.run(
+                ['7z', 'e', ARCHIVE, filename, f'-o{WORKDIR}/', '-y'],
+                capture_output=True, timeout=120
+            )
+        if not os.path.exists(filepath):
+            return ('skip', table_id, dlnr, 0)
+
+        # Parse SQL to CSV
+        subprocess.run(
+            ['python3', PARSER, filepath, '-o', csvpath],
+            capture_output=True, timeout=300
+        )
+        if not os.path.exists(csvpath):
+            return ('skip', table_id, dlnr, 0)
+
+        # Count columns
+        with open(csvpath) as f:
+            first = next(csv.reader(f))
+            ncols = len(first)
+
+        # Ensure table exists
+        conn = get_conn()
+        conn.autocommit = True
+        cur = conn.cursor()
+
+        # Check table exists
+        cur.execute("""SELECT count(*) FROM information_schema.tables
+            WHERE table_schema = 'tecdoc_raw' AND table_name = %s""", (f't{table_id}',))
+        if cur.fetchone()[0] == 0:
+            # Create table with correct column count
+            cols = ', '.join([f'col_{i+1} TEXT' for i in range(ncols)])
+            cur.execute(f"CREATE TABLE IF NOT EXISTS tecdoc_raw.t{table_id} ({cols})")
+            log(f"  Auto-created tecdoc_raw.t{table_id} ({ncols} cols)")
+
+        # Load data in batches of 500
+        rows = 0
+        with open(csvpath) as f:
+            batch = []
+            for row in csv.reader(f):
+                vals = [None if v in ('__PG_NULL__', '') else v for v in row]
+                # Pad or truncate to match expected columns
+                if len(vals) < ncols:
+                    vals.extend([None] * (ncols - len(vals)))
+                elif len(vals) > ncols:
+                    vals = vals[:ncols]
+                batch.append(vals)
+                if len(batch) >= 500:
+                    ph = ','.join(['%s'] * ncols)
+                    args = ','.join(cur.mogrify(f"({ph})", b).decode() for b in batch)
+                    cur.execute(f"INSERT INTO tecdoc_raw.t{table_id} VALUES {args}")
+                    rows += len(batch)
+                    batch = []
+            if batch:
+                ph = ','.join(['%s'] * ncols)
+                args = ','.join(cur.mogrify(f"({ph})", b).decode() for b in batch)
+                cur.execute(f"INSERT INTO tecdoc_raw.t{table_id} VALUES {args}")
+                rows += len(batch)
+
+        cur.close()
+        conn.close()
+        return ('ok', table_id, dlnr, rows)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        log_error(f"t{table_id} DLNR={dlnr}: {err}")
+        return ('error', table_id, dlnr, err)
+    finally:
+        for f in [filepath, csvpath, metapath]:
+            if f and os.path.exists(f):
+                try:
+                    os.remove(f)
+                except:
+                    pass
+
+
+def get_loaded_dlnrs(table_id):
+    """Get set of already loaded DLNR for a table."""
+    conn = get_conn()
+    cur = conn.cursor()
+    try:
+        # Try to find dlnr column
+        cur.execute("""SELECT column_name FROM information_schema.columns
+            WHERE table_schema = 'tecdoc_raw' AND table_name = %s AND column_name = 'dlnr'""",
+            (f't{table_id}',))
+        if cur.fetchone():
+            cur.execute(f"SELECT DISTINCT CASE WHEN dlnr ~ '^\\d+$' THEN dlnr::int ELSE NULL END FROM tecdoc_raw.t{table_id}")
+            result = set(r[0] for r in cur.fetchall() if r[0] is not None)
+        else:
+            # Check generic column names — dlnr is usually col_2 for most tables
+            # For t200: col_2 is dlnr
+            cur.execute(f"SELECT DISTINCT CASE WHEN col_2 ~ '^\\d+$' THEN col_2::int ELSE NULL END FROM tecdoc_raw.t{table_id}")
+            result = set(r[0] for r in cur.fetchall() if r[0] is not None)
+    except Exception:
+        conn.rollback()
+        result = set()
+    cur.close()
+    conn.close()
+    return result
+
+
+def get_archive_dlnrs(table_id):
+    """Get list of DLNR files available in archive for a table."""
+    result = subprocess.run(
+        ['7z', 'l', ARCHIVE],
+        capture_output=True, text=True, timeout=60
+    )
+    dlnrs = []
+    for line in result.stdout.split('\n'):
+        if f'{table_id}.' in line and '.sql' in line:
+            fname = line.strip().split()[-1] if line.strip() else ''
+            parts = fname.replace('.sql', '').split('.')
+            if len(parts) == 2:
+                try:
+                    dlnrs.append(int(parts[1]))
+                except ValueError:
+                    pass
+    return sorted(set(dlnrs))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='TecDoc Loader v3 — Complete')
+    parser.add_argument('--tables', nargs='+', default=None, help='Specific tables to load (e.g., 200 211)')
+    parser.add_argument('--workers', type=int, default=8, help='Parallel workers (default: 8)')
+    parser.add_argument('--priority-only', action='store_true', help='Load only priority tables (t200, t211, t210, t204, t207, t209, t212)')
+    args = parser.parse_args()
+
+    if args.tables:
+        tables = args.tables
+    elif args.priority_only:
+        tables = PRIORITY_TABLES
+    else:
+        tables = ALL_SHARDED_TABLES
+
+    log(f"=== TecDoc Loader v3 — {len(tables)} tables, {args.workers} workers ===")
+
+    # Get active suppliers
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT dlnr FROM __tecdoc_supplier_mapping WHERE dlnr IS NOT NULL ORDER BY dlnr")
+    active_dlnrs = set(r[0] for r in cur.fetchall())
+    cur.close()
+    conn.close()
+    log(f"  Active suppliers: {len(active_dlnrs)}")
+
+    # Build task list
+    all_tasks = []
+    for t in tables:
+        archive_dlnrs = get_archive_dlnrs(t)
+
+        # Check table existence
+        conn = get_conn()
+        cur = conn.cursor()
+        cur.execute("""SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'tecdoc_raw' AND table_name = %s""", (f't{t}',))
+        table_exists = cur.fetchone() is not None
+        cur.close()
+        conn.close()
+
+        if table_exists:
+            loaded = get_loaded_dlnrs(t)
+        else:
+            loaded = set()
+
+        # Only load active suppliers that are in archive but not yet loaded
+        to_load = [d for d in archive_dlnrs if d in active_dlnrs and d not in loaded]
+
+        if to_load:
+            all_tasks.extend([(t, d) for d in to_load])
+            log(f"  t{t}: {len(loaded)} loaded, {len(to_load)} to load (archive has {len(archive_dlnrs)})")
+        else:
+            log(f"  t{t}: complete ✅ ({len(loaded)} loaded)")
+
+    if not all_tasks:
+        log("Nothing to load — all tables complete!")
+        return
+
+    log(f"\n  Total tasks: {len(all_tasks)} (table, DLNR) pairs")
+    log(f"  Running with {args.workers} workers...\n")
+
+    start = time.monotonic()
+    total_rows = 0
+    total_errors = 0
+    total_skips = 0
+    completed = 0
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {executor.submit(load_one, t, d): (t, d) for t, d in all_tasks}
+        for future in as_completed(futures):
+            result = future.result()
+            completed += 1
+            if result[0] == 'ok':
+                total_rows += result[3]
+                if result[3] > 10000:
+                    log(f"  t{result[1]} DLNR={result[2]}: +{result[3]:,}")
+            elif result[0] == 'error':
+                total_errors += 1
+            elif result[0] == 'skip':
+                total_skips += 1
+
+            if completed % 100 == 0:
+                elapsed = int((time.monotonic() - start) / 60)
+                log(f"  Progress: {completed}/{len(all_tasks)} ({elapsed}min, +{total_rows:,} rows, {total_errors} err, {total_skips} skip)")
+
+    duration = int((time.monotonic() - start) / 60)
+    log(f"\n=== DONE ===")
+    log(f"  Total tasks: {len(all_tasks)}")
+    log(f"  Completed: {completed}")
+    log(f"  Rows loaded: {total_rows:,}")
+    log(f"  Errors: {total_errors}")
+    log(f"  Skips: {total_skips}")
+    log(f"  Duration: {duration} minutes")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/load-all-suppliers.py
+++ b/scripts/tecdoc-pipeline/load-all-suppliers.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Standalone script to load ALL remaining DLNR for all supplier-sharded tables."""
+import psycopg2, subprocess, os, csv, time, sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+ARCHIVE = '/opt/automecanik/app/.github/SQL-CONVERTED.7z'
+WORKDIR = '/opt/automecanik/data/tecdoc/workdir'
+PARSER = '/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py'
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/load-all-suppliers.log'
+
+def get_conn():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                pw = line.strip().split('=',1)[1]
+    return psycopg2.connect(f'postgresql://postgres.cxpojprgwgubzjyqzmoq:{pw}@aws-0-eu-west-3.pooler.supabase.com:6543/postgres')
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+def load_one(table_id, dlnr):
+    dlnr_pad = str(dlnr).zfill(4)
+    filename = f"{table_id}.{dlnr_pad}.sql"
+    filepath = os.path.join(WORKDIR, filename)
+    csvpath = filepath.replace('.sql', '.csv')
+    try:
+        if not os.path.exists(filepath):
+            subprocess.run(['7z', 'e', ARCHIVE, filename, f'-o{WORKDIR}/', '-y'], capture_output=True, timeout=120)
+        if not os.path.exists(filepath):
+            return ('skip', table_id, dlnr, 0)
+        subprocess.run(['python3', PARSER, filepath, '-o', csvpath], capture_output=True, timeout=300)
+        if not os.path.exists(csvpath):
+            return ('skip', table_id, dlnr, 0)
+        with open(csvpath) as f:
+            first = next(csv.reader(f))
+            ncols = len(first)
+        c = get_conn()
+        c.autocommit = True
+        cu = c.cursor()
+        rows = 0
+        with open(csvpath) as f:
+            reader = csv.reader(f)
+            batch = []
+            for row in reader:
+                vals = [None if v in ('__PG_NULL__', '') else v for v in row]
+                batch.append(vals)
+                if len(batch) >= 500:
+                    ph = ','.join(['%s'] * ncols)
+                    args = ','.join(cu.mogrify(f"({ph})", b).decode() for b in batch)
+                    cu.execute(f"INSERT INTO tecdoc_raw.t{table_id} VALUES {args}")
+                    rows += len(batch)
+                    batch = []
+            if batch:
+                ph = ','.join(['%s'] * ncols)
+                args = ','.join(cu.mogrify(f"({ph})", b).decode() for b in batch)
+                cu.execute(f"INSERT INTO tecdoc_raw.t{table_id} VALUES {args}")
+                rows += len(batch)
+        cu.close()
+        c.close()
+        return ('ok', table_id, dlnr, rows)
+    except Exception as e:
+        return ('error', table_id, dlnr, str(e)[:80])
+    finally:
+        for f in [filepath, csvpath]:
+            if f and os.path.exists(f):
+                os.remove(f)
+        meta = csvpath.replace('.csv', '.meta') if csvpath else None
+        if meta and os.path.exists(meta):
+            os.remove(meta)
+
+def main():
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT dlnr FROM __tecdoc_supplier_mapping WHERE dlnr IS NOT NULL AND mapping_confidence = 'high' ORDER BY dlnr")
+    all_dlnr = [r[0] for r in cur.fetchall()]
+    log(f"Active DLNR: {len(all_dlnr)}")
+
+    TABLES = ['035', '042', '043', '203', '205', '206', '222', '228', '231', '232', '233']
+    todo = {}
+    for t in TABLES:
+        try:
+            cur.execute(f"SELECT DISTINCT CASE WHEN dlnr ~ '^\\d+$' THEN dlnr::int ELSE NULL END FROM tecdoc_raw.t{t}")
+            loaded = set(r[0] for r in cur.fetchall() if r[0])
+        except:
+            conn.rollback()
+            loaded = set()
+        missing = [d for d in all_dlnr if d not in loaded]
+        if missing:
+            todo[t] = missing
+            log(f"  t{t}: {len(loaded)} loaded, {len(missing)} remaining")
+        else:
+            log(f"  t{t}: all loaded ✅")
+    cur.close()
+    conn.close()
+
+    grand_total = 0
+    for table_id, missing in todo.items():
+        start = time.monotonic()
+        table_total = 0
+        errors = 0
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = {executor.submit(load_one, table_id, dlnr): dlnr for dlnr in missing}
+            for future in as_completed(futures):
+                result = future.result()
+                if result[0] == 'ok':
+                    table_total += result[3]
+                elif result[0] == 'error':
+                    errors += 1
+        duration = int((time.monotonic() - start) * 1000)
+        grand_total += table_total
+        log(f"  t{table_id}: +{table_total:,} rows, {errors} errors ({duration}ms)")
+
+    log(f"\nGrand total: {grand_total:,}")
+    log("Done.")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/load-t400-active.py
+++ b/scripts/tecdoc-pipeline/load-t400-active.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Load t400 linkages ONLY for active DLNR (pm_display='1').
+Streaming + chunks + workers. Skip already loaded.
+
+Usage:
+  python3 load-t400-active.py --workers 6
+  python3 load-t400-active.py --workers 4 --dry-run
+"""
+import psycopg2, subprocess, os, csv, time, sys, argparse, io, tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+ARCHIVE = '/opt/automecanik/app/.github/SQL-CONVERTED.7z'
+WORKDIR = '/opt/automecanik/data/tecdoc/workdir'
+PARSER = '/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py'
+CHUNK_SIZE = 50000  # rows per COPY batch
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+PW = get_pw()
+
+def get_conn_direct(timeout=600):
+    """Direct connection (not pooler) for COPY."""
+    conn = psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=PW, dbname='postgres',
+        options=f'-c statement_timeout={timeout}s')
+    conn.autocommit = True
+    return conn
+
+def get_conn_pooler(timeout=300):
+    """Pooler connection for queries."""
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com', port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq', password=PW, dbname='postgres',
+        options=f'-c statement_timeout={timeout}s')
+    conn.autocommit = True
+    return conn
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def get_active_dlnrs():
+    """Get list of active DLNR from DB."""
+    conn = get_conn_pooler()
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT sm.dlnr FROM __tecdoc_supplier_mapping sm
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    ORDER BY sm.dlnr
+    """)
+    dlnrs = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return dlnrs
+
+
+def get_loaded_dlnrs():
+    """Get DLNR already loaded in t400 (direct connection, table is large)."""
+    conn = get_conn_direct(timeout=600)
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT col_2::int FROM tecdoc_raw.t400")
+    loaded = {r[0] for r in cur.fetchall()}
+    cur.close()
+    conn.close()
+    return loaded
+
+
+def list_archive_files(table='400'):
+    """List files matching table in archive."""
+    result = subprocess.run(
+        ['7z', 'l', ARCHIVE],
+        capture_output=True, text=True, timeout=60
+    )
+    files = []
+    for line in result.stdout.split('\n'):
+        line = line.strip()
+        if f'{table}.' in line and line.endswith('.sql'):
+            parts = line.split()
+            fname = parts[-1]
+            # Extract DLNR: 400.XXXX.sql -> XXXX
+            try:
+                dlnr = int(fname.replace(f'{table}.', '').replace('.sql', ''))
+                files.append((dlnr, fname))
+            except ValueError:
+                pass
+    return files
+
+
+def extract_file(fname):
+    """Extract a single file from 7z archive."""
+    os.makedirs(WORKDIR, exist_ok=True)
+    subprocess.run(
+        ['7z', 'e', '-y', f'-o{WORKDIR}', ARCHIVE, fname],
+        capture_output=True, timeout=120
+    )
+    return os.path.join(WORKDIR, fname)
+
+
+def parse_mysql_to_csv(sql_file):
+    """Parse MySQL INSERT to CSV using parser script."""
+    csv_file = sql_file.replace('.sql', '.csv')
+    result = subprocess.run(
+        ['python3', PARSER, sql_file, '-o', csv_file],
+        capture_output=True, text=True, timeout=600
+    )
+    if result.returncode != 0:
+        log(f"  Parser error: {result.stderr[:200]}")
+    return csv_file
+
+
+T400_COLUMNS = [
+    'col_1', 'col_2', 'col_3', 'col_4', 'col_5', 'col_6', 'col_7', 'col_8',
+    '_source_filename', '_batch_id', '_loaded_at', '_source_row_no', '_raw_hash'
+]
+
+def load_csv_streaming(csv_file, dlnr):
+    """Load CSV into t400 using streaming COPY with chunks."""
+    if not os.path.exists(csv_file):
+        return 0
+
+    conn = get_conn_direct(timeout=600)
+    cur = conn.cursor()
+    cur.execute('SET search_path TO tecdoc_raw, public')
+    total = 0
+
+    try:
+        with open(csv_file, 'r') as f:
+            reader = csv.reader(f)
+            chunk = []
+
+            for row in reader:
+                if len(row) >= 8:
+                    # Pad to 13 columns if needed (some rows may miss meta cols)
+                    while len(row) < 13:
+                        row.append('')
+                    # Replace empty strings with \N for COPY NULL handling
+                    tsv_row = '\t'.join(v if v else '\\N' for v in row[:13])
+                    chunk.append(tsv_row)
+
+                if len(chunk) >= CHUNK_SIZE:
+                    total += _copy_chunk(cur, chunk)
+                    chunk = []
+
+            if chunk:
+                total += _copy_chunk(cur, chunk)
+
+    except Exception as e:
+        log(f"  ERROR DLNR={dlnr}: {e}")
+    finally:
+        cur.close()
+        conn.close()
+
+    return total
+
+
+def _copy_chunk(cur, rows):
+    """COPY a chunk of rows into t400."""
+    buf = io.StringIO('\n'.join(rows) + '\n')
+    cur.copy_from(buf, 't400', sep='\t', columns=T400_COLUMNS, null='\\N')
+    return len(rows)
+
+
+def process_dlnr(dlnr, fname, dry_run=False):
+    """Process one DLNR: extract → parse → load → cleanup."""
+    t0 = time.time()
+
+    if dry_run:
+        log(f"  DRY-RUN DLNR={dlnr}: {fname}")
+        return dlnr, 0
+
+    try:
+        # Extract
+        sql_path = extract_file(fname)
+        if not os.path.exists(sql_path):
+            log(f"  SKIP DLNR={dlnr}: file not found after extract")
+            return dlnr, 0
+
+        # Parse
+        csv_path = parse_mysql_to_csv(sql_path)
+        if not os.path.exists(csv_path):
+            log(f"  SKIP DLNR={dlnr}: CSV parse failed")
+            return dlnr, 0
+
+        # Load streaming
+        count = load_csv_streaming(csv_path, dlnr)
+
+        # Cleanup
+        for f in [sql_path, csv_path]:
+            if os.path.exists(f):
+                os.remove(f)
+
+        elapsed = time.time() - t0
+        log(f"  DLNR={dlnr}: +{count:,} rows ({elapsed:.0f}s)")
+        return dlnr, count
+
+    except Exception as e:
+        log(f"  ERROR DLNR={dlnr}: {e}")
+        return dlnr, 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Load t400 for active DLNR only')
+    parser.add_argument('--workers', type=int, default=4, help='Parallel workers')
+    parser.add_argument('--dry-run', action='store_true', help='List what would be loaded')
+    args = parser.parse_args()
+
+    log("=== Load t400 linkages — Active DLNR only ===")
+
+    # Step 1: Get active DLNR
+    active = set(get_active_dlnrs())
+    log(f"  Active DLNR: {len(active)}")
+
+    # Step 2: Get already loaded
+    loaded = get_loaded_dlnrs()
+    log(f"  Already loaded in t400: {len(loaded)}")
+
+    # Step 3: List archive files
+    archive_files = list_archive_files('400')
+    log(f"  Files in archive: {len(archive_files)}")
+
+    # Step 4: Filter to active + missing
+    to_load = [(dlnr, fname) for dlnr, fname in archive_files
+               if dlnr in active and dlnr not in loaded]
+    log(f"  To load (active & missing): {len(to_load)}")
+
+    if not to_load:
+        log("  Nothing to load!")
+        return
+
+    if args.dry_run:
+        for dlnr, fname in to_load:
+            log(f"  WOULD LOAD: DLNR={dlnr} ({fname})")
+        return
+
+    # Step 5: Process with workers
+    log(f"  Starting {args.workers} workers...")
+    total_rows = 0
+    completed = 0
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {executor.submit(process_dlnr, dlnr, fname): dlnr
+                   for dlnr, fname in to_load}
+
+        for future in as_completed(futures):
+            dlnr, count = future.result()
+            total_rows += count
+            completed += 1
+            if completed % 10 == 0:
+                log(f"  Progress: {completed}/{len(to_load)} DLNR, {total_rows:,} rows total")
+
+    log(f"\n=== DONE: {completed} DLNR loaded, {total_rows:,} rows total ===")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/load-vehicle-tables.py
+++ b/scripts/tecdoc-pipeline/load-vehicle-tables.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Load t012, t140, t143, t144, t145, t146, t147 from CSV into tecdoc_raw.
+CSV format from tecdoc-mysql-to-csv.py output."""
+import csv, psycopg2, time, sys, os
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+PW = get_pw()
+EXTRACT = '/opt/automecanik/data/tecdoc/extract'
+BATCH_SIZE = 500
+
+def get_conn():
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com', port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq', password=PW, dbname='postgres',
+        options='-c statement_timeout=300000')
+    conn.autocommit = True
+    return conn
+
+# Table configs: db_columns, csv_column_indices, csv_file
+# CSV column indices based on verified tecdoc-mysql-to-csv.py output
+TABLES = {
+    't012': {
+        'db_cols': ['lbeznr', 'lkz', 'sprachnr', 'bez'],
+        # CSV: RESERVIERT(0), DLNR(1), SA(2), LBEZNR(3), LKZ(4), SPRACHNR(5), BEZ(6), _src(7), _batch(8), _loaded(9), _row(10), _hash(11)
+        'csv_idx': [3, 4, 5, 6],
+        'csv_file': f'{EXTRACT}/012.csv',
+    },
+    't140': {
+        'db_cols': ['kmodnr', 'lbeznr1', 'lbeznr2'],
+        # CSV: DLNR(0), SA(1), KMODNR(2), LBEZNR1(3), LBEZNR2(4), _src(5), ..., _row(8), _hash(9)
+        'csv_idx': [2, 3, 4],
+        'csv_file': f'{EXTRACT}/140.csv',
+    },
+    't143': {
+        'db_cols': ['kmodnr', 'lkz', 'sortnr', 'muster'],
+        # CSV: DLNR(0), SA(1), KMODNR(2), LKZ(3), SORTNR(4), MUSTER(5), _src(6), ..., _row(9), _hash(10)
+        'csv_idx': [2, 3, 4, 5],
+        'csv_file': f'{EXTRACT}/143.csv',
+    },
+    't144': {
+        'db_cols': ['ktypnr', 'lbeznr1', 'lbeznr2'],
+        # CSV: RESERVIERT(0), DLNR(1), SA(2), KTYPNR(3), LBEZNR1(4), LBEZNR2(5), _src(6), ..., _row(9), _hash(10)
+        'csv_idx': [3, 4, 5],
+        'csv_file': f'{EXTRACT}/144.csv',
+    },
+    't145': {
+        'db_cols': ['ktypnr', 'lkz', 'sortnr', 'muster'],
+        # CSV: RESERVIERT(0), DLNR(1), SA(2), KTYPNR(3), LKZ(4), SORTNR(5), MUSTER(6), _src(7), ..., _row(10), _hash(11)
+        'csv_idx': [3, 4, 5, 6],
+        'csv_file': f'{EXTRACT}/145.csv',
+    },
+    't146': {
+        'db_cols': ['sprachnr', 'lbeznr', 'muster'],
+        # CSV: DLNR(0), SA(1), SPRACHNR(2), LBEZNR(3), encoded(4), _src(5), ..., _row(8), _hash(9)
+        'csv_idx': [2, 3, 4],
+        'csv_file': f'{EXTRACT}/146.csv',
+    },
+    't147': {
+        'db_cols': ['sprachnr', 'lbeznr', 'muster'],
+        # CSV: RESERVIERT(0), DLNR(1), SA(2), SPRACHNR(3), LBEZNR(4), encoded(5), _src(6), ..., _row(9), _hash(10)
+        'csv_idx': [3, 4, 5],
+        'csv_file': f'{EXTRACT}/147.csv',
+    },
+}
+
+
+def esc(v):
+    if v is None or v == '':
+        return 'NULL'
+    return "'" + v.replace("'", "''") + "'"
+
+
+def load_table(name, cfg):
+    path = cfg['csv_file']
+    if not os.path.exists(path):
+        print(f"  SKIP {name}: {path} not found")
+        return 0
+
+    db_cols = cfg['db_cols']
+    col_list = ','.join(db_cols)
+    idx = cfg['csv_idx']
+
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(f"DELETE FROM tecdoc_raw.{name}")
+    print(f"  Cleared tecdoc_raw.{name}")
+
+    total = 0
+    errors = 0
+    batch = []
+    start = time.monotonic()
+
+    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+        reader = csv.reader(f)
+        for row_no, row in enumerate(reader, 1):
+            try:
+                vals = []
+                for i in idx:
+                    v = row[i] if i < len(row) else ''
+                    vals.append(esc(v))
+                batch.append('(' + ','.join(vals) + ')')
+
+                if len(batch) >= BATCH_SIZE:
+                    sql = f"INSERT INTO tecdoc_raw.{name} ({col_list}) VALUES {','.join(batch)}"
+                    cur.execute(sql)
+                    total += len(batch)
+                    batch = []
+                    if total % 100000 == 0:
+                        elapsed = int(time.monotonic() - start)
+                        print(f"  {name}: {total:,} rows ({elapsed}s)", flush=True)
+            except Exception as e:
+                errors += 1
+                batch = []
+                if errors <= 3:
+                    print(f"  Error row {row_no}: {str(e)[:120]}")
+
+    if batch:
+        sql = f"INSERT INTO tecdoc_raw.{name} ({col_list}) VALUES {','.join(batch)}"
+        cur.execute(sql)
+        total += len(batch)
+
+    cur.close()
+    conn.close()
+    elapsed = int(time.monotonic() - start)
+    print(f"  {name}: DONE {total:,} rows, {errors} errors ({elapsed}s)")
+    return total
+
+
+def main():
+    tables = sys.argv[1:] if len(sys.argv) > 1 else ['t140', 't143', 't144', 't145', 't146', 't147']
+    # t012 excluded by default (large, run separately)
+    print(f"Loading: {', '.join(tables)}")
+    for t in tables:
+        if t not in TABLES:
+            print(f"  Unknown: {t}")
+            continue
+        print(f"\n=== {t} ===")
+        load_table(t, TABLES[t])
+    print("\nDone.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/populate-linkages-genartnr.py
+++ b/scripts/tecdoc-pipeline/populate-linkages-genartnr.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Populate source_linkages par héritage GENARTNR.
+
+Mécanisme TecDoc : un article sans linkage direct dans t400 hérite
+les linkages d'autres articles du même fournisseur qui partagent le même GENARTNR.
+
+Exemple : VALEO 032801 (GENARTNR=106) n'a pas de t400, mais VALEO 032000
+(même GENARTNR=106) en a → 032801 hérite les véhicules compatibles.
+
+Pipeline :
+  1. Identifier les pièces year=2025, display=false, sans source_linkage
+  2. Résoudre leur GENARTNR via t211
+  3. Trouver les linkages existants dans source_linkages pour ce GENARTNR+DLNR
+  4. Créer les source_linkages manquants (ARTNR article, linkages du GENARTNR)
+  5. Projeter vers pieces_relation_type
+
+Sécurité :
+  - ON CONFLICT DO NOTHING
+  - Connexion directe port 5432
+  - Workers par DLNR
+  - Dry-run obligatoire
+
+Usage:
+  python3 populate-linkages-genartnr.py --dry-run
+  python3 populate-linkages-genartnr.py --execute --workers 6
+"""
+import psycopg2, time, sys, argparse, hashlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/populate-linkages-genartnr.log'
+
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+
+PW = get_pw()
+
+
+def get_conn(timeout_s=600):
+    """Direct connection port 5432."""
+    conn = psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=PW, dbname='postgres')
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(f"SET statement_timeout = '{timeout_s}s'")
+    cur.close()
+    return conn
+
+
+def get_conn_pooler(timeout_ms=300000):
+    """Pooler connection for light queries."""
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com', port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq', password=PW, dbname='postgres',
+        options=f'-c statement_timeout={timeout_ms}')
+    conn.autocommit = True
+    return conn
+
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def get_dlnr_with_missing_articles():
+    """Get DLNR that have articles without source_linkages."""
+    conn = get_conn(timeout_s=600)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT ar.source_dlnr, pm.pm_name, count(*) as nb
+    FROM pieces p
+    JOIN tecdoc_map.article_registry ar ON ar.piece_id = p.piece_id
+    JOIN __tecdoc_supplier_mapping sm ON sm.dlnr = ar.source_dlnr
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    WHERE p.piece_year = 2025 AND p.piece_display = false
+      AND NOT EXISTS (SELECT 1 FROM pieces_relation_type prt WHERE prt.rtp_piece_id = p.piece_id)
+      AND NOT EXISTS (
+        SELECT 1 FROM tecdoc_map.source_linkages sl
+        WHERE sl.source_artnr = ar.source_artnr AND sl.source_dlnr = ar.source_dlnr
+      )
+    GROUP BY ar.source_dlnr, pm.pm_name
+    HAVING count(*) > 0
+    ORDER BY count(*) DESC
+    """)
+    result = cur.fetchall()
+    cur.close()
+    conn.close()
+    return result
+
+
+def process_dlnr(dlnr, pm_name, dry_run=True):
+    """Process one DLNR: find missing articles, inherit linkages via GENARTNR.
+
+    Chunked approach: 3 small queries instead of 1 massive JOIN.
+    Step 1: Get missing ARTNR (light query on article_registry)
+    Step 2: Get GENARTNR for each missing ARTNR (light query on t211)
+    Step 3: For each GENARTNR, INSERT linkages one at a time (small targeted INSERT)
+    """
+    conn = get_conn(timeout_s=300)
+    cur = conn.cursor()
+    t0 = time.time()
+
+    try:
+        # Step 1: Get missing article ARTNR for this DLNR
+        cur.execute("""
+        SELECT DISTINCT ar.source_artnr
+        FROM tecdoc_map.article_registry ar
+        JOIN pieces p ON p.piece_id = ar.piece_id
+        WHERE ar.source_dlnr = %s AND p.piece_year = 2025 AND p.piece_display = false
+          AND NOT EXISTS (SELECT 1 FROM tecdoc_map.source_linkages sl
+            WHERE sl.source_artnr = ar.source_artnr AND sl.source_dlnr = %s)
+        """, (dlnr, dlnr))
+        missing_artnrs = [r[0] for r in cur.fetchall()]
+
+        if not missing_artnrs:
+            return ('ok', dlnr, pm_name, 0, 0, 0, time.time() - t0)
+
+        # Step 2: Get GENARTNR for each missing ARTNR via t211
+        ga_to_artnrs = {}
+        for i in range(0, len(missing_artnrs), 500):
+            batch = missing_artnrs[i:i+500]
+            cur.execute("""
+            SELECT artnr, genartnr::int FROM tecdoc_raw.t211
+            WHERE dlnr = %s AND artnr = ANY(%s) AND losch_flag != '1'
+            """, (str(dlnr), batch))
+            for artnr, ga in cur.fetchall():
+                if ga not in ga_to_artnrs:
+                    ga_to_artnrs[ga] = []
+                if artnr not in ga_to_artnrs[ga]:
+                    ga_to_artnrs[ga].append(artnr)
+
+        if dry_run:
+            # Count how many GENARTNR have donors in source_linkages
+            recoverable_ga = 0
+            for ga in ga_to_artnrs:
+                cur.execute("""
+                SELECT 1 FROM tecdoc_map.source_linkages
+                WHERE source_genartnr = %s AND source_dlnr = %s AND source_vknzielart = 2
+                LIMIT 1
+                """, (ga, dlnr))
+                if cur.fetchone():
+                    recoverable_ga += 1
+            recoverable_artnrs = sum(len(v) for ga, v in ga_to_artnrs.items()
+                                     if ga in [g for g in ga_to_artnrs])
+            return ('dry-run', dlnr, pm_name, len(missing_artnrs), recoverable_ga, 0, time.time() - t0)
+
+        # Step 3: For each GENARTNR, INSERT linkages for missing articles
+        total_inserted = 0
+        for ga, artnrs in ga_to_artnrs.items():
+            for artnr in artnrs:
+                try:
+                    cur.execute("""
+                    INSERT INTO tecdoc_map.source_linkages (
+                        source_artnr, source_dlnr, source_genartnr,
+                        source_vknzielart, source_vknzielnr_raw, source_vknzielnr,
+                        target_internal_id, rtp_target_kind,
+                        deduplicated, source_business_key
+                    )
+                    SELECT DISTINCT
+                        %s,
+                        sl.source_dlnr,
+                        sl.source_genartnr,
+                        sl.source_vknzielart,
+                        sl.source_vknzielnr_raw,
+                        sl.source_vknzielnr,
+                        sl.target_internal_id,
+                        sl.rtp_target_kind,
+                        true,
+                        encode(digest(concat_ws('|', %s, sl.source_dlnr::text,
+                            sl.source_vknzielart::text, sl.source_vknzielnr::text
+                        ), 'sha256'), 'hex')
+                    FROM tecdoc_map.source_linkages sl
+                    WHERE sl.source_genartnr = %s
+                      AND sl.source_dlnr = %s
+                      AND sl.source_vknzielart = 2
+                    ON CONFLICT DO NOTHING
+                    """, (artnr, artnr, ga, dlnr))
+                    total_inserted += cur.rowcount
+                except Exception:
+                    pass  # skip individual failures
+
+        return ('ok', dlnr, pm_name, len(missing_artnrs), len(ga_to_artnrs), total_inserted, time.time() - t0)
+
+    except Exception as e:
+        elapsed = time.time() - t0
+        return ('error', dlnr, pm_name, 0, 0, str(e)[:200], elapsed)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def project_new_linkages(dlnr):
+    """Project newly created source_linkages to pieces_relation_type."""
+    conn = get_conn(timeout_s=600)
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_relation_type (rtp_type_id, rtp_piece_id, rtp_pm_id,
+          rtp_pg_id, rtp_pg_pid, rtp_ga_id, rtp_psf_id, rtp_inside, rtp_target_kind)
+        SELECT DISTINCT
+            sl.source_vknzielnr,
+            ar.piece_id,
+            p.piece_pm_id,
+            p.piece_pg_id,
+            p.piece_pg_pid,
+            p.piece_ga_id,
+            0, '0', 'vehicle_type'
+        FROM tecdoc_map.source_linkages sl
+        JOIN tecdoc_map.article_registry ar
+          ON ar.source_artnr = sl.source_artnr AND ar.source_dlnr = sl.source_dlnr
+        JOIN pieces p ON p.piece_id = ar.piece_id
+          AND p.piece_year = 2025 AND p.piece_display = false
+        JOIN auto_type at2 ON at2.type_id_i = sl.source_vknzielnr
+        WHERE sl.source_dlnr = %s
+          AND sl.source_vknzielart = 2
+          AND sl.deduplicated = true  -- only inherited linkages
+          AND NOT EXISTS (
+            SELECT 1 FROM pieces_relation_type prt
+            WHERE prt.rtp_piece_id = p.piece_id AND prt.rtp_type_id = sl.source_vknzielnr
+          )
+        ON CONFLICT DO NOTHING
+        """, (dlnr,))
+        return cur.rowcount
+    except Exception as e:
+        log(f"  Projection error DLNR={dlnr}: {str(e)[:100]}")
+        return 0
+    finally:
+        cur.close()
+        conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Populate linkages by GENARTNR inheritance')
+    parser.add_argument('--dry-run', action='store_true', help='Count only')
+    parser.add_argument('--execute', action='store_true', help='Create linkages')
+    parser.add_argument('--workers', type=int, default=4, help='Parallel workers')
+    parser.add_argument('--project', action='store_true', help='Also project to pieces_relation_type')
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.execute:
+        parser.print_help()
+        sys.exit(1)
+
+    log("=== Populate linkages by GENARTNR inheritance ===")
+    log(f"  Mode: {'DRY-RUN' if args.dry_run else 'EXECUTE'}")
+
+    # Get DLNR with missing articles
+    dlnr_list = get_dlnr_with_missing_articles()
+    total_missing = sum(r[2] for r in dlnr_list)
+    log(f"  DLNR with missing articles: {len(dlnr_list)}")
+    log(f"  Total missing articles: {total_missing}")
+
+    # Process
+    t0 = time.time()
+    total_recoverable = 0
+    total_inserted = 0
+    errors = 0
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(process_dlnr, dlnr, pm_name, args.dry_run): (dlnr, pm_name, nb)
+            for dlnr, pm_name, nb in dlnr_list
+        }
+
+        completed = 0
+        for future in as_completed(futures):
+            result = future.result()
+            completed += 1
+
+            if result[0] == 'dry-run':
+                _, dlnr, pm_name, total, recoverable, _, elapsed = result
+                pct = 100 * recoverable // max(total, 1)
+                log(f"  {pm_name} (DLNR={dlnr}): {recoverable}/{total} récupérables ({pct}%) ({elapsed:.0f}s)")
+                total_recoverable += recoverable
+
+            elif result[0] == 'ok':
+                _, dlnr, pm_name, _, _, inserted, elapsed = result
+                log(f"  {pm_name} (DLNR={dlnr}): +{inserted:,} linkages ({elapsed:.0f}s)")
+                total_inserted += inserted
+
+            elif result[0] == 'error':
+                _, dlnr, pm_name, _, _, err, elapsed = result
+                log(f"  ERROR {pm_name} (DLNR={dlnr}): {err} ({elapsed:.0f}s)")
+                errors += 1
+
+            if completed % 10 == 0:
+                log(f"  Progress: {completed}/{len(dlnr_list)}")
+
+    elapsed_total = time.time() - t0
+
+    # Summary
+    log(f"\n=== BILAN ===")
+    log(f"  DLNR traités: {len(dlnr_list)}")
+    if args.dry_run:
+        log(f"  Récupérables via GENARTNR: {total_recoverable}")
+    else:
+        log(f"  Linkages insérés: {total_inserted:,}")
+    log(f"  Erreurs: {errors}")
+    log(f"  Temps: {elapsed_total:.0f}s ({elapsed_total/60:.1f}min)")
+
+    # Project to pieces_relation_type if requested
+    if args.execute and args.project and total_inserted > 0:
+        log(f"\n--- Projection vers pieces_relation_type ---")
+        total_projected = 0
+        for dlnr, pm_name, nb in dlnr_list:
+            projected = project_new_linkages(dlnr)
+            if projected > 0:
+                log(f"  {pm_name} (DLNR={dlnr}): +{projected:,} prt rows")
+                total_projected += projected
+        log(f"  Total projeté: {total_projected:,}")
+
+        # Activate newly linked pieces
+        log(f"\n--- Activation des pièces débloquées ---")
+        conn = get_conn(timeout_s=300)
+        cur = conn.cursor()
+        cur.execute("""
+        UPDATE pieces p SET piece_display = true
+        FROM pieces_marque pm, gamme_aggregates ga
+        WHERE pm.pm_id = p.piece_pm_id AND pm.pm_display = '1'
+          AND ga.ga_pg_id = p.piece_pg_id
+          AND p.piece_year = 2025 AND p.piece_display = false
+          AND EXISTS (
+            SELECT 1 FROM pieces_relation_type prt
+            JOIN auto_type at2 ON at2.type_id_i = prt.rtp_type_id AND at2.type_display = '1'
+            WHERE prt.rtp_piece_id = p.piece_id
+          )
+        """)
+        activated = cur.rowcount
+        log(f"  Pièces activées: {activated}")
+
+        cur.execute("ANALYZE pieces")
+        log(f"  ANALYZE pieces ✓")
+        try:
+            cur.execute("SELECT refresh_gamme_aggregates(NULL)")
+            log(f"  refresh_gamme_aggregates ✓")
+        except:
+            log(f"  refresh_gamme_aggregates: non-blocking error")
+
+        cur.close()
+        conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/populate-source-linkages.v2.py
+++ b/scripts/tecdoc-pipeline/populate-source-linkages.v2.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Populate source_linkages from t400 raw — v2 (2026-04-13, fix pollution).
+
+Lien : t400 → tecdoc_map.linkage_target_registry → auto_type → target_internal_id
+Filtre : DLNR actifs uniquement (pm_display='1')
+Filtre : source_vknzielart = 2 (PKW linkages) — hardcoded dans le WHERE
+Filtre : linkage_target_registry.internal_entity_type = 'vehicle_type'
+Filtre : auto_type.type_display = '1' (types actifs uniquement)
+
+Changements v2 vs frozen (2026-03-23) :
+  - AND t400.col_5 = '2' ajouté dans le WHERE (filtre PKW)
+  - target_internal_id devient ltr.internal_id (résolu via LTR), plus de cast
+    direct du KTYP brut
+  - source_vknzielart figé à 2::smallint, rtp_target_kind figé à 'vehicle_type'
+  - business_key recalculé avec '2' hardcodé (plus t400.col_5)
+  - Ajout JOIN obligatoire sur linkage_target_registry + auto_type
+  - --target-schema optionnel : écrit dans <schema>.source_linkages pour tests
+  - --dlnr-only N : ne traite qu'un seul DLNR (tests)
+
+Voir /home/deploy/.claude/plans/swirling-giggling-scott.md §5.A.2 et
+.spec/reports/session-a-audit-20260413.md pour le rationnel.
+
+Pré-requis :
+  - t400 chargée (load-all-suppliers-v3.py --tables 400)
+  - tecdoc_map.linkage_target_registry peuplée (~43k entrées vknzielart=2)
+  - auto_type peuplée
+
+Usage:
+  python3 populate-source-linkages.v2.py --dry-run
+  python3 populate-source-linkages.v2.py --execute
+  python3 populate-source-linkages.v2.py --execute --target-schema tecdoc_rebuild --dlnr-only 21
+"""
+import psycopg2, time, sys, argparse, hashlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/populate-source-linkages.log'
+
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+
+PW = get_pw()
+
+
+def get_conn(timeout=600000):
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com', port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq', password=PW, dbname='postgres',
+        options=f'-c statement_timeout={timeout}')
+    conn.autocommit = True
+    return conn
+
+
+def get_conn_direct(timeout_s=600):
+    """Direct connection (port 5432) for long-running queries."""
+    conn = psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=PW, dbname='postgres')
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(f'SET statement_timeout = \'{timeout_s}s\'')
+    cur.close()
+    return conn
+
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def create_indexes(conn):
+    """Create indexes required for the t400→t211 JOIN."""
+    cur = conn.cursor()
+
+    log("  Creating index on t400 (col_2, col_4) ...")
+    cur.execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_t400_dlnr_sa
+    ON tecdoc_raw.t400 (col_2, col_4)
+    """)
+    log("  idx_t400_dlnr_sa created ✓")
+
+    log("  Creating index on t211 (dlnr, sa) ...")
+    cur.execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_t211_dlnr_sa
+    ON tecdoc_raw.t211 (dlnr, sa)
+    """)
+    log("  idx_t211_dlnr_sa created ✓")
+
+    cur.close()
+
+
+def get_active_dlnrs(cur):
+    """Get list of active DLNR (pm_display='1')."""
+    cur.execute("""
+    SELECT DISTINCT sm.dlnr
+    FROM __tecdoc_supplier_mapping sm
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    ORDER BY sm.dlnr
+    """)
+    return [r[0] for r in cur.fetchall()]
+
+
+def get_already_loaded_dlnrs(cur):
+    """Get DLNR already in source_linkages."""
+    cur.execute("SELECT DISTINCT source_dlnr FROM tecdoc_map.source_linkages")
+    return {r[0] for r in cur.fetchall()}
+
+
+TARGET_SCHEMA = 'tecdoc_map'
+
+
+def populate_dlnr(dlnr):
+    """Populate <TARGET_SCHEMA>.source_linkages for one DLNR from t400 + LTR.
+
+    t400 mapping (verified 2026-03-23):
+      col_1 = ARTNR, col_2 = DLNR, col_3 = SA (=400),
+      col_4 = GENARTNR, col_5 = VKNZIELART, col_6 = VKNZIELNR (KTYP),
+      col_7 = LFDNR, col_8 = LOSCH_FLAG
+    """
+    conn = get_conn_direct(timeout_s=600)
+    cur = conn.cursor()
+    try:
+        cur.execute(f"""
+        INSERT INTO {TARGET_SCHEMA}.source_linkages (
+            source_artnr, source_dlnr, pg_id_source,
+            source_vknzielart, source_vknzielnr_raw, source_vknzielnr,
+            target_internal_id, rtp_target_kind,
+            deduplicated, source_business_key
+        )
+        SELECT DISTINCT
+            t400.col_1,
+            t400.col_2::int,
+            COALESCE(NULLIF(t400.col_4, '')::int, 0),
+            2::smallint,
+            lpad(t400.col_6, 9, '0'),
+            t400.col_6::int,
+            ltr.internal_id,
+            'vehicle_type',
+            false,
+            encode(digest(concat_ws('|', t400.col_1, t400.col_2, '2', t400.col_6), 'sha256'), 'hex')
+        FROM tecdoc_raw.t400 t400
+        JOIN tecdoc_map.linkage_target_registry ltr
+          ON ltr.vknzielnr = t400.col_6::int
+         AND ltr.vknzielart = 2
+         AND ltr.internal_entity_type = 'vehicle_type'
+        JOIN auto_type at
+          ON at.type_id_i = ltr.internal_id
+         AND at.type_display = '1'
+        WHERE t400.col_2 = %s
+          AND t400.col_5 = '2'
+          AND t400.col_8 != '1'
+        ON CONFLICT DO NOTHING
+        """, (str(dlnr),))
+        inserted = cur.rowcount
+        return ('ok', dlnr, inserted)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+def dry_run_dlnr(dlnr):
+    """Count how many linkages would be created for one DLNR after LTR+auto_type filter."""
+    conn = get_conn(120000)
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        SELECT count(DISTINCT (t400.col_1, t400.col_6))
+        FROM tecdoc_raw.t400 t400
+        JOIN tecdoc_map.linkage_target_registry ltr
+          ON ltr.vknzielnr = t400.col_6::int
+         AND ltr.vknzielart = 2
+         AND ltr.internal_entity_type = 'vehicle_type'
+        JOIN auto_type at
+          ON at.type_id_i = ltr.internal_id
+         AND at.type_display = '1'
+        WHERE t400.col_2 = %s
+          AND t400.col_5 = '2'
+          AND t400.col_8 != '1'
+        """, (str(dlnr),))
+        count = cur.fetchone()[0]
+        return ('ok', dlnr, count)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+def main():
+    global TARGET_SCHEMA
+    parser = argparse.ArgumentParser(description='Populate source_linkages from t400 raw (v2)')
+    parser.add_argument('--dry-run', action='store_true', help='Count only, no writes')
+    parser.add_argument('--execute', action='store_true', help='Insert into source_linkages')
+    parser.add_argument('--create-indexes', action='store_true', help='Create required indexes first')
+    parser.add_argument('--workers', type=int, default=4, help='Number of parallel workers')
+    parser.add_argument('--target-schema', type=str, default='tecdoc_map',
+                        help='Target schema for source_linkages (default tecdoc_map; use tecdoc_rebuild for sibling tests)')
+    parser.add_argument('--dlnr-only', type=int, default=None,
+                        help='Process only this DLNR (test mode, bypasses already_loaded filter)')
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.execute and not args.create_indexes:
+        parser.print_help()
+        sys.exit(1)
+
+    TARGET_SCHEMA = args.target_schema
+    log(f"=== Populate {TARGET_SCHEMA}.source_linkages from t400 raw (v2) ===")
+
+    if args.create_indexes:
+        log("\n--- Creating indexes ---")
+        conn = get_conn_direct()
+        create_indexes(conn)
+        conn.close()
+        log("  Indexes done ✓")
+        if not args.dry_run and not args.execute:
+            return
+
+    conn = get_conn()
+    cur = conn.cursor()
+
+    if args.dlnr_only is not None:
+        to_process = [args.dlnr_only]
+        log(f"  Test mode: processing only DLNR={args.dlnr_only} (bypassing already_loaded check)")
+    else:
+        active_dlnrs = get_active_dlnrs(cur)
+        already_loaded = get_already_loaded_dlnrs(cur) if TARGET_SCHEMA == 'tecdoc_map' else set()
+        to_process = [d for d in active_dlnrs if d not in already_loaded]
+        log(f"  Active DLNR: {len(active_dlnrs)}, already in {TARGET_SCHEMA}.source_linkages: {len(already_loaded)}, to process: {len(to_process)}")
+
+    cur.close()
+    conn.close()
+
+    if not to_process:
+        log("  Nothing to do!")
+        return
+
+    if args.dry_run:
+        log(f"\n--- DRY-RUN: counting linkages for {len(to_process)} DLNR ---")
+        total = 0
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            futures = {executor.submit(dry_run_dlnr, dlnr): dlnr for dlnr in to_process}
+            done = 0
+            for future in as_completed(futures):
+                result = future.result()
+                done += 1
+                if result[0] == 'ok':
+                    total += result[2]
+                    if result[2] > 0:
+                        log(f"    DLNR={result[1]}: {result[2]:,} linkages")
+                else:
+                    log(f"    DLNR={result[1]}: ERROR {result[2]}")
+                if done % 20 == 0:
+                    log(f"  Progress: {done}/{len(to_process)} ({total:,} total)")
+        log(f"\n  DRY-RUN TOTAL: {total:,} linkages for {len(to_process)} DLNR")
+        return
+
+    if args.execute:
+        log(f"\n--- EXECUTE: populating source_linkages for {len(to_process)} DLNR ---")
+        total = 0
+        errors = 0
+        start = time.monotonic()
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            futures = {executor.submit(populate_dlnr, dlnr): dlnr for dlnr in to_process}
+            done = 0
+            for future in as_completed(futures):
+                result = future.result()
+                done += 1
+                if result[0] == 'ok':
+                    total += result[2]
+                    if result[2] > 0:
+                        log(f"    DLNR={result[1]}: +{result[2]:,}")
+                else:
+                    errors += 1
+                    log(f"    DLNR={result[1]}: ERROR {result[2]}")
+                if done % 20 == 0:
+                    elapsed = int((time.monotonic() - start) / 60)
+                    log(f"  Progress: {done}/{len(to_process)} (+{total:,} total, {errors} errors, {elapsed}min)")
+
+        elapsed = int((time.monotonic() - start) / 60)
+        log(f"\n=== BILAN ===")
+        log(f"  DLNR processed: {len(to_process)}")
+        log(f"  Linkages inserted: {total:,}")
+        log(f"  Errors: {errors}")
+        log(f"  Time: {elapsed} minutes")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/project-core-v2.py
+++ b/scripts/tecdoc-pipeline/project-core-v2.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Project newly loaded TecDoc data to core tables — v2 (with proper types + error logging).
+
+Phase 1: t203 → pieces_ref_oem (requires index on t203.dlnr)
+Phase 2: t231 → graphics_registry + t232 → pieces_media_img
+Phase 3: source_linkages → pieces_relation_type
+Phase 4: ANALYZE
+
+Usage:
+  python3 project-core-v2.py --oem              # Phase 1 only
+  python3 project-core-v2.py --images           # Phase 2 only
+  python3 project-core-v2.py --linkages         # Phase 3 only
+  python3 project-core-v2.py --all              # All phases
+  python3 project-core-v2.py --all --workers 8  # 8 parallel workers
+"""
+import argparse
+import psycopg2
+import time
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/project-core-v2.log'
+ERRFILE = '/opt/automecanik/data/tecdoc/logs/project-core-v2-errors.log'
+
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('SUPABASE_DB_PASSWORD not found in .env')
+
+
+PW = get_pw()
+
+
+def get_conn(timeout_ms=300000):
+    return psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com',
+        port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq',
+        password=PW,
+        dbname='postgres',
+        options=f'-c statement_timeout={timeout_ms}'
+    )
+
+
+def get_conn_direct():
+    """Direct connection (port 5432, session mode) for long-running queries."""
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com',
+        port=5432,
+        user='postgres.cxpojprgwgubzjyqzmoq',
+        password=PW,
+        dbname='postgres'
+    )
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute('SET statement_timeout = 0')
+    cur.close()
+    return conn
+
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def log_error(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    with open(ERRFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def get_dlnrs():
+    """Get active DLNR list from supplier mapping."""
+    conn = get_conn(30000)
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT dlnr FROM __tecdoc_supplier_mapping WHERE dlnr IS NOT NULL ORDER BY dlnr")
+    result = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return result
+
+
+# ============ Phase 1: t203 → pieces_ref_oem ============
+def project_oem_chunk(dlnr):
+    conn = get_conn(300000)  # 5 min per chunk
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_ref_oem (pro_piece_id, pro_prb_id, pro_oem, pro_oem_serach)
+        SELECT DISTINCT ON (ar.piece_id, t203.khernr::text, regexp_replace(t203.refnr, '[^A-Za-z0-9]', '', 'g'))
+          ar.piece_id::text, t203.khernr::text, t203.refnr,
+          regexp_replace(t203.refnr, '[^A-Za-z0-9]', '', 'g')
+        FROM tecdoc_raw.t203 t203
+        JOIN tecdoc_map.article_registry ar
+          ON ar.source_artnr = t203.artnr AND ar.source_dlnr = t203.dlnr::int
+        WHERE ar.piece_id IS NOT NULL
+          AND t203.losch_flag != 1
+          AND t203.dlnr = %s::smallint
+        ON CONFLICT (pro_piece_id, pro_prb_id, pro_oem_serach) DO NOTHING
+        """, (dlnr,))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        log_error(f"OEM DLNR={dlnr}: {err}")
+        return ('error', dlnr, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def run_oem(workers):
+    log("=== Phase 1: t203 → pieces_ref_oem ===")
+    dlnrs = get_dlnrs()
+    log(f"  {len(dlnrs)} DLNR to project")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(project_oem_chunk, d): d for d in dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total += result[2]
+                if result[2] > 1000:
+                    log(f"  DLNR={result[1]}: +{result[2]:,}")
+            else:
+                errors += 1
+                if done <= 5:  # Log first 5 errors inline
+                    log(f"  ERROR DLNR={result[1]}: {result[2][:80]}")
+            if done % 50 == 0:
+                log(f"  Progress: {done}/{len(dlnrs)} (+{total:,} rows, {errors} errors)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  OEM DONE: +{total:,} rows, {errors} errors ({dur}s / {dur//60}min)")
+    return total
+
+
+# ============ Phase 2: t232 → pieces_media_img ============
+def update_graphics_registry():
+    """Insert new t231 entries into graphics_registry."""
+    log("  Updating graphics_registry from t231 (direct connection, no timeout)...")
+    conn = get_conn_direct()
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO tecdoc_doc.graphics_registry
+          (source_bildnr, source_dlnr, bildname, bildtype, dokumentenart, width, height, source_business_key)
+        SELECT DISTINCT ON (bildnr::int, dlnr::int)
+          bildnr::int, dlnr::int, bildname, bildtype::smallint, dokumentenart::smallint,
+          CASE WHEN breit ~ '^\\d+$' THEN breit::smallint ELSE NULL END,
+          CASE WHEN hoch ~ '^\\d+$' THEN hoch::smallint ELSE NULL END,
+          encode(digest(concat_ws('|', bildnr, dlnr), 'sha256'), 'hex')
+        FROM tecdoc_raw.t231
+        WHERE losch_flag != '1'
+        ON CONFLICT (source_bildnr, source_dlnr) DO NOTHING
+        """)
+        log(f"  Graphics registry: +{cur.rowcount:,}")
+    finally:
+        cur.close()
+        conn.close()
+
+
+def project_img_chunk(dlnr):
+    conn = get_conn(300000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_media_img
+          (pmi_piece_id, pmi_pm_id, pmi_folder, pmi_name, pmi_sort, pmi_display, pmi_piece_id_i)
+        SELECT ar.piece_id::text, %s::text, '', gr.bildname, t232.sortnr, '1', ar.piece_id
+        FROM tecdoc_raw.t232 t232
+        JOIN tecdoc_map.article_registry ar
+          ON ar.source_artnr = t232.artnr AND ar.source_dlnr = t232.dlnr::int
+        JOIN tecdoc_doc.graphics_registry gr
+          ON gr.source_bildnr = t232.bildnr::int AND gr.source_dlnr = t232.dlnr::int
+        WHERE ar.piece_id IS NOT NULL
+          AND t232.losch_flag != '1'
+          AND gr.bildname IS NOT NULL
+          AND t232.dlnr = %s
+        ON CONFLICT (pmi_piece_id, pmi_name) DO NOTHING
+        """, (str(dlnr), str(dlnr)))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        log_error(f"IMG DLNR={dlnr}: {err}")
+        return ('error', dlnr, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def run_images(workers):
+    log("\n=== Phase 2: t232 → pieces_media_img ===")
+    update_graphics_registry()
+
+    dlnrs = get_dlnrs()
+    log(f"  {len(dlnrs)} DLNR to project images")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(project_img_chunk, d): d for d in dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total += result[2]
+                if result[2] > 100:
+                    log(f"  DLNR={result[1]}: +{result[2]:,} images")
+            else:
+                errors += 1
+                if done <= 5:
+                    log(f"  ERROR DLNR={result[1]}: {result[2][:80]}")
+            if done % 50 == 0:
+                log(f"  Progress: {done}/{len(dlnrs)} (+{total:,} rows, {errors} errors)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  IMG DONE: +{total:,} rows, {errors} errors ({dur}s / {dur//60}min)")
+    return total
+
+
+# ============ Phase 3: source_linkages → pieces_relation_type ============
+def project_linkage_chunk(dlnr, prefix):
+    conn = get_conn(300000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_relation_type
+          (rtp_piece_id, rtp_type_id, rtp_target_kind, rtp_pg_id, rtp_ga_id, rtp_pm_id)
+        SELECT DISTINCT ON (ar.piece_id, sl.target_internal_id)
+          ar.piece_id, sl.target_internal_id, sl.rtp_target_kind,
+          COALESCE(pg.pg_id, 0), sl.source_genartnr, sl.source_dlnr
+        FROM tecdoc_map.source_linkages sl
+        JOIN tecdoc_map.article_registry ar
+          ON ar.source_artnr = sl.source_artnr AND ar.source_dlnr = sl.source_dlnr
+        LEFT JOIN pieces_gamme pg ON pg.pg_id = sl.source_genartnr
+        WHERE ar.piece_id IS NOT NULL
+          AND sl.source_dlnr = %s
+          AND left(sl.source_artnr, 3) = %s
+        ON CONFLICT (rtp_type_id, rtp_piece_id) DO NOTHING
+        """, (dlnr, prefix))
+        return ('ok', dlnr, prefix, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        log_error(f"LINK DLNR={dlnr} prefix={prefix}: {err}")
+        return ('error', dlnr, prefix, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def run_linkages(workers):
+    log("\n=== Phase 3: source_linkages → pieces_relation_type ===")
+    conn = get_conn(120000)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT source_dlnr, left(source_artnr, 3) as prefix, count(*)
+    FROM tecdoc_map.source_linkages
+    GROUP BY source_dlnr, left(source_artnr, 3)
+    ORDER BY count(*) ASC
+    """)
+    chunks = cur.fetchall()
+    cur.close()
+    conn.close()
+    log(f"  {len(chunks)} chunks to project")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(project_linkage_chunk, dlnr, prefix): (dlnr, prefix)
+            for dlnr, prefix, _ in chunks
+        }
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total += result[3]
+                if result[3] > 500:
+                    log(f"  DLNR={result[1]} prefix={result[2]}: +{result[3]:,}")
+            else:
+                errors += 1
+            if done % 100 == 0:
+                log(f"  Progress: {done}/{len(chunks)} (+{total:,} rows, {errors} errors)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  LINK DONE: +{total:,} rows, {errors} errors ({dur}s / {dur//60}min)")
+    return total
+
+
+def run_analyze():
+    log("\n=== Phase 4: ANALYZE ===")
+    conn = get_conn(600000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    for t in ['pieces_ref_oem', 'pieces_media_img', 'pieces_relation_type']:
+        s = time.monotonic()
+        cur.execute(f"ANALYZE {t}")
+        log(f"  ANALYZE {t} ({int((time.monotonic()-s)*1000)}ms)")
+    cur.close()
+    conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='TecDoc Core Projector v2')
+    parser.add_argument('--oem', action='store_true', help='Phase 1: t203 → pieces_ref_oem')
+    parser.add_argument('--images', action='store_true', help='Phase 2: t232 → pieces_media_img')
+    parser.add_argument('--linkages', action='store_true', help='Phase 3: linkages → pieces_relation_type')
+    parser.add_argument('--analyze', action='store_true', help='Phase 4: ANALYZE')
+    parser.add_argument('--all', action='store_true', help='All phases')
+    parser.add_argument('--workers', type=int, default=6, help='Parallel workers (default: 6)')
+    args = parser.parse_args()
+
+    if not any([args.oem, args.images, args.linkages, args.analyze, args.all]):
+        parser.print_help()
+        sys.exit(1)
+
+    results = {}
+
+    if args.all or args.oem:
+        results['oem'] = run_oem(args.workers)
+
+    if args.all or args.images:
+        results['images'] = run_images(args.workers)
+
+    if args.all or args.linkages:
+        results['linkages'] = run_linkages(args.workers)
+
+    if args.all or args.analyze:
+        run_analyze()
+
+    log("\n=== BILAN FINAL ===")
+    for k, v in results.items():
+        log(f"  {k}: +{v:,}")
+    log("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/project-enrichment.py
+++ b/scripts/tecdoc-pipeline/project-enrichment.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""
+Projection sélective — enrichir UNIQUEMENT le périmètre catalogue établi.
+
+Doctrine : on n'injecte pas tout TecDoc, on enrichit seulement :
+  - fournisseurs actifs (v_projection_scope_suppliers)
+  - pièces déjà créées (v_projection_scope_pieces)
+  - véhicules/linkages déjà établis (v_projection_scope_linkages)
+
+Phases :
+  P1: t203 → pieces_ref_oem (refs OEM/constructeur)
+  P2: t207/t209 → pieces_ref_search (refs recherche)
+  P3: t232 → pieces_media_img (images)
+  P4: t210 → pieces_criteria (critères techniques)
+  P5: t410 → pieces_relation_criteria (critères par linkage véhicule)
+
+Usage:
+  python3 project-enrichment.py --dry-run                    # Compter tout
+  python3 project-enrichment.py --oem --workers 6            # P1 seulement
+  python3 project-enrichment.py --refs --workers 6           # P2 seulement
+  python3 project-enrichment.py --images --workers 6         # P3 seulement
+  python3 project-enrichment.py --criteria --workers 6       # P4 seulement
+  python3 project-enrichment.py --all --workers 6            # Tout
+"""
+import psycopg2, time, sys, argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/project-enrichment.log'
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+PW = get_pw()
+
+def get_conn(timeout_s=300):
+    """Direct connection port 5432."""
+    conn = psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=PW, dbname='postgres')
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(f"SET statement_timeout = '{timeout_s}s'")
+    cur.close()
+    return conn
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+def get_active_dlnrs():
+    conn = get_conn(60)
+    cur = conn.cursor()
+    cur.execute("SELECT dlnr FROM tecdoc_map.v_projection_scope_suppliers ORDER BY dlnr")
+    result = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return result
+
+
+def get_image_projection_dlnrs():
+    """
+    DLNR needed for canonical image projection : tous les DLNR qui ont des
+    pieces actives mappees via article_registry + supplier_registry.
+
+    Plus large que v_projection_scope_suppliers (qui est trop etroit et couvre
+    seulement ~76K pieces au lieu des ~417K actives mappees en article_registry).
+    """
+    conn = get_conn(60)
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT DISTINCT sr.source_dlnr
+        FROM pieces p
+        JOIN tecdoc_map.article_registry ar ON ar.piece_id = p.piece_id
+        JOIN tecdoc_map.supplier_registry sr
+          ON sr.source_dlnr = ar.source_dlnr
+         AND sr.pm_id = p.piece_pm_id
+         AND sr.mapping_confidence = 'high'
+        WHERE p.piece_display = true
+        ORDER BY sr.source_dlnr
+    """)
+    result = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return result
+
+
+# ============ P1: OEM References (t203 → pieces_ref_oem) ============
+
+def project_oem_dlnr(dlnr):
+    """Project OEM references for one DLNR — scope-limited to existing pieces."""
+    conn = get_conn(600)
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_ref_oem (pro_piece_id, pro_prb_id, pro_oem, pro_oem_serach)
+        SELECT DISTINCT ON (sp.piece_id, t203.khernr, regexp_replace(t203.refnr, '[^A-Za-z0-9]', '', 'g'))
+          sp.piece_id::text,
+          COALESCE(t203.khernr::text, '0'),
+          t203.refnr,
+          regexp_replace(t203.refnr, '[^A-Za-z0-9]', '', 'g')
+        FROM tecdoc_map.v_projection_scope_pieces sp
+        JOIN tecdoc_raw.t203 t203 ON t203.artnr = sp.source_artnr AND t203.dlnr = sp.source_dlnr::smallint
+        WHERE sp.source_dlnr = %s
+          AND t203.losch_flag != 1
+          AND t203.refnr IS NOT NULL AND t203.refnr != ''
+        ON CONFLICT (pro_piece_id, pro_prb_id, pro_oem_serach) DO NOTHING
+        """, (dlnr,))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ============ P2: Search References (t207/t209 → pieces_ref_search) ============
+
+def project_refs_dlnr(dlnr):
+    """Project search references for one DLNR — scope-limited."""
+    conn = get_conn(600)
+    cur = conn.cursor()
+    try:
+        # t207 = trade/usage numbers (gebrnr)
+        cur.execute("""
+        INSERT INTO pieces_ref_search (prs_piece_id, prs_piece_id_i, prs_search, prs_kind, prs_ref)
+        SELECT DISTINCT ON (sp.piece_id, regexp_replace(t207.gebrnr, '[^A-Za-z0-9]', '', 'g'))
+          sp.piece_id::text,
+          sp.piece_id,
+          regexp_replace(t207.gebrnr, '[^A-Za-z0-9]', '', 'g'),
+          'trade',
+          t207.gebrnr
+        FROM tecdoc_map.v_projection_scope_pieces sp
+        JOIN tecdoc_raw.t207 t207 ON t207.artnr = sp.source_artnr AND t207.dlnr = sp.source_dlnr::text
+        WHERE sp.source_dlnr = %s
+          AND t207.losch_flag != '1'
+          AND t207.gebrnr IS NOT NULL AND t207.gebrnr != ''
+        ON CONFLICT (prs_piece_id, prs_search, prs_kind) DO NOTHING
+        """, (dlnr,))
+        trade_count = cur.rowcount
+
+        # t209 = EAN barcodes (eannr)
+        cur.execute("""
+        INSERT INTO pieces_ref_search (prs_piece_id, prs_piece_id_i, prs_search, prs_kind, prs_ref)
+        SELECT DISTINCT ON (sp.piece_id, regexp_replace(t209.eannr, '[^A-Za-z0-9]', '', 'g'))
+          sp.piece_id::text,
+          sp.piece_id,
+          regexp_replace(t209.eannr, '[^A-Za-z0-9]', '', 'g'),
+          'ean',
+          t209.eannr
+        FROM tecdoc_map.v_projection_scope_pieces sp
+        JOIN tecdoc_raw.t209 t209 ON t209.artnr = sp.source_artnr AND t209.dlnr = sp.source_dlnr::text
+        WHERE sp.source_dlnr = %s
+          AND t209.losch_flag != '1'
+          AND t209.eannr IS NOT NULL AND t209.eannr != ''
+        ON CONFLICT (prs_piece_id, prs_search, prs_kind) DO NOTHING
+        """, (dlnr,))
+        ean_count = cur.rowcount
+
+        return ('ok', dlnr, trade_count + ean_count)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ============ P3: Images (t232 → pieces_media_img) ============
+#
+# Projection canonique via IDs internes uniquement.
+# - Source de verite : tecdoc_map.article_registry (pas v_projection_scope_pieces, trop etroit)
+# - Bridge brand : tecdoc_map.supplier_registry (pm_id interne ↔ source_dlnr externe)
+# - Resolution fichier : tecdoc_doc.graphics_registry (bildnr → bildname)
+# - pmi_pm_id = sr.pm_id (interne), pmi_folder = sr.source_dlnr (chemin Storage),
+#   pmi_name = bildname || '.JPG' (nom fichier reel)
+#
+# Reparation du bug historique : l'ancienne version ecrivait pmi_pm_id=source_dlnr,
+# pmi_folder='' et pmi_name=bildnr brut, ce qui a casse ~1.1M rows actives en mars 2026.
+
+def project_images_dlnr(dlnr):
+    """Project images for one DLNR — canonical via internal IDs."""
+    conn = get_conn(600)
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_media_img (pmi_piece_id, pmi_piece_id_i, pmi_pm_id, pmi_folder, pmi_name, pmi_sort, pmi_display)
+        SELECT DISTINCT ON (p.piece_id, gr.source_bildnr)
+          p.piece_id::text,
+          p.piece_id,
+          sr.pm_id::text,
+          sr.source_dlnr::text,
+          gr.bildname || '.JPG',
+          COALESCE(t232.sortnr, '1'),
+          '1'
+        FROM pieces p
+        JOIN tecdoc_map.article_registry ar
+          ON ar.piece_id = p.piece_id
+        JOIN tecdoc_map.supplier_registry sr
+          ON sr.source_dlnr = ar.source_dlnr
+         AND sr.pm_id = p.piece_pm_id
+         AND sr.mapping_confidence = 'high'
+        JOIN tecdoc_raw.t232 t232
+          ON t232.artnr = ar.source_artnr
+         AND t232.dlnr::int = ar.source_dlnr
+         AND t232.losch_flag != '1'
+        JOIN tecdoc_doc.graphics_registry gr
+          ON gr.source_bildnr = t232.bildnr::int
+         AND gr.source_dlnr = t232.dlnr::int
+        WHERE p.piece_display = true
+          AND sr.source_dlnr = %s
+          AND t232.bildnr IS NOT NULL AND t232.bildnr != ''
+          AND gr.bildname IS NOT NULL AND gr.bildname != ''
+        ON CONFLICT DO NOTHING
+        """, (dlnr,))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ============ P4: Article Criteria (t210 → pieces_criteria) ============
+
+def project_criteria_dlnr(dlnr):
+    """Project technical criteria for one DLNR — scope-limited."""
+    conn = get_conn(600)
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_criteria (pc_piece_id, pc_piece_id_i, pc_pg_pid, pc_pg_id, pc_ga_id, pc_cri_id, pc_cri_value, pc_has_txt, pc_display, pc_sort)
+        SELECT DISTINCT ON (sp.piece_id, sp.piece_pg_id, t210.kritnr, t210.kritwert)
+          sp.piece_id::text,
+          sp.piece_id,
+          sp.piece_pg_id::text,
+          sp.piece_pg_id::text,
+          '0',
+          t210.kritnr,
+          COALESCE(t210.kritwert, ''),
+          '0',
+          '1',
+          COALESCE(t210.sortnr, '1')
+        FROM tecdoc_map.v_projection_scope_pieces sp
+        JOIN tecdoc_raw.t210 t210 ON t210.artnr = sp.source_artnr AND t210.dlnr = sp.source_dlnr::text
+        WHERE sp.source_dlnr = %s
+          AND t210.losch_flag != '1'
+          AND t210.kritnr IS NOT NULL
+        ON CONFLICT (pc_piece_id, pc_pg_pid, pc_cri_id, pc_cri_value) DO NOTHING
+        """, (dlnr,))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ============ Runner ============
+
+def run_phase(name, func, dlnrs, workers, dry_run=False):
+    """Run a projection phase across all DLNR."""
+    log(f"\n--- {name} ({len(dlnrs)} DLNR, {workers} workers) ---")
+
+    if dry_run:
+        log(f"  DRY-RUN: would project {name} for {len(dlnrs)} DLNR")
+        return 0
+
+    t0 = time.time()
+    total = 0
+    errors = 0
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(func, dlnr): dlnr for dlnr in dlnrs}
+
+        completed = 0
+        for future in as_completed(futures):
+            result = future.result()
+            completed += 1
+            if result[0] == 'ok':
+                total += result[2]
+                if completed % 20 == 0 or completed == len(dlnrs):
+                    elapsed = time.time() - t0
+                    log(f"  Progress: {completed}/{len(dlnrs)} "
+                        f"(+{total:,} rows, {errors} errors, {elapsed:.0f}s)")
+            else:
+                errors += 1
+                log(f"  ERROR DLNR={result[1]}: {result[2]}")
+
+    elapsed = time.time() - t0
+    log(f"  DONE {name}: +{total:,} rows, {errors} errors ({elapsed:.0f}s)")
+    return total
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Projection sélective — enrichissement catalogue')
+    parser.add_argument('--dry-run', action='store_true', help='Compter seulement')
+    parser.add_argument('--oem', action='store_true', help='P1: OEM references')
+    parser.add_argument('--refs', action='store_true', help='P2: Search references')
+    parser.add_argument('--images', action='store_true', help='P3: Images')
+    parser.add_argument('--criteria', action='store_true', help='P4: Article criteria')
+    parser.add_argument('--all', action='store_true', help='Toutes les phases')
+    parser.add_argument('--workers', type=int, default=4, help='Workers parallèles')
+    args = parser.parse_args()
+
+    if not any([args.oem, args.refs, args.images, args.criteria, args.all, args.dry_run]):
+        parser.print_help()
+        sys.exit(1)
+
+    log("=== Projection sélective — enrichissement catalogue ===")
+    log(f"  Mode: {'DRY-RUN' if args.dry_run else 'EXECUTE'}")
+    log(f"  Scope: fournisseurs actifs + pièces year=2025 + linkages établis")
+
+    dlnrs = get_active_dlnrs()
+    log(f"  DLNR actifs: {len(dlnrs)}")
+
+    results = {}
+
+    if args.oem or args.all:
+        results['oem'] = run_phase('P1: OEM refs (t203→pieces_ref_oem)',
+                                    project_oem_dlnr, dlnrs, args.workers, args.dry_run)
+
+    if args.refs or args.all:
+        results['refs'] = run_phase('P2: Search refs (t207/t209→pieces_ref_search)',
+                                    project_refs_dlnr, dlnrs, args.workers, args.dry_run)
+
+    if args.images or args.all:
+        # Canonique : scope elargi via article_registry (109 DLNR au lieu de 105)
+        image_dlnrs = get_image_projection_dlnrs()
+        log(f"  DLNR images (article_registry scope): {len(image_dlnrs)}")
+        results['images'] = run_phase('P3: Images (t232→pieces_media_img)',
+                                      project_images_dlnr, image_dlnrs, args.workers, args.dry_run)
+
+    if args.criteria or args.all:
+        results['criteria'] = run_phase('P4: Criteria (t210→pieces_criteria)',
+                                        project_criteria_dlnr, dlnrs, args.workers, args.dry_run)
+
+    log(f"\n=== BILAN ===")
+    for phase, count in results.items():
+        log(f"  {phase}: +{count:,}")
+    log(f"  Total: +{sum(results.values()):,}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/project-linkages-retry.py
+++ b/scripts/tecdoc-pipeline/project-linkages-retry.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Retry failed linkage chunks with direct connection (no timeout) + sub-chunking.
+Chunks > 200K rows are split by 4th char of ARTNR.
+"""
+import psycopg2, time, sys, string
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/project-linkages-retry.log'
+
+FAILED_CHUNKS = [
+    (21, '032'), (253, 'LID'), (95, '000'), (95, '350'), (95, '359'),
+    (95, '363'), (95, '360'), (161, 'GDB'), (95, '154'), (95, '069'),
+    (95, '301'), (95, '341'), (95, '361'), (161, 'DF4'), (253, '121'),
+    (95, '064'), (95, '430'),
+]
+
+# Chunks > 200K — need sub-chunking by 4th char
+BIG_CHUNKS = {(21, '032'), (253, 'LID'), (95, '000'), (95, '350'),
+              (95, '359'), (95, '363'), (95, '360')}
+
+SUB_CHARS = list(string.digits + string.ascii_uppercase + string.ascii_lowercase) + [None]
+
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+
+PW = get_pw()
+
+
+def get_conn_direct():
+    """Direct connection port 5432, no timeout."""
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com',
+        port=5432,
+        user='postgres.cxpojprgwgubzjyqzmoq',
+        password=PW,
+        dbname='postgres'
+    )
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute('SET statement_timeout = 0')
+    cur.close()
+    return conn
+
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def project_linkage(dlnr, prefix, sub_char=None):
+    """Project one chunk (or sub-chunk if sub_char given)."""
+    conn = get_conn_direct()
+    cur = conn.cursor()
+    try:
+        if sub_char is not None:
+            where_extra = "AND substring(sl.source_artnr, 4, 1) = %s"
+            params = (dlnr, prefix, sub_char)
+        else:
+            where_extra = ""
+            params = (dlnr, prefix)
+
+        cur.execute(f"""
+        INSERT INTO pieces_relation_type
+          (rtp_piece_id, rtp_type_id, rtp_target_kind, rtp_pg_id, rtp_ga_id, rtp_pm_id)
+        SELECT DISTINCT ON (ar.piece_id, sl.target_internal_id)
+          ar.piece_id, sl.target_internal_id, sl.rtp_target_kind,
+          COALESCE(pg.pg_id, 0), sl.source_genartnr, sl.source_dlnr
+        FROM tecdoc_map.source_linkages sl
+        JOIN tecdoc_map.article_registry ar
+          ON ar.source_artnr = sl.source_artnr AND ar.source_dlnr = sl.source_dlnr
+        LEFT JOIN pieces_gamme pg ON pg.pg_id = sl.source_genartnr
+        WHERE ar.piece_id IS NOT NULL
+          AND sl.source_dlnr = %s
+          AND left(sl.source_artnr, 3) = %s
+          {where_extra}
+        ON CONFLICT (rtp_type_id, rtp_piece_id) DO NOTHING
+        """, params)
+        return ('ok', dlnr, prefix, sub_char, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        return ('error', dlnr, prefix, sub_char, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def main():
+    workers = int(sys.argv[1]) if len(sys.argv) > 1 else 4
+    log(f"=== Retry {len(FAILED_CHUNKS)} failed linkage chunks, {workers} workers ===")
+
+    # Build task list: big chunks get sub-chunked, small ones run as-is
+    tasks = []
+    for dlnr, prefix in FAILED_CHUNKS:
+        if (dlnr, prefix) in BIG_CHUNKS:
+            for sc in SUB_CHARS:
+                tasks.append((dlnr, prefix, sc))
+        else:
+            tasks.append((dlnr, prefix, None))
+
+    log(f"  {len(tasks)} tasks total ({len(BIG_CHUNKS)} big chunks sub-divided)")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(project_linkage, d, p, s): (d, p, s)
+            for d, p, s in tasks
+        }
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            dlnr, prefix, sub_char, = result[1], result[2], result[3]
+            label = f"DLNR={dlnr} prefix={prefix}" + (f"/{sub_char}" if sub_char else "")
+            if result[0] == 'ok':
+                rows = result[4]
+                total += rows
+                if rows > 100:
+                    log(f"  {label}: +{rows:,}")
+            else:
+                errors += 1
+                log(f"  ERROR {label}: {result[4][:100]}")
+            if done % 50 == 0 or done == len(tasks):
+                log(f"  Progress: {done}/{len(tasks)} (+{total:,} rows, {errors} errors)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  RETRY DONE: +{total:,} rows, {errors} errors ({dur}s / {dur // 60}min)")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/project-linkages-v3.py
+++ b/scripts/tecdoc-pipeline/project-linkages-v3.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Project source_linkages → pieces_relation_type for NEW pieces (year=2025).
+v3 — Direct connection, by DLNR, no GROUP BY prefix.
+
+Usage:
+  python3 project-linkages-v3.py --workers 6
+  python3 project-linkages-v3.py --dry-run
+"""
+import psycopg2, time, sys, argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+PW = get_pw()
+
+def get_conn_direct(timeout_s=600):
+    conn = psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=PW, dbname='postgres')
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(f"SET statement_timeout = '{timeout_s}s'")
+    cur.close()
+    return conn
+
+def get_conn_pooler(timeout_s=120):
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com', port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq', password=PW, dbname='postgres',
+        options=f'-c statement_timeout={timeout_s * 1000}')
+    conn.autocommit = True
+    return conn
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def get_dlnrs_to_project():
+    """Get DLNR list from source_linkages that have new pieces."""
+    conn = get_conn_pooler(timeout_s=120)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT DISTINCT sm.dlnr
+    FROM __tecdoc_supplier_mapping sm
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    ORDER BY sm.dlnr
+    """)
+    dlnrs = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return dlnrs
+
+
+def project_dlnr(dlnr):
+    """Project linkages for one DLNR: source_linkages → pieces_relation_type."""
+    conn = get_conn_direct(timeout_s=600)
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_relation_type
+          (rtp_type_id, rtp_piece_id, rtp_pm_id, rtp_pg_id, rtp_pg_pid, rtp_ga_id, rtp_psf_id, rtp_inside, rtp_target_kind)
+        SELECT DISTINCT
+          sl.source_vknzielnr,
+          ar.piece_id,
+          p.piece_pm_id,
+          p.piece_pg_id,
+          p.piece_pg_pid,
+          p.piece_ga_id,
+          0,
+          '0',
+          'vehicle_type'
+        FROM tecdoc_map.source_linkages sl
+        JOIN tecdoc_map.article_registry ar ON ar.source_artnr = sl.source_artnr AND ar.source_dlnr = sl.source_dlnr
+        JOIN pieces p ON p.piece_id = ar.piece_id AND p.piece_year = 2025
+        JOIN auto_type at2 ON at2.type_id_i = sl.source_vknzielnr
+        WHERE sl.source_vknzielart = 2
+          AND sl.source_dlnr = %s
+        ON CONFLICT DO NOTHING
+        """, (dlnr,))
+        inserted = cur.rowcount
+        return ('ok', dlnr, inserted)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:200])
+    finally:
+        cur.close()
+        conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Project linkages v3')
+    parser.add_argument('--workers', type=int, default=4)
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    log("=== Project linkages: source_linkages → pieces_relation_type (year=2025) ===")
+
+    dlnrs = get_dlnrs_to_project()
+    log(f"  DLNR to project: {len(dlnrs)}")
+
+    if args.dry_run:
+        log("  DRY-RUN: would project linkages for all active DLNR")
+        return
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {executor.submit(project_dlnr, dlnr): dlnr for dlnr in dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                count = result[2]
+                total += count
+                if count > 0:
+                    log(f"  DLNR={result[1]}: +{count:,}")
+            else:
+                errors += 1
+                log(f"  ERROR DLNR={result[1]}: {result[2]}")
+            if done % 20 == 0:
+                elapsed = int(time.monotonic() - start)
+                log(f"  Progress: {done}/{len(dlnrs)} (+{total:,} rows, {errors} errors, {elapsed}s)")
+
+    dur = int(time.monotonic() - start)
+    log(f"\n=== DONE: +{total:,} linkages, {errors} errors ({dur}s / {dur//60}min) ===")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/project-new-data.py
+++ b/scripts/tecdoc-pipeline/project-new-data.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Project newly loaded data to core tables — t203→pieces_ref_oem, t232→pieces_media_img, linkages."""
+import psycopg2, time, sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/project-new-data.log'
+
+def get_conn(timeout=300000):
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                pw = line.strip().split('=',1)[1]
+    return psycopg2.connect(
+        f'postgresql://postgres.cxpojprgwgubzjyqzmoq:{pw}@aws-0-eu-west-3.pooler.supabase.com:6543/postgres',
+        options=f'-c statement_timeout={timeout}'
+    )
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+# ============ t203 → pieces_ref_oem ============
+def project_oem_chunk(dlnr):
+    conn = get_conn(180000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_ref_oem (pro_piece_id, pro_prb_id, pro_oem, pro_oem_serach)
+        SELECT DISTINCT ON (ar.piece_id, t203.refnr)
+          ar.piece_id::text, t203.khernr, t203.refnr, regexp_replace(t203.refnr, '[^A-Za-z0-9]', '', 'g')
+        FROM tecdoc_raw.t203 t203
+        JOIN tecdoc_map.article_registry ar ON ar.source_artnr = t203.artnr AND ar.source_dlnr = t203.dlnr::int
+        WHERE ar.piece_id IS NOT NULL AND t203.losch_flag != '1' AND t203.dlnr = %s
+        ON CONFLICT (pro_piece_id, pro_oem) DO NOTHING
+        """, (str(dlnr),))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:100])
+    finally:
+        cur.close()
+        conn.close()
+
+# ============ t232 → pieces_media_img ============
+def project_img_chunk(dlnr):
+    conn = get_conn(180000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_media_img (pmi_piece_id, pmi_pm_id, pmi_folder, pmi_name, pmi_sort, pmi_display, pmi_piece_id_i)
+        SELECT ar.piece_id::text, %s, '', gr.bildname, t232.sortnr, '1', ar.piece_id
+        FROM tecdoc_raw.t232 t232
+        JOIN tecdoc_map.article_registry ar ON ar.source_artnr = t232.artnr AND ar.source_dlnr = t232.dlnr::int
+        JOIN tecdoc_doc.graphics_registry gr ON gr.source_bildnr = t232.bildnr::int AND gr.source_dlnr = t232.dlnr::int
+        WHERE ar.piece_id IS NOT NULL AND t232.losch_flag != '1' AND gr.bildname IS NOT NULL AND t232.dlnr = %s
+        ON CONFLICT (pmi_piece_id, pmi_name) DO NOTHING
+        """, (str(dlnr), str(dlnr)))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        return ('error', dlnr, str(e)[:100])
+    finally:
+        cur.close()
+        conn.close()
+
+# ============ linkages source → core ============
+def project_linkage_chunk(dlnr, prefix):
+    conn = get_conn(300000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        INSERT INTO pieces_relation_type (rtp_piece_id, rtp_type_id, rtp_target_kind, rtp_pg_id, rtp_ga_id, rtp_pm_id)
+        SELECT DISTINCT ON (ar.piece_id, sl.target_internal_id)
+          ar.piece_id, sl.target_internal_id, sl.rtp_target_kind,
+          COALESCE(pg.pg_id, 0), sl.source_genartnr, sl.source_dlnr
+        FROM tecdoc_map.source_linkages sl
+        JOIN tecdoc_map.article_registry ar ON ar.source_artnr = sl.source_artnr AND ar.source_dlnr = sl.source_dlnr
+        LEFT JOIN pieces_gamme pg ON pg.pg_id = sl.source_genartnr
+        WHERE ar.piece_id IS NOT NULL AND sl.source_dlnr = %s AND left(sl.source_artnr, 3) = %s
+        ON CONFLICT (rtp_type_id, rtp_piece_id) DO NOTHING
+        """, (dlnr, prefix))
+        return ('ok', dlnr, prefix, cur.rowcount)
+    except Exception as e:
+        return ('error', dlnr, prefix, str(e)[:100])
+    finally:
+        cur.close()
+        conn.close()
+
+def main():
+    # === Phase 1: t203 → pieces_ref_oem ===
+    log("=== Phase 1: t203 → pieces_ref_oem ===")
+    conn = get_conn(120000)
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT dlnr FROM __tecdoc_supplier_mapping WHERE dlnr IS NOT NULL ORDER BY dlnr")
+    oem_dlnrs = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    log(f"  {len(oem_dlnrs)} DLNR to project")
+
+    total_oem = 0
+    errors_oem = 0
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futures = {executor.submit(project_oem_chunk, dlnr): dlnr for dlnr in oem_dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total_oem += result[2]
+            else:
+                errors_oem += 1
+            if done % 50 == 0:
+                log(f"  OEM progress: {done}/{len(oem_dlnrs)} (+{total_oem:,} rows, {errors_oem} errors)")
+    log(f"  OEM DONE: +{total_oem:,} rows, {errors_oem} errors ({int((time.monotonic()-start)/60)}min)")
+
+    # === Phase 2: t232 → pieces_media_img ===
+    log("\n=== Phase 2: t232 → pieces_media_img ===")
+    conn = get_conn(120000)
+    cur = conn.cursor()
+
+    # First update graphics_registry with new t231 data
+    log("  Updating graphics_registry...")
+    conn2 = get_conn(300000)
+    conn2.autocommit = True
+    cur2 = conn2.cursor()
+    cur2.execute("""
+    INSERT INTO tecdoc_doc.graphics_registry (source_bildnr, source_dlnr, bildname, bildtype, dokumentenart, width, height, source_business_key)
+    SELECT DISTINCT ON (bildnr::int, dlnr::int)
+      bildnr::int, dlnr::int, bildname, bildtype::smallint, dokumentenart::smallint,
+      CASE WHEN breit ~ '^\d+$' THEN breit::smallint ELSE NULL END,
+      CASE WHEN hoch ~ '^\d+$' THEN hoch::smallint ELSE NULL END,
+      encode(digest(concat_ws('|', bildnr, dlnr), 'sha256'), 'hex')
+    FROM tecdoc_raw.t231
+    WHERE losch_flag != '1'
+    ON CONFLICT (source_bildnr, source_dlnr) DO NOTHING
+    """)
+    log(f"  Graphics registry: +{cur2.rowcount:,}")
+    cur2.close()
+    conn2.close()
+
+    cur.execute("SELECT DISTINCT dlnr FROM __tecdoc_supplier_mapping WHERE dlnr IS NOT NULL ORDER BY dlnr")
+    img_dlnrs = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    log(f"  {len(img_dlnrs)} DLNR to project images")
+
+    total_img = 0
+    errors_img = 0
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futures = {executor.submit(project_img_chunk, dlnr): dlnr for dlnr in img_dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total_img += result[2]
+            else:
+                errors_img += 1
+            if done % 50 == 0:
+                log(f"  IMG progress: {done}/{len(img_dlnrs)} (+{total_img:,} rows, {errors_img} errors)")
+    log(f"  IMG DONE: +{total_img:,} rows, {errors_img} errors ({int((time.monotonic()-start)/60)}min)")
+
+    # === Phase 3: linkages source → core ===
+    log("\n=== Phase 3: source_linkages → pieces_relation_type ===")
+    conn = get_conn(120000)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT source_dlnr, left(source_artnr, 3) as prefix, count(*)
+    FROM tecdoc_map.source_linkages
+    GROUP BY source_dlnr, left(source_artnr, 3)
+    ORDER BY count(*) ASC
+    """)
+    linkage_chunks = cur.fetchall()
+    cur.close()
+    conn.close()
+    log(f"  {len(linkage_chunks)} chunks to project")
+
+    total_link = 0
+    errors_link = 0
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futures = {executor.submit(project_linkage_chunk, dlnr, prefix): (dlnr, prefix) for dlnr, prefix, _ in linkage_chunks}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total_link += result[3]
+            else:
+                errors_link += 1
+            if done % 100 == 0:
+                log(f"  LINK progress: {done}/{len(linkage_chunks)} (+{total_link:,} rows, {errors_link} errors)")
+    log(f"  LINK DONE: +{total_link:,} rows, {errors_link} errors ({int((time.monotonic()-start)/60)}min)")
+
+    # === ANALYZE ===
+    log("\n=== ANALYZE ===")
+    conn = get_conn(300000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    for t in ['pieces_ref_oem', 'pieces_media_img', 'pieces_relation_type']:
+        s = time.monotonic()
+        cur.execute(f"ANALYZE {t}")
+        log(f"  ANALYZE {t} ({int((time.monotonic()-s)*1000)}ms)")
+    cur.close()
+    conn.close()
+
+    log(f"\n=== BILAN FINAL ===")
+    log(f"  OEM refs: +{total_oem:,} ({errors_oem} errors)")
+    log(f"  Images: +{total_img:,} ({errors_img} errors)")
+    log(f"  Linkages: +{total_link:,} ({errors_link} errors)")
+    log("Done.")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/project-prt-remap-batch.py
+++ b/scripts/tecdoc-pipeline/project-prt-remap-batch.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Project source_linkages → pieces_relation_type with KTYPNR→massdoc remap.
+Batch optimized: fetches all articles first, then processes in chunks with remap JOIN.
+"""
+import psycopg2, time, sys, os
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.split('=', 1)[1].strip()
+
+def get_conn(timeout_s=600):
+    return psycopg2.connect(
+        host='db.cxpojprgwgubzjyqzmoq.supabase.co', port=5432,
+        user='postgres', password=get_pw(), dbname='postgres',
+        options=f'-c statement_timeout={timeout_s * 1000}'
+    )
+
+def log(msg):
+    line = f'[{time.strftime("%Y-%m-%d %H:%M:%S")}] {msg}'
+    print(line, flush=True)
+    with open('/opt/automecanik/data/tecdoc/logs/project-prt-remap-batch.log', 'a') as f:
+        f.write(line + '\n')
+
+def main():
+    conn = get_conn(timeout_s=300)
+    conn.autocommit = True
+    cur = conn.cursor()
+    t0 = time.time()
+
+    # Step 1: Get all articles without prt but with source_linkages
+    log("Step 1: Fetching articles without prt...")
+    cur.execute("""
+    SELECT p.piece_id, ar.source_artnr, ar.source_dlnr,
+           p.piece_pm_id, p.piece_pg_id,
+           COALESCE(p.piece_pg_pid, p.piece_pg_id) as pg_pid,
+           COALESCE(p.piece_ga_id, 0) as ga_id
+    FROM pieces p
+    JOIN tecdoc_map.article_registry ar ON ar.piece_id = p.piece_id
+    WHERE p.piece_year = 2025 AND p.piece_display = false
+      AND NOT EXISTS (SELECT 1 FROM pieces_relation_type prt WHERE prt.rtp_piece_id = p.piece_id)
+      AND EXISTS (SELECT 1 FROM tecdoc_map.source_linkages sl
+        WHERE sl.source_artnr = ar.source_artnr AND sl.source_dlnr = ar.source_dlnr
+        AND sl.source_vknzielart = 2)
+    """)
+    articles = cur.fetchall()
+    log(f"  {len(articles)} articles to project")
+
+    if not articles:
+        log("Nothing to do.")
+        return
+
+    # Step 2: Project per chunk of 50 articles
+    CHUNK = 50
+    total_prt = 0
+    errors = 0
+
+    for i in range(0, len(articles), CHUNK):
+        chunk = articles[i:i+CHUNK]
+        chunk_prt = 0
+
+        for pid, artnr, dlnr, pm, pg, pgp, ga in chunk:
+            try:
+                cur.execute("""
+                INSERT INTO pieces_relation_type
+                  (rtp_type_id, rtp_piece_id, rtp_pm_id, rtp_pg_id, rtp_pg_pid, rtp_ga_id, rtp_psf_id, rtp_inside, rtp_target_kind)
+                SELECT DISTINCT COALESCE(r.new_id, sl.source_vknzielnr),
+                  %s, %s, %s, %s, %s, 0, 0, 'vehicle_type'
+                FROM tecdoc_map.source_linkages sl
+                LEFT JOIN tecdoc_map.type_id_remap r ON r.old_id = sl.source_vknzielnr
+                JOIN auto_type at2 ON at2.type_id_i = COALESCE(r.new_id, sl.source_vknzielnr)
+                WHERE sl.source_artnr = %s AND sl.source_dlnr = %s AND sl.source_vknzielart = 2
+                ON CONFLICT DO NOTHING
+                """, (pid, pm, pg, pgp, ga, artnr, dlnr))
+                chunk_prt += cur.rowcount
+            except Exception as e:
+                errors += 1
+                if errors <= 5:
+                    log(f"  ERROR {artnr}/{dlnr}: {str(e)[:80]}")
+
+        total_prt += chunk_prt
+        done = min(i + CHUNK, len(articles))
+        if done % 500 == 0 or done == len(articles):
+            elapsed = time.time() - t0
+            rate = done / elapsed if elapsed > 0 else 0
+            eta = (len(articles) - done) / rate if rate > 0 else 0
+            log(f"  {done}/{len(articles)} +{total_prt} prt {errors}e {elapsed:.0f}s (ETA {eta:.0f}s)")
+
+    log(f"\nStep 2 done: +{total_prt} prt rows, {errors} errors, {time.time()-t0:.0f}s")
+
+    # Step 3: Activate pieces with nom + image + prt visible
+    log("\nStep 3: Activating pieces...")
+    cur.execute("""
+    UPDATE pieces p SET piece_display = true
+    WHERE p.piece_year = 2025 AND p.piece_display = false
+      AND p.piece_name IS NOT NULL AND p.piece_name != ''
+      AND p.piece_has_img = true
+      AND EXISTS (
+        SELECT 1 FROM pieces_relation_type prt
+        JOIN auto_type at2 ON at2.type_id_i = prt.rtp_type_id AND at2.type_display = '1'
+        WHERE prt.rtp_piece_id = p.piece_id
+      )
+    """)
+    activated = cur.rowcount
+    log(f"  +{activated} pieces activated")
+
+    # Step 4: ANALYZE + refresh
+    log("\nStep 4: ANALYZE + refresh...")
+    cur.execute("ANALYZE pieces")
+    cur.execute("ANALYZE pieces_relation_type")
+    try:
+        cur.execute("SELECT refresh_gamme_aggregates(NULL)")
+        cur.execute("SELECT refresh_equipementier_counts()")
+    except:
+        log("  refresh functions skipped (timeout or error)")
+
+    elapsed = time.time() - t0
+    log(f"\n=== DONE: +{total_prt} prt, +{activated} activated, {errors} errors, {elapsed:.0f}s ===")
+    cur.close()
+    conn.close()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc-pipeline/register-and-create-pieces.py
+++ b/scripts/tecdoc-pipeline/register-and-create-pieces.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+Register new t200 articles + create missing pieces.
+Phase 1: INSERT into article_registry (match existing pieces or NULL)
+Phase 2: INSERT into pieces for unmatched articles with valid gamme
+Phase 3: UPDATE article_registry.piece_id for newly created pieces
+
+Usage:
+  python3 register-and-create-pieces.py --phase1 --workers 6   # Register articles
+  python3 register-and-create-pieces.py --phase2 --workers 6   # Create pieces
+  python3 register-and-create-pieces.py --phase3 --workers 6   # Update registry
+  python3 register-and-create-pieces.py --all --workers 6       # All phases
+"""
+import psycopg2, time, sys, argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+LOGFILE = '/opt/automecanik/data/tecdoc/logs/register-create-pieces.log'
+ERRFILE = '/opt/automecanik/data/tecdoc/logs/register-create-pieces-errors.log'
+
+
+def get_pw():
+    with open('/opt/automecanik/app/backend/.env') as f:
+        for line in f:
+            if line.startswith('SUPABASE_DB_PASSWORD='):
+                return line.strip().split('=', 1)[1]
+    raise RuntimeError('PW not found')
+
+
+PW = get_pw()
+
+
+def get_conn(timeout_ms=300000):
+    return psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com',
+        port=6543,
+        user='postgres.cxpojprgwgubzjyqzmoq',
+        password=PW,
+        dbname='postgres',
+        options=f'-c statement_timeout={timeout_ms}'
+    )
+
+
+def get_conn_direct():
+    conn = psycopg2.connect(
+        host='aws-0-eu-west-3.pooler.supabase.com',
+        port=5432,
+        user='postgres.cxpojprgwgubzjyqzmoq',
+        password=PW,
+        dbname='postgres'
+    )
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute('SET statement_timeout = 0')
+    cur.close()
+    return conn
+
+
+def log(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    with open(LOGFILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def log_error(msg):
+    ts = time.strftime('%Y-%m-%d %H:%M:%S')
+    with open(ERRFILE, 'a') as f:
+        f.write(f"[{ts}] {msg}\n")
+
+
+def get_active_dlnrs():
+    """109 fournisseurs principaux : pm_display = '1' + mapping TecDoc."""
+    conn = get_conn(30000)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT DISTINCT sm.dlnr
+    FROM __tecdoc_supplier_mapping sm
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    WHERE sm.dlnr IS NOT NULL
+    ORDER BY sm.dlnr
+    """)
+    result = [r[0] for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return result
+
+
+# ============ Phase 1: Register articles in article_registry ============
+
+def register_chunk(dlnr):
+    """Insert new t200 articles into article_registry, matching existing pieces."""
+    conn = get_conn(600000)  # 10 min per chunk
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        # Insert with ARTNR direct match to existing pieces
+        cur.execute("""
+        INSERT INTO tecdoc_map.article_registry (source_artnr, source_dlnr, piece_id, source_business_key, mapping_confidence)
+        SELECT DISTINCT ON (t.artnr, t.dlnr::int)
+          t.artnr,
+          t.dlnr::int,
+          p.piece_id,
+          encode(digest(concat_ws('|', t.artnr, t.dlnr), 'sha256'), 'hex'),
+          CASE WHEN p.piece_id IS NOT NULL THEN 'high' ELSE 'low' END
+        FROM tecdoc_raw.t200 t
+        JOIN __tecdoc_supplier_mapping sm ON sm.dlnr = t.dlnr::int
+        JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+        JOIN tecdoc_raw.t211 t211 ON t211.artnr = t.artnr AND t211.dlnr = t.dlnr AND t211.losch_flag != '1'
+        JOIN gamme_aggregates ga ON ga.ga_pg_id = t211.genartnr::int
+        LEFT JOIN pieces p ON p.piece_ref = t.artnr AND p.piece_pm_id = sm.sup_pm_id
+        WHERE t.losch_flag != '1'
+          AND t.dlnr::int = %s
+          AND NOT EXISTS (
+            SELECT 1 FROM tecdoc_map.article_registry ar
+            WHERE ar.source_artnr = t.artnr AND ar.source_dlnr = t.dlnr::int
+          )
+        ON CONFLICT (source_artnr, source_dlnr) DO NOTHING
+        """, (dlnr,))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        log_error(f"REGISTER DLNR={dlnr}: {err}")
+        return ('error', dlnr, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def run_phase1(workers):
+    log("=== Phase 1: Register new articles in article_registry ===")
+    dlnrs = get_active_dlnrs()
+    log(f"  {len(dlnrs)} DLNR to process")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(register_chunk, d): d for d in dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total += result[2]
+                if result[2] > 5000:
+                    log(f"  DLNR={result[1]}: +{result[2]:,}")
+            else:
+                errors += 1
+                if errors <= 5:
+                    log(f"  ERROR DLNR={result[1]}: {result[2][:80]}")
+            if done % 50 == 0:
+                log(f"  Progress: {done}/{len(dlnrs)} (+{total:,} registered, {errors} errors)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  Phase 1 DONE: +{total:,} articles registered, {errors} errors ({dur}s / {dur//60}min)")
+    return total
+
+
+# ============ Phase 2: Create missing pieces ============
+
+CHUNK_THRESHOLD = 3000  # DLNR with more articles than this get chunked by prefix
+
+
+def create_pieces_chunk(dlnr, prefix=None):
+    """Create pieces for articles with valid gamme that don't have a piece yet.
+    Uses pooler (6543) with 10 min timeout. Large DLNR are chunked by ARTNR prefix."""
+    conn = get_conn(600000)  # 10 min timeout via pooler
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        prefix_filter = ""
+        params = (dlnr,)
+        if prefix is not None:
+            prefix_filter = "AND left(ar.source_artnr, 3) = %s"
+            params = (dlnr, prefix)
+
+        cur.execute(f"""
+        INSERT INTO pieces (
+          piece_ref, piece_ref_clean, piece_pm_id, piece_pg_id, piece_ga_id,
+          piece_pg_pid, piece_fil_id, piece_qty_sale, piece_qty_pack,
+          piece_weight_kgm, piece_has_oem, piece_has_img, piece_year,
+          piece_display, piece_sort, piece_update, piece_psf_id
+        )
+        SELECT DISTINCT ON (t.artnr, sm.sup_pm_id)
+          t.artnr,
+          regexp_replace(t.artnr, '[^A-Za-z0-9]', '', 'g'),
+          sm.sup_pm_id,
+          t211.genartnr::int,
+          t211.genartnr::int,
+          COALESCE(pg.pg_parent::int, 0),
+          1, 1, 1, 0.000,
+          false, false, 2025, false, 1, false, 9999
+        FROM tecdoc_map.article_registry ar
+        JOIN tecdoc_raw.t200 t ON t.artnr = ar.source_artnr AND t.dlnr::int = ar.source_dlnr
+        JOIN __tecdoc_supplier_mapping sm ON sm.dlnr = ar.source_dlnr
+        JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+        JOIN tecdoc_raw.t211 t211 ON t211.artnr = ar.source_artnr AND t211.dlnr::int = ar.source_dlnr AND t211.losch_flag != '1'
+        JOIN gamme_aggregates ga ON ga.ga_pg_id = t211.genartnr::int
+        JOIN pieces_gamme pg ON pg.pg_id = t211.genartnr::int
+        WHERE ar.piece_id IS NULL
+          AND ar.source_dlnr = %s
+          AND t.losch_flag != '1'
+          {prefix_filter}
+        ON CONFLICT (piece_ref, piece_pm_id) DO NOTHING
+        """, params)
+        label = f"DLNR={dlnr}" + (f"/prefix={prefix}" if prefix else "")
+        return ('ok', label, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        label = f"DLNR={dlnr}" + (f"/prefix={prefix}" if prefix else "")
+        log_error(f"CREATE {label}: {err}")
+        return ('error', label, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def get_phase2_chunks():
+    """Build work units: small DLNR as-is, big DLNR split by ARTNR prefix."""
+    conn = get_conn(60000)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT ar.source_dlnr, count(*) as cnt
+    FROM tecdoc_map.article_registry ar
+    JOIN __tecdoc_supplier_mapping sm ON sm.dlnr = ar.source_dlnr
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    WHERE ar.piece_id IS NULL
+    GROUP BY ar.source_dlnr
+    ORDER BY count(*) DESC
+    """)
+    dlnr_counts = cur.fetchall()
+    total_articles = sum(r[1] for r in dlnr_counts)
+
+    # Split big DLNR into prefix chunks
+    big_dlnrs = [r[0] for r in dlnr_counts if r[1] >= CHUNK_THRESHOLD]
+    chunks = []
+    if big_dlnrs:
+        cur.execute("""
+        SELECT ar.source_dlnr, left(ar.source_artnr, 3) as prefix, count(*)
+        FROM tecdoc_map.article_registry ar
+        JOIN __tecdoc_supplier_mapping sm ON sm.dlnr = ar.source_dlnr
+        JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+        WHERE ar.piece_id IS NULL AND ar.source_dlnr = ANY(%s)
+        GROUP BY ar.source_dlnr, left(ar.source_artnr, 3)
+        ORDER BY count(*) ASC
+        """, (big_dlnrs,))
+        for dlnr, prefix, cnt in cur.fetchall():
+            chunks.append((dlnr, prefix))
+
+    # Small DLNR as single chunks
+    for dlnr, cnt in dlnr_counts:
+        if cnt < CHUNK_THRESHOLD:
+            chunks.append((dlnr, None))
+
+    cur.close()
+    conn.close()
+    return chunks, len(dlnr_counts), total_articles
+
+
+def run_phase2(workers):
+    log("\n=== Phase 2: Create missing pieces ===")
+
+    chunks, dlnr_count, total_articles = get_phase2_chunks()
+    big_count = sum(1 for _, p in chunks if p is not None)
+    small_count = sum(1 for _, p in chunks if p is None)
+    log(f"  {dlnr_count} DLNR pm_display='1' ({total_articles:,} articles)")
+    log(f"  {len(chunks)} work units ({big_count} prefix chunks + {small_count} whole DLNR)")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(create_pieces_chunk, dlnr, prefix): (dlnr, prefix)
+            for dlnr, prefix in chunks
+        }
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total += result[2]
+                if result[2] > 500:
+                    log(f"  {result[1]}: +{result[2]:,} pieces")
+            else:
+                errors += 1
+                if errors <= 10:
+                    log(f"  ERROR {result[1]}: {result[2][:80]}")
+            if done % 50 == 0 or done == len(chunks):
+                elapsed = int(time.monotonic() - start)
+                log(f"  Progress: {done}/{len(chunks)} (+{total:,} pieces, {errors} errors, {elapsed}s)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  Phase 2 DONE: +{total:,} pieces created, {errors} errors ({dur}s / {dur//60}min)")
+    return total
+
+
+# ============ Phase 3: Update article_registry with new piece_ids ============
+
+def update_registry_chunk(dlnr):
+    """Set piece_id in article_registry for newly created pieces."""
+    conn = get_conn(600000)  # 10 min timeout via pooler
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute("""
+        UPDATE tecdoc_map.article_registry ar
+        SET piece_id = p.piece_id,
+            mapping_confidence = 'high',
+            updated_at = now()
+        FROM pieces p
+        JOIN __tecdoc_supplier_mapping sm ON sm.sup_pm_id = p.piece_pm_id AND sm.dlnr = %s
+        WHERE ar.source_artnr = p.piece_ref
+          AND ar.piece_id IS NULL
+          AND ar.source_dlnr = %s
+        """, (dlnr, dlnr))
+        return ('ok', dlnr, cur.rowcount)
+    except Exception as e:
+        err = str(e).replace('\n', ' ')[:200]
+        log_error(f"UPDATE DLNR={dlnr}: {err}")
+        return ('error', dlnr, err)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def run_phase3(workers):
+    log("\n=== Phase 3: Update article_registry with new piece_ids ===")
+
+    # Only pm_display='1' DLNR
+    conn = get_conn(60000)
+    cur = conn.cursor()
+    cur.execute("""
+    SELECT ar.source_dlnr, count(*) as cnt
+    FROM tecdoc_map.article_registry ar
+    JOIN __tecdoc_supplier_mapping sm ON sm.dlnr = ar.source_dlnr
+    JOIN pieces_marque pm ON pm.pm_id = sm.sup_pm_id AND pm.pm_display = '1'
+    WHERE ar.piece_id IS NULL
+    GROUP BY ar.source_dlnr
+    ORDER BY count(*) DESC
+    """)
+    dlnr_counts = cur.fetchall()
+    cur.close()
+    conn.close()
+
+    dlnrs = [r[0] for r in dlnr_counts]
+    log(f"  {len(dlnrs)} DLNR pm_display='1' with NULL piece_id ({sum(r[1] for r in dlnr_counts):,} total)")
+
+    total = 0
+    errors = 0
+    start = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(update_registry_chunk, d): d for d in dlnrs}
+        done = 0
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result[0] == 'ok':
+                total += result[2]
+            else:
+                errors += 1
+            if done % 50 == 0:
+                log(f"  Progress: {done}/{len(dlnrs)} (+{total:,} updated, {errors} errors)")
+
+    dur = int(time.monotonic() - start)
+    log(f"  Phase 3 DONE: +{total:,} registry entries updated, {errors} errors ({dur}s / {dur//60}min)")
+    return total
+
+
+def run_fix_sequence():
+    """Fix pieces_piece_id_seq after bulk insert."""
+    log("\n=== Fix sequence ===")
+    conn = get_conn(60000)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("SELECT setval('pieces_piece_id_seq', (SELECT max(piece_id) + 1 FROM pieces))")
+    val = cur.fetchone()[0]
+    log(f"  Sequence reset to {val}")
+    cur.close()
+    conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Register & Create Pieces from TecDoc')
+    parser.add_argument('--phase1', action='store_true', help='Register articles in article_registry')
+    parser.add_argument('--phase2', action='store_true', help='Create missing pieces')
+    parser.add_argument('--phase3', action='store_true', help='Update registry with new piece_ids')
+    parser.add_argument('--all', action='store_true', help='All phases')
+    parser.add_argument('--workers', type=int, default=6, help='Parallel workers (default: 6)')
+    args = parser.parse_args()
+
+    if not any([args.phase1, args.phase2, args.phase3, args.all]):
+        parser.print_help()
+        sys.exit(1)
+
+    results = {}
+
+    if args.all or args.phase1:
+        results['registered'] = run_phase1(args.workers)
+
+    if args.all or args.phase2:
+        results['pieces_created'] = run_phase2(args.workers)
+        run_fix_sequence()
+
+    if args.all or args.phase3:
+        results['registry_updated'] = run_phase3(args.workers)
+
+    log("\n=== BILAN FINAL ===")
+    for k, v in results.items():
+        log(f"  {k}: +{v:,}")
+    log("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tecdoc_identity_guard.py
+++ b/scripts/tecdoc_identity_guard.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Garde d'identite TecDoc — un identifiant attribue ne se reattribue jamais.
+
+Ce que cette garde protege
+--------------------------
+La campagne de mars 2026 a cree des entites applicatives qui sont aujourd'hui SERVIES
+et INDEXEES : 23 457 types vehicule (auto_type 60000-83456), 7 088 modeles,
+119 702 pieces, 876 gammes (pieces_gamme 60000-61103). Leurs identifiants sont
+references par des URL, des relations, des medias et des mappings.
+
+Un rejeu qui recalculerait ces identifiants « proprement » les renumeroterait. Les URL
+casseraient, les relations pointeraient a cote, et le mal serait fait avant qu'un
+humain le voie. Le risque n'est pas theorique : la copie DEV de `fix-vehicles-massdoc.py`
+(anterieure a la version versionnee) contient
+`DROP TABLE IF EXISTS tecdoc_map.modele_id_remap` suivi d'un CREATE + INSERT qui
+reattribue les identifiants de modele par ROW_NUMBER.
+
+Les trois interdits, verifies separement
+----------------------------------------
+1. DERIVE      — une cle deja mappee change d'identifiant interne.
+2. REEMPLOI    — un identifiant deja pris par une cle est propose pour une AUTRE cle.
+3. COLLISION   — une cle nouvelle recoit un identifiant deja attribue.
+
+Une cle nouvelle qui recoit un identifiant libre est LEGITIME : c'est ainsi qu'un rejeu
+source-truth ajoute ce que le chargement de mars avait perdu. La garde ne s'y oppose pas.
+
+Une cle qui DISPARAIT du mapping propose n'est pas une violation d'identite en soi
+(le rejeu peut etre partiel), mais elle est signalee : `absentes`. C'est au verificateur
+de conservation (`tecdoc_preservation.py`) de dire si cette absence est acceptable.
+
+Usage
+-----
+    from tecdoc_identity_guard import verifier_mapping, IdentiteViolee
+
+    existant = {"KTYP:12345": 60050, "KTYP:12346": 60051}
+    propose  = {"KTYP:12345": 60050, "KTYP:12346": 60051, "KTYP:99999": 83457}
+    rapport  = verifier_mapping(existant, propose)   # OK, 1 ajout
+
+    verifier_mapping(existant, {"KTYP:12345": 70000})   # leve : DERIVE
+
+Codes de sortie CLI : 0 conforme · 3 fichier illisible · 6 identite violee.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class IdentiteViolee(RuntimeError):
+    """Un identifiant deja attribue serait modifie ou reattribue — rejeu REFUSE."""
+
+
+@dataclass(frozen=True)
+class RapportIdentite:
+    """Resultat d'une comparaison de mappings. N'existe que si aucun interdit n'est viole."""
+
+    registre: str
+    conservees: int
+    ajoutees: int
+    absentes: tuple
+
+    def __str__(self) -> str:
+        s = (f"{self.registre} : {self.conservees} identites conservees, "
+             f"{self.ajoutees} nouvelles")
+        if self.absentes:
+            s += f", {len(self.absentes)} absentes du rejeu"
+        return s
+
+
+def verifier_mapping(existant: dict, propose: dict, *,
+                     registre: str = "mapping") -> RapportIdentite:
+    """Verifie qu'aucune identite deja attribuee n'est modifiee ni reattribuee.
+
+    Args:
+        existant: mapping en place, {cle source: identifiant interne}.
+        propose: mapping que le rejeu produirait.
+        registre: nom du registre, pour les messages.
+
+    Returns:
+        RapportIdentite si les trois interdits sont respectes.
+
+    Raises:
+        IdentiteViolee: derive, reemploi ou collision. Ne jamais « corriger » en
+            alignant l'existant sur le propose : c'est l'existant qui fait foi.
+    """
+    derives = [
+        (cle, existant[cle], propose[cle])
+        for cle in existant
+        if cle in propose and propose[cle] != existant[cle]
+    ]
+    if derives:
+        detail = "\n".join(
+            f"    {cle} : {avant} -> {apres}" for cle, avant, apres in derives[:10]
+        )
+        suite = f"\n    … et {len(derives) - 10} autres" if len(derives) > 10 else ""
+        raise IdentiteViolee(
+            f"{registre} : DERIVE — {len(derives)} identite(s) deja attribuee(s) "
+            f"changeraient de valeur.\n{detail}{suite}\n"
+            "STOP. Ces identifiants sont references par des URL, des relations et des "
+            "medias en production. L'existant fait foi, jamais le recalcul."
+        )
+
+    #: identifiant -> cle, pour l'existant. Sert a detecter reemploi et collision.
+    par_id = {}
+    for cle, ident in existant.items():
+        par_id.setdefault(ident, cle)
+
+    reemplois, collisions = [], []
+    for cle, ident in propose.items():
+        if cle in existant:
+            continue
+        proprietaire = par_id.get(ident)
+        if proprietaire is None:
+            continue
+        (reemplois if proprietaire != cle else collisions).append((cle, ident, proprietaire))
+
+    if reemplois or collisions:
+        lignes = "\n".join(
+            f"    identifiant {ident} appartient deja a {ancien}, propose pour {cle}"
+            for cle, ident, ancien in (reemplois + collisions)[:10]
+        )
+        raise IdentiteViolee(
+            f"{registre} : REEMPLOI — {len(reemplois) + len(collisions)} identifiant(s) "
+            f"deja attribue(s) seraient donnes a une autre entite.\n{lignes}\n"
+            "STOP. Reutiliser un identifiant fait pointer d'anciennes references vers "
+            "une entite differente — la corruption la plus difficile a detecter."
+        )
+
+    return RapportIdentite(
+        registre=registre,
+        conservees=sum(1 for c in existant if c in propose),
+        ajoutees=sum(1 for c in propose if c not in existant),
+        absentes=tuple(sorted(c for c in existant if c not in propose)),
+    )
+
+
+REGISTRES_PROTEGES = (
+    "tecdoc_map.type_id_remap",
+    "tecdoc_map.article_registry",
+    "tecdoc_map.linkage_target_registry",
+    "tecdoc_map.pg_id_remap",
+    "tecdoc_map.modele_id_remap",
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--existant", required=True, help="JSON {cle: id} en place")
+    ap.add_argument("--propose", required=True, help="JSON {cle: id} que le rejeu produirait")
+    ap.add_argument("--registre", default="mapping")
+    a = ap.parse_args(argv)
+
+    try:
+        existant = json.loads(Path(a.existant).read_text(encoding="utf-8"))
+        propose = json.loads(Path(a.propose).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"illisible : {e}", file=sys.stderr)
+        return 3
+
+    try:
+        rapport = verifier_mapping(existant, propose, registre=a.registre)
+    except IdentiteViolee as e:
+        print(f"REFUS :\n{e}", file=sys.stderr)
+        return 6
+
+    print(rapport)
+    if rapport.absentes:
+        print(f"\nAVERTISSEMENT : {len(rapport.absentes)} cle(s) absente(s) du rejeu. "
+              "L'identite n'est pas violee, mais la conservation doit etre verifiee "
+              "separement (scripts/tecdoc_preservation.py).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tecdoc_load_guard.py
+++ b/scripts/tecdoc_load_guard.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Garde de completude du chargement TecDoc — rend impossible la perte silencieuse.
+
+Le defaut que cette garde existe pour empecher
+----------------------------------------------
+En mars 2026, le chargement de `tecdoc_raw.t400` a perdu des lignes en masse sans
+qu'aucun signal ne soit emis. Mesure du 2026-09-08, en confrontant les fichiers `.meta`
+du parseur au contenu reel de la base :
+
+    DLNR 123  NISSENS   parseur    790 974 -> base       100   (99,99 % perdu)
+    DLNR 30   BOSCH     parseur  9 357 752 -> base    69 000   (99,26 % perdu)
+    DLNR 101  FEBI      parseur 17 421 432 -> base 2 558 500   (85,31 % perdu)
+    DLNR 6358 RIDEX     parseur  5 662 767 -> base 2 323 000   (58,98 % perdu)
+    DLNR 113  PAYEN     parseur  1 259 429 -> base 1 085 500   (13,81 % perdu)
+
+Les 66 fichiers `.meta` declarent tous `rows_rejected=0`. Le parseur n'a donc rien
+rejete : la perte s'est produite AU CHARGEMENT, et le lot a ete considere comme reussi.
+
+L'invariant
+-----------
+    emis == charges + dedoublonnes + somme(rejets par raison)
+
+Toute ligne lue par le parseur doit se retrouver dans exactement une categorie, et
+chaque categorie doit etre COMPTEE et NOMMEE. Un ecart, meme d'une ligne, meme
+favorable, fait echouer le lot : STOP, pas de projection.
+
+Pourquoi les rejets sont un dictionnaire et non un entier
+---------------------------------------------------------
+Un compteur global de rejets se solde tout seul : il suffit d'y verser l'ecart pour
+que l'egalite tienne, et la garde devient decorative. Exiger une RAISON par rejet
+oblige a nommer ce qu'on jette. Une raison vide, blanche ou generique
+(« autre », « erreur », « inconnu ») est refusee : elle rouvrirait cette porte.
+
+Usage bibliotheque
+------------------
+    from tecdoc_load_guard import verifier_lot, ComptabiliteIncoherente
+
+    verifier_lot(dlnr=21, emis=790_974, charges=790_974)                  # PASS
+    verifier_lot(dlnr=30, emis=9_357_752, charges=69_000)                 # LEVE
+    verifier_lot(dlnr=101, emis=100, charges=90,
+                 rejets={"ktypnr_absent_du_registre": 10})                # PASS
+
+Usage CLI
+---------
+    python3 scripts/tecdoc_load_guard.py --rapport rapport-de-lot.json
+
+Codes de sortie : 0 lots equilibres · 3 rapport illisible · 5 lot incoherent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Raisons refusees : elles ne nomment rien et permettraient de solder l'ecart.
+RAISONS_INTERDITES = {
+    "", "autre", "autres", "erreur", "erreurs", "inconnu", "inconnue",
+    "divers", "reste", "n/a", "na", "none", "null", "other", "unknown", "misc",
+}
+
+
+class ComptabiliteIncoherente(RuntimeError):
+    """Le lot ne se solde pas — chargement REFUSE, projection interdite."""
+
+
+@dataclass(frozen=True)
+class Bilan:
+    """Compte rendu d'un lot equilibre. N'existe que si la garde est passee."""
+
+    dlnr: int | None
+    emis: int
+    charges: int
+    dedoublonnes: int
+    rejets: dict = field(default_factory=dict)
+
+    @property
+    def rejetes(self) -> int:
+        return sum(self.rejets.values())
+
+    @property
+    def taux_charge(self) -> float:
+        return 0.0 if self.emis == 0 else self.charges / self.emis
+
+    def __str__(self) -> str:
+        cible = f"DLNR {self.dlnr}" if self.dlnr is not None else "lot"
+        detail = ""
+        if self.dedoublonnes:
+            detail += f" · {self.dedoublonnes} dedoublonnes"
+        for raison, n in sorted(self.rejets.items()):
+            detail += f" · {n} rejets[{raison}]"
+        return (f"{cible} : {self.emis} emis = {self.charges} charges{detail}"
+                f"  ({self.taux_charge:.2%} charge)")
+
+
+def _valider_entier(nom: str, valeur) -> int:
+    if isinstance(valeur, bool) or not isinstance(valeur, int):
+        raise ComptabiliteIncoherente(
+            f"{nom} doit etre un entier, recu {type(valeur).__name__} ({valeur!r}). "
+            "Un compteur approximatif ne prouve rien."
+        )
+    if valeur < 0:
+        raise ComptabiliteIncoherente(f"{nom} est negatif ({valeur}) — compteur corrompu.")
+    return valeur
+
+
+def verifier_lot(*, emis: int, charges: int, dedoublonnes: int = 0,
+                 rejets: dict | None = None, dlnr: int | None = None) -> Bilan:
+    """Verifie qu'un lot de chargement se solde exactement. Leve sinon.
+
+    Args:
+        emis: lignes emises par le parseur (`rows_emitted` du fichier .meta).
+        charges: lignes reellement presentes en base apres le chargement.
+        dedoublonnes: lignes volontairement fusionnees, comptees explicitement.
+        rejets: {raison: nombre}. Chaque raison doit nommer un motif reel.
+        dlnr: fournisseur concerne, pour le message d'erreur.
+
+    Returns:
+        Bilan, uniquement si le lot est equilibre.
+
+    Raises:
+        ComptabiliteIncoherente: des que l'egalite ne tient pas, ou qu'un rejet n'est
+            pas motive. La bonne reaction est de STOPPER, jamais d'ajuster un compteur
+            pour faire tenir l'egalite.
+    """
+    emis = _valider_entier("emis", emis)
+    charges = _valider_entier("charges", charges)
+    dedoublonnes = _valider_entier("dedoublonnes", dedoublonnes)
+
+    propres: dict = {}
+    for raison, n in dict(rejets or {}).items():
+        cle = str(raison).strip()
+        if cle.lower() in RAISONS_INTERDITES:
+            raise ComptabiliteIncoherente(
+                f"raison de rejet non recevable : {raison!r}. "
+                "Une categorie fourre-tout permet de solder n'importe quel ecart et "
+                "vide la garde de son sens — nommer le motif reel."
+            )
+        propres[cle] = _valider_entier(f"rejets[{cle}]", n)
+
+    total = charges + dedoublonnes + sum(propres.values())
+    if total != emis:
+        ecart = emis - total
+        cible = f"DLNR {dlnr}" if dlnr is not None else "lot"
+        sens = "manquantes" if ecart > 0 else "en trop"
+        part = f" ({abs(ecart) / emis:.2%} du lot)" if emis else ""
+        raise ComptabiliteIncoherente(
+            f"{cible} : le lot ne se solde pas.\n"
+            f"  emis         : {emis}\n"
+            f"  charges      : {charges}\n"
+            f"  dedoublonnes : {dedoublonnes}\n"
+            f"  rejets       : {sum(propres.values())} {propres}\n"
+            f"  ECART        : {abs(ecart)} lignes {sens}{part}\n"
+            "STOP — chargement refuse, projection interdite. C'est exactement le defaut "
+            "de mars 2026 (BOSCH : 9 357 752 emis, 69 000 charges, statut OK)."
+        )
+
+    return Bilan(dlnr=dlnr, emis=emis, charges=charges,
+                 dedoublonnes=dedoublonnes, rejets=propres)
+
+
+def verifier_rapport(rapport: dict) -> list[Bilan]:
+    """Verifie tous les lots d'un rapport. Leve au PREMIER lot incoherent.
+
+    Format attendu :
+        {"lots": [{"dlnr": 21, "emis": 100, "charges": 100,
+                   "dedoublonnes": 0, "rejets": {"motif": 0}}, ...]}
+    """
+    lots = rapport.get("lots")
+    if not isinstance(lots, list):
+        raise ComptabiliteIncoherente(
+            "rapport sans liste 'lots' — rien n'est verifiable. "
+            "Un rapport vide n'est pas un rapport vert."
+        )
+    if not lots:
+        raise ComptabiliteIncoherente(
+            "rapport a zero lot. Un chargement qui n'a rien charge doit le declarer "
+            "explicitement, pas se presenter comme un succes vide."
+        )
+    return [
+        verifier_lot(
+            dlnr=lot.get("dlnr"),
+            emis=lot["emis"],
+            charges=lot["charges"],
+            dedoublonnes=lot.get("dedoublonnes", 0),
+            rejets=lot.get("rejets"),
+        )
+        for lot in lots
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--rapport", required=True,
+                    help="rapport de chargement JSON ({'lots': [...]})")
+    a = ap.parse_args(argv)
+
+    try:
+        rapport = json.loads(Path(a.rapport).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"rapport illisible : {e}", file=sys.stderr)
+        return 3
+
+    try:
+        bilans = verifier_rapport(rapport)
+    except ComptabiliteIncoherente as e:
+        print(f"REFUS :\n{e}", file=sys.stderr)
+        return 5
+
+    for b in bilans:
+        print(b)
+    print(f"\n{len(bilans)} lot(s) equilibre(s) — chargement recevable.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tecdoc_preservation.py
+++ b/scripts/tecdoc_preservation.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Verificateur de conservation TecDoc — AVANT == APRES, ou STOP.
+
+Ce que ce module fait respecter
+-------------------------------
+`audit/massdoc-tecdoc-preservation-manifest-2026-03.json` fige, par empreinte MD5
+calculee cote serveur, les 9 ensembles applicatifs que la campagne TecDoc de mars 2026
+a produits et que MassDoc sert aujourd'hui. L'invariant inscrit dans le manifeste :
+
+    AVANT cleanup == APRES cleanup, pour chaque ensemble.
+    Un seul ecart => VERDICT ECHEC, STOP, aucun DROP suivant.
+
+Ce module rejoue les empreintes et compare. Il ne repare rien et ne propose rien : un
+ecart est un verdict, pas un point de depart de negociation.
+
+Fail-closed sur trois points
+----------------------------
+1. Sceau du manifeste verifie avant toute lecture (tecdoc_seal).
+2. Un ensemble SANS mesure fournie est un ECHEC, pas un « ignore ». Une conservation
+   qu'on ne mesure pas n'est pas une conservation constatee.
+3. Une mesure incomplete (empreinte absente) est un ECHEC : compter les lignes ne dit
+   pas que ce sont les MEMES lignes.
+
+Deux facons de fournir les mesures
+----------------------------------
+    --mesures fichier.json   mesures deja prises (permet de tester hors base)
+    --dsn postgresql://...   les prend en rejouant les requetes du manifeste
+
+Codes de sortie : 0 conservation intacte · 3 illisible · 7 conservation rompue.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from tecdoc_seal import SceauInvalide, verifier as _verifier_sceau
+
+#: Champs compares. L'empreinte est la seule preuve d'identite du CONTENU ; le cardinal
+#: et les bornes servent a rendre un ecart lisible (« 3 lignes manquent » plutot que
+#: « le hash a change »).
+CHAMPS = ("cardinal", "borne_min", "borne_max", "empreinte_md5")
+
+#: Requetes d'empreinte, une par ensemble, VERIFIEES contre la PROD le 2026-09-08 :
+#: chacune reproduit exactement le `empreinte_md5` scelle dans le manifeste.
+#:
+#: Pourquoi une table explicite plutot qu'une derivation depuis le manifeste
+#: -------------------------------------------------------------------------
+#: `methode_de_controle` documente la forme
+#:     SELECT count(*), min(<cle>), max(<cle>), md5(string_agg(<cle>::text, ',' ORDER BY <cle>))
+#: qui est SOUS-SPECIFIEE pour les entrees a cle composite. Une derivation naive a ete
+#: ecrite, puis rejetee apres confrontation a la base : sur `gamme_registry`, ordonner
+#: par l'expression texte `pg_id_source||'>'||pg_id` donne
+#: 64816aa0aef69d7a702725350a5bbafe, alors que le manifeste porte
+#: 0a2ef785f1b820e7405f375819450a96 — obtenu en ordonnant par `pg_id_source` NUMERIQUE.
+#: Meme cardinal (9702), empreinte differente : un tri texte place "1000" avant "2".
+#: Sur `type_id_remap` la derivation tombait juste par accident, tous les `old_id` ayant
+#: six chiffres, donc ordre texte == ordre numerique.
+#:
+#: Une requete devinee qui tombe juste par hasard sur 8 cas sur 9 est plus dangereuse
+#: qu'une table ecrite : elle ferait un jour echouer un controle de conservation sur une
+#: base pourtant intacte, et l'ecart serait attribue a la donnee.
+REQUETES = {
+    "auto_type — types crees/remappes par la campagne": """
+        SELECT count(*), min(type_id_i), max(type_id_i),
+               md5(string_agg(type_id_i::text, ',' ORDER BY type_id_i))
+        FROM public.auto_type WHERE type_id_i BETWEEN 60000 AND 83456""",
+    "auto_modele — modeles ajoutes": """
+        SELECT count(*), min(modele_id), max(modele_id),
+               md5(string_agg(modele_id::text, ',' ORDER BY modele_id))
+        FROM public.auto_modele WHERE modele_is_new::text = '1'""",
+    "pieces — cohorte introduite par la campagne": """
+        SELECT count(*), min(piece_id), max(piece_id),
+               md5(string_agg(piece_id::text, ',' ORDER BY piece_id))
+        FROM public.pieces WHERE piece_year::text = '2025'""",
+    "pieces — sous-ensemble affiche de la cohorte": """
+        SELECT count(*), min(piece_id), max(piece_id),
+               md5(string_agg(piece_id::text, ',' ORDER BY piece_id))
+        FROM public.pieces WHERE piece_year::text = '2025' AND piece_display""",
+    "pieces_gamme — gammes creees par la campagne (bande reservee)": """
+        SELECT count(*), min(pg_id), max(pg_id),
+               md5(string_agg(pg_id::text, ',' ORDER BY pg_id))
+        FROM public.pieces_gamme WHERE pg_id >= 60000""",
+    "tecdoc_map.type_id_remap — mapping d'identite vehicule (ancien -> nouveau)": """
+        SELECT count(*), min(old_id), max(old_id),
+               md5(string_agg(old_id||'>'||new_id, ',' ORDER BY old_id))
+        FROM tecdoc_map.type_id_remap""",
+    "tecdoc_map.gamme_registry — filiation gamme source -> pg_id": """
+        SELECT count(*), min(pg_id), max(pg_id),
+               md5(string_agg(pg_id_source||'>'||pg_id, ',' ORDER BY pg_id_source))
+        FROM tecdoc_map.gamme_registry WHERE pg_id IS NOT NULL""",
+    "tecdoc_map.linkage_target_registry — cibles de liaison": """
+        SELECT count(*), min(id), max(id),
+               md5(string_agg(id::text, ',' ORDER BY id))
+        FROM tecdoc_map.linkage_target_registry""",
+    # Rollup : un string_agg sur les 3,24 M identifiants batirait une chaine de ~50 Mo
+    # cote serveur. L'empreinte porte donc sur l'agregat par source_dlnr (229 groupes),
+    # et les bornes sont NULL dans le manifeste — d'ou le NULL::int explicite ici.
+    "tecdoc_map.article_registry — ancrage piece_id <-> ARTNR/DLNR": """
+        WITH r AS (SELECT source_dlnr, count(*) AS n
+                   FROM tecdoc_map.article_registry GROUP BY source_dlnr)
+        SELECT (SELECT count(*) FROM tecdoc_map.article_registry),
+               NULL::int, NULL::int,
+               md5(string_agg(source_dlnr||':'||n, ',' ORDER BY source_dlnr))
+        FROM r""",
+}
+
+
+class ConservationRompue(RuntimeError):
+    """Au moins un ensemble applicatif a change — STOP, aucun DROP suivant."""
+
+
+@dataclass(frozen=True)
+class Ecart:
+    ensemble: str
+    champ: str
+    attendu: object
+    obtenu: object
+
+    def __str__(self) -> str:
+        return f"{self.ensemble} · {self.champ} : attendu {self.attendu!r}, obtenu {self.obtenu!r}"
+
+
+def charger_manifeste(chemin: str | Path) -> dict:
+    """Charge le manifeste et verifie son sceau. Leve SceauInvalide si altere."""
+    p = Path(chemin)
+    document = json.loads(p.read_text(encoding="utf-8"))
+    _verifier_sceau(document, source=str(p))
+    return document
+
+
+def requete_empreinte(ensemble: dict) -> str:
+    """Rend la requete d'empreinte VERIFIEE de cet ensemble.
+
+    Raises:
+        KeyError: si le manifeste contient un ensemble sans requete verifiee. C'est
+            volontairement une erreur et non un saut : mesurer 8 ensembles sur 9 et
+            annoncer « conservation intacte » serait un faux vert.
+    """
+    nom = _nom(ensemble)
+    try:
+        return " ".join(REQUETES[nom].split())
+    except KeyError:
+        raise KeyError(
+            f"aucune requete d'empreinte verifiee pour {nom!r}. Ajouter la requete a "
+            "REQUETES APRES avoir verifie qu'elle reproduit l'empreinte du manifeste — "
+            "jamais l'inverse."
+        ) from None
+
+
+def _nom(ensemble: dict) -> str:
+    return ensemble.get("nom") or f"{ensemble['table']} [{ensemble.get('filtre', '')}]"
+
+
+def comparer(manifeste: dict, mesures: dict) -> list[Ecart]:
+    """Compare les mesures fournies aux valeurs figees. Rend la liste des ecarts.
+
+    Args:
+        manifeste: document deja charge et scelle-verifie.
+        mesures: {nom d'ensemble: {cardinal, borne_min, borne_max, empreinte_md5}}.
+            Le nom est celui du champ `nom` du manifeste.
+
+    Returns:
+        Liste d'Ecart, vide si la conservation est intacte.
+    """
+    ecarts: list[Ecart] = []
+    for ensemble in manifeste["ensembles_figes"]:
+        nom = _nom(ensemble)
+        mesure = mesures.get(nom)
+        if mesure is None:
+            ecarts.append(Ecart(nom, "mesure", "fournie", "ABSENTE"))
+            continue
+        if not mesure.get("empreinte_md5"):
+            ecarts.append(Ecart(nom, "empreinte_md5", ensemble.get("empreinte_md5"), "ABSENTE"))
+        for champ in CHAMPS:
+            if champ not in ensemble or champ not in mesure:
+                continue
+            if ensemble[champ] != mesure[champ]:
+                ecarts.append(Ecart(nom, champ, ensemble[champ], mesure[champ]))
+    return ecarts
+
+
+def verifier(manifeste: dict, mesures: dict) -> int:
+    """Leve ConservationRompue au moindre ecart. Rend le nombre d'ensembles verifies."""
+    ecarts = comparer(manifeste, mesures)
+    if ecarts:
+        detail = "\n".join(f"    {e}" for e in ecarts)
+        raise ConservationRompue(
+            f"CONSERVATION ROMPUE — {len(ecarts)} ecart(s) :\n{detail}\n\n"
+            "VERDICT : ECHEC. STOP. Aucun DROP suivant.\n"
+            "Ces ensembles sont les vehicules, modeles, pieces, gammes et mappings que "
+            "la campagne de mars 2026 a crees et que MassDoc sert aujourd'hui. Le but du "
+            "nettoyage est de retirer la matiere intermediaire reconstructible, jamais "
+            "ces resultats."
+        )
+    return len(manifeste["ensembles_figes"])
+
+
+def mesurer(manifeste: dict, dsn: str) -> dict:
+    """Prend les mesures en base. LECTURE SEULE — que des SELECT."""
+    import psycopg2  # import tardif : la mesure hors-ligne ne doit rien exiger
+
+    mesures: dict = {}
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        for ensemble in manifeste["ensembles_figes"]:
+            cur.execute(requete_empreinte(ensemble))
+            cardinal, bmin, bmax, empreinte = cur.fetchone()
+            mesures[_nom(ensemble)] = {
+                "cardinal": cardinal,
+                "borne_min": bmin,
+                "borne_max": bmax,
+                "empreinte_md5": empreinte,
+            }
+    return mesures
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--manifest", required=True)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--mesures", help="mesures deja prises (JSON)")
+    src.add_argument("--dsn", help="prendre les mesures en base (lecture seule)")
+    ap.add_argument("--ecrire-mesures", help="ecrire les mesures prises dans ce fichier")
+    a = ap.parse_args(argv)
+
+    try:
+        manifeste = charger_manifeste(a.manifest)
+    except SceauInvalide as e:
+        print(f"REFUS : {e}", file=sys.stderr)
+        return 2
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"illisible : {e}", file=sys.stderr)
+        return 3
+
+    if a.mesures:
+        try:
+            mesures = json.loads(Path(a.mesures).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"mesures illisibles : {e}", file=sys.stderr)
+            return 3
+    else:
+        mesures = mesurer(manifeste, a.dsn)
+        if a.ecrire_mesures:
+            Path(a.ecrire_mesures).write_text(
+                json.dumps(mesures, indent=2, ensure_ascii=False, sort_keys=True),
+                encoding="utf-8")
+
+    try:
+        n = verifier(manifeste, mesures)
+    except ConservationRompue as e:
+        print(str(e), file=sys.stderr)
+        return 7
+
+    print(f"conservation intacte — {n} ensembles applicatifs identiques au manifeste.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tecdoc_reconcile.py
+++ b/scripts/tecdoc_reconcile.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Reconciliation rejeu <-> PROD, et mise en quarantaine de ce que la source ajoute.
+
+Le probleme que ce module resout
+--------------------------------
+La decision owner du 2026-09-08 est que le futur rejeu suive la SOURCE TecDoc, pas le
+defaut de chargement historique. Consequence mecanique : pour NISSENS, BOSCH, FEBI,
+RIDEX et PAYEN, un rejeu fidele a la source produira BEAUCOUP plus de lignes que la
+PROD actuelle — jusqu'a 790 974 la ou la base en porte 100.
+
+Ces lignes supplementaires sont probablement legitimes. « Probablement » ne suffit pas
+pour les afficher, les activer, les publier ou les indexer : ce sont des pieces vues
+par des clients et des URL vues par Google. Elles vont donc en QUARANTAINE, et un
+humain decide.
+
+L'invariant de l'owner, formule en ensembles :
+
+    PROD actuelle  ⊆  REBUILD source-truth
+
+et non `PROD actuelle == REBUILD`. Ce module verifie l'inclusion et non l'egalite.
+
+Les quatre categories
+---------------------
+    EXISTING_PROD    la cle existe des deux cotes, avec la MEME valeur. Rien a faire.
+    NEW_FROM_SOURCE  la cle n'existe qu'au rejeu. QUARANTAINE — jamais activee d'office.
+    CONFLICT         la cle existe des deux cotes avec des valeurs DIFFERENTES.
+                     C'est le cas le plus grave : la PROD dit une chose, la source une
+                     autre. Ni ecrasement, ni ignorance — arbitrage humain.
+    UNKNOWN          la valeur manque d'un cote. Indecidable, donc traite comme du
+                     CONFLICT du point de vue de l'activation : jamais active.
+
+Une cinquieme grandeur est rapportee a part : `absentes_du_rejeu`, les cles presentes
+en PROD que le rejeu n'a pas reproduites. Ce n'est pas une categorie de quarantaine
+mais un signal de CONSERVATION : c'est exactement ce que l'invariant d'inclusion
+interdit. Sa presence rend `inclusion_respectee` faux.
+
+Usage
+-----
+    from tecdoc_reconcile import reconcilier, a_activer, ActivationInterdite
+
+    rec = reconcilier(prod={"A": 1, "B": 2}, source={"A": 1, "B": 9, "C": 3})
+    rec.par_categorie["CONFLICT"]        # ['B']
+    rec.par_categorie["NEW_FROM_SOURCE"] # ['C']
+    a_activer(rec)                       # ['A'] — et rien d'autre
+
+Codes de sortie CLI : 0 inclusion respectee · 3 illisible · 8 inclusion rompue.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+CATEGORIES = ("EXISTING_PROD", "NEW_FROM_SOURCE", "CONFLICT", "UNKNOWN")
+
+#: Categories qui ne doivent JAMAIS etre activees, affichees, publiees ni indexees
+#: sans decision humaine explicite.
+QUARANTAINE = ("NEW_FROM_SOURCE", "CONFLICT", "UNKNOWN")
+
+
+class ActivationInterdite(RuntimeError):
+    """On a tente d'activer des elements sous quarantaine — refus."""
+
+
+@dataclass(frozen=True)
+class Reconciliation:
+    """Comparaison d'un rejeu a la PROD, pour un DLNR ou globalement."""
+
+    dlnr: int | None
+    par_categorie: dict = field(default_factory=dict)
+    absentes_du_rejeu: tuple = ()
+
+    @property
+    def inclusion_respectee(self) -> bool:
+        """Vrai si PROD ⊆ REBUILD : rien de ce que sert la PROD n'a disparu.
+
+        Un CONFLICT compte comme une rupture d'inclusion : la cle existe des deux
+        cotes, mais ce que la PROD sert n'est PAS ce que le rejeu produirait.
+        """
+        return not self.absentes_du_rejeu and not self.par_categorie.get("CONFLICT")
+
+    def total(self, categorie: str) -> int:
+        return len(self.par_categorie.get(categorie, ()))
+
+    def resume(self) -> dict:
+        """La forme demandee pour le rapport de dry-run."""
+        return {
+            "dlnr": self.dlnr,
+            "lignes_source_attendues": sum(self.total(c) for c in
+                                           ("EXISTING_PROD", "NEW_FROM_SOURCE",
+                                            "CONFLICT", "UNKNOWN")),
+            "lignes_prod_actuelles": (self.total("EXISTING_PROD") + self.total("CONFLICT")
+                                      + self.total("UNKNOWN") + len(self.absentes_du_rejeu)),
+            "absentes_de_prod": self.total("NEW_FROM_SOURCE"),
+            "en_trop_dans_prod": len(self.absentes_du_rejeu),
+            "conflits": self.total("CONFLICT"),
+            "indecidables": self.total("UNKNOWN"),
+            "identites_conservees": self.total("EXISTING_PROD"),
+            "candidats_en_quarantaine": sum(self.total(c) for c in QUARANTAINE),
+            "inclusion_respectee": self.inclusion_respectee,
+        }
+
+    def __str__(self) -> str:
+        cible = f"DLNR {self.dlnr}" if self.dlnr is not None else "global"
+        parts = " · ".join(f"{c}={self.total(c)}" for c in CATEGORIES)
+        etat = "inclusion OK" if self.inclusion_respectee else "INCLUSION ROMPUE"
+        return f"{cible} : {parts} · absentes_du_rejeu={len(self.absentes_du_rejeu)} · {etat}"
+
+
+def reconcilier(prod: dict, source: dict, *, dlnr: int | None = None) -> Reconciliation:
+    """Classe chaque cle des deux cotes dans une des quatre categories.
+
+    Args:
+        prod: etat servi aujourd'hui, {cle: valeur}.
+        source: etat qu'un rejeu source-truth produirait, {cle: valeur}.
+        dlnr: fournisseur concerne, pour le rapport.
+
+    Returns:
+        Reconciliation. Ne leve jamais : classer n'est pas juger. C'est `a_activer`
+        qui refuse, et `inclusion_respectee` qui alerte.
+    """
+    par: dict = {c: [] for c in CATEGORIES}
+    for cle, valeur_src in source.items():
+        if cle not in prod:
+            par["NEW_FROM_SOURCE"].append(cle)
+            continue
+        valeur_prod = prod[cle]
+        if valeur_prod is None or valeur_src is None:
+            par["UNKNOWN"].append(cle)
+        elif valeur_prod == valeur_src:
+            par["EXISTING_PROD"].append(cle)
+        else:
+            par["CONFLICT"].append(cle)
+
+    return Reconciliation(
+        dlnr=dlnr,
+        par_categorie={c: sorted(v, key=str) for c, v in par.items()},
+        absentes_du_rejeu=tuple(sorted((c for c in prod if c not in source), key=str)),
+    )
+
+
+def a_activer(rec: Reconciliation, *, inclure_quarantaine: bool = False) -> list:
+    """Rend ce qui peut etre active sans decision humaine : EXISTING_PROD, et rien d'autre.
+
+    Raises:
+        ActivationInterdite: si l'appelant demande explicitement d'inclure la
+            quarantaine. Le drapeau existe pour que cette demande soit ECRITE dans le
+            code appelant et visible en revue, jamais pour etre honoree.
+    """
+    if inclure_quarantaine:
+        sous_quarantaine = sum(rec.total(c) for c in QUARANTAINE)
+        raise ActivationInterdite(
+            f"activation de {sous_quarantaine} element(s) sous quarantaine refusee "
+            f"({', '.join(f'{c}={rec.total(c)}' for c in QUARANTAINE)}).\n"
+            "Les donnees qu'un rejeu source-truth ajoute ne sont ni affichees, ni "
+            "activees, ni publiees, ni indexees d'office : elles sont vues par des "
+            "clients et par Google. Decision humaine, explicite, tracee."
+        )
+    return list(rec.par_categorie.get("EXISTING_PROD", ()))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--prod", required=True, help="JSON {cle: valeur} servi aujourd'hui")
+    ap.add_argument("--source", required=True, help="JSON {cle: valeur} produit par le rejeu")
+    ap.add_argument("--dlnr", type=int, default=None)
+    ap.add_argument("--quarantaine", help="ecrire les cles sous quarantaine dans ce fichier")
+    a = ap.parse_args(argv)
+
+    try:
+        prod = json.loads(Path(a.prod).read_text(encoding="utf-8"))
+        source = json.loads(Path(a.source).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"illisible : {e}", file=sys.stderr)
+        return 3
+
+    rec = reconcilier(prod, source, dlnr=a.dlnr)
+    print(json.dumps(rec.resume(), indent=2, ensure_ascii=False))
+
+    if a.quarantaine:
+        Path(a.quarantaine).write_text(
+            json.dumps({c: rec.par_categorie.get(c, []) for c in QUARANTAINE},
+                       indent=2, ensure_ascii=False, sort_keys=True),
+            encoding="utf-8")
+
+    if not rec.inclusion_respectee:
+        print(
+            f"\nINCLUSION ROMPUE : {len(rec.absentes_du_rejeu)} cle(s) servie(s) en PROD "
+            f"absente(s) du rejeu, {rec.total('CONFLICT')} conflit(s).\n"
+            "L'invariant est PROD ⊆ REBUILD. Un rejeu qui perd ou contredit ce que la "
+            "PROD sert deja n'est pas promouvable.", file=sys.stderr)
+        return 8
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tecdoc_scope.py
+++ b/scripts/tecdoc_scope.py
@@ -19,9 +19,26 @@ et chercherait VDO (4836), qui n'a jamais eu de shard source.
 Ce module lit a la place un artefact scelle et immuable, et REFUSE de servir un
 perimetre dont le sceau ne se verifie pas. Aucun repli silencieux.
 
+Deux modes, jamais confondus
+----------------------------
+Les scripts du pipeline n'ont plus le droit de deviner leur perimetre. Ils declarent
+lequel des deux ils veulent, et il n'existe aucun repli de l'un vers l'autre :
+
+    --scope-mode historical --scope-file <artefact scelle>
+        Rejouer mars 2026. L'artefact est OBLIGATOIRE ; son absence leve
+        PerimetreManquant. Retomber sur la requete vivante rejouerait le perimetre
+        de 2026-09 en croyant rejouer mars — c'est precisement le defaut a interdire.
+
+    --scope-mode current
+        Import courant, pilote par pieces_marque.pm_display. `--scope-file` y est
+        REFUSE : les deux sources se contrediraient, et l'appelant croirait rejouer
+        l'historique alors qu'il lit le vivant.
+
 Usage bibliotheque
 ------------------
-    from tecdoc_scope import charger_perimetre
+    from tecdoc_scope import charger_perimetre, resoudre_dlnr
+
+    dlnrs = resoudre_dlnr("historical", "audit/massdoc-tecdoc-import-scope-2026-03.json")
 
     scope = charger_perimetre("audit/massdoc-tecdoc-import-scope-2026-03.json")
     for dlnr in scope.dlnr_projetes():      # 110 — ce que mars 2026 a projete
@@ -40,25 +57,30 @@ Codes de sortie : 0 succes · 2 sceau invalide · 3 fichier illisible · 4 diver
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import sys
 from pathlib import Path
 
+from tecdoc_seal import SceauInvalide, verifier as _verifier_sceau
+
 VERSIONS_SUPPORTEES = {"2026-03-reconstructed-v1", "2026-03-reconstructed-v2"}
 
 
-class SceauInvalide(RuntimeError):
-    """Le hash recalcule ne correspond pas au hash declare — l'artefact a ete altere."""
+MODES = ("historical", "current")
+
+#: Re-exporte depuis tecdoc_seal : le sceau a UNE seule definition, partagee avec le
+#: manifeste de preservation. `except SceauInvalide` continue de fonctionner a l'identique.
+__all__ = ["MODES", "SceauInvalide", "PerimetreManquant", "Perimetre",
+           "charger_perimetre", "resoudre_dlnr", "ajouter_arguments_perimetre"]
 
 
-def _canonique(charge: dict) -> str:
-    """Serialisation canonique documentee dans l'artefact lui-meme.
+class PerimetreManquant(RuntimeError):
+    """Mode `historical` demande sans artefact scelle.
 
-    Doit rester STRICTEMENT identique a celle de scripts/tecdoc-scope-build/build_scope.py,
-    sinon le sceau ne se verifiera jamais.
+    On leve au lieu de retomber sur la requete vivante. Ce repli est exactement le
+    defaut que le mode `historical` existe pour empecher : il rejouerait un perimetre
+    de 2026-09 en croyant rejouer mars 2026.
     """
-    return json.dumps(charge, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
 
 class Perimetre:
@@ -133,31 +155,90 @@ def charger_perimetre(chemin: str | Path, *, verifier_sceau: bool = True) -> Per
         )
 
     if verifier_sceau:
-        sceau = document.get("seal")
-        if not sceau or "sha256" not in sceau:
-            raise SceauInvalide(f"{p} ne porte aucun sceau — refus de servir ce perimetre")
-        charge = {k: v for k, v in document.items() if k != "seal"}
-        calcule = hashlib.sha256(_canonique(charge).encode("utf-8")).hexdigest()
-        if calcule != sceau["sha256"]:
-            raise SceauInvalide(
-                f"sceau invalide pour {p}\n  declare  : {sceau['sha256']}\n  recalcule: {calcule}\n"
-                "L'artefact a ete modifie apres scellement. Rejeu REFUSE."
-            )
+        _verifier_sceau(document, source=str(p))
 
     return Perimetre(document, p)
+
+
+# ---------------------------------------------------------------------------
+# Resolution du perimetre — le point d'entree des scripts du pipeline
+# ---------------------------------------------------------------------------
+
+def ajouter_arguments_perimetre(ap: argparse.ArgumentParser) -> None:
+    """Ajoute `--scope-mode` et `--scope-file` a un parseur de script du pipeline.
+
+    Mutualise pour que les 16 scripts exposent EXACTEMENT la meme surface : un mode
+    divergent d'un script a l'autre serait une porte de rentree du defaut.
+    """
+    ap.add_argument(
+        "--scope-mode", choices=MODES, required=True,
+        help="historical = rejouer le perimetre fige de mars 2026 (--scope-file obligatoire) ; "
+             "current = importer le perimetre commercial du jour (requete vivante). "
+             "Aucune valeur par defaut : le mode doit etre choisi explicitement.",
+    )
+    ap.add_argument(
+        "--scope-file", default=None,
+        help="artefact scelle du perimetre. Obligatoire en mode historical, "
+             "interdit en mode current.",
+    )
+    ap.add_argument(
+        "--scope-selection", choices=["projetes", "charges"], default="projetes",
+        help="projetes = les 110 DLNR qui ont produit des source_linkages ; "
+             "charges = les 149 presents dans t400. Defaut : projetes.",
+    )
+
+
+def resoudre_dlnr(mode: str, scope_file: str | Path | None = None, *,
+                  selection: str = "projetes", dsn: str | None = None) -> list[int]:
+    """Rend la liste de DLNR a traiter, selon un mode EXPLICITE.
+
+    C'est la fonction qui remplace `get_active_dlnrs()` dans les scripts du pipeline.
+
+    Contrat, volontairement rigide :
+      * `historical` sans `scope_file`      -> PerimetreManquant. Jamais de repli.
+      * `historical` avec artefact altere   -> SceauInvalide (via charger_perimetre).
+      * `historical` avec version inconnue  -> SceauInvalide.
+      * `current` avec `scope_file`         -> ValueError : les deux sources se
+        contrediraient, et laisser passer reviendrait a ce que l'appelant croie
+        rejouer l'historique alors qu'il lit le vivant.
+    """
+    if mode not in MODES:
+        raise ValueError(f"mode de perimetre inconnu : {mode!r} (attendus : {list(MODES)})")
+
+    if mode == "historical":
+        if not scope_file:
+            raise PerimetreManquant(
+                "--scope-mode historical exige --scope-file.\n"
+                "Refus de deriver le perimetre de l'etat vivant : pieces_marque.pm_display "
+                "a change depuis mars 2026, un rejeu ainsi pilote perdrait DIEDERICHS (253) "
+                "et RIDEX (6358) et chercherait VDO (4836), qui n'a aucun shard source."
+            )
+        scope = charger_perimetre(scope_file)
+        return scope.dlnr_projetes() if selection == "projetes" else scope.dlnr_charges()
+
+    if scope_file:
+        raise ValueError(
+            "--scope-file est interdit avec --scope-mode current : l'artefact decrit "
+            "mars 2026, la requete vivante decrit aujourd'hui. Choisir l'un des deux."
+        )
+    return _dlnr_vivants(dsn)
 
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
-def _dlnr_vivants() -> list[int]:
-    """Rejoue la requete vivante de load-t400-active.py, pour comparaison uniquement."""
+def _dlnr_vivants(dsn: str | None = None) -> list[int]:
+    """Rejoue la requete vivante de load-t400-active.py.
+
+    Legitime pour un import courant et pour la comparaison ; JAMAIS pour un rejeu
+    historique — c'est `resoudre_dlnr` qui fait respecter cette distinction.
+    """
     import os
 
     import psycopg2  # import tardif : la comparaison est optionnelle
 
-    dsn = os.environ.get("DATABASE_URL")
+    dsn = dsn or os.environ.get("DATABASE_URL")
     if not dsn:
         raise SystemExit("DATABASE_URL absent de l'environnement — comparaison impossible")
     with psycopg2.connect(dsn) as conn, conn.cursor() as cur:

--- a/scripts/tecdoc_seal.py
+++ b/scripts/tecdoc_seal.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Sceau des artefacts TecDoc — une seule definition de la canonicalisation.
+
+Deux artefacts scelles cohabitent (`massdoc-tecdoc-import-scope-2026-03.json` et
+`massdoc-tecdoc-preservation-manifest-2026-03.json`), lus par trois modules et
+produits par deux generateurs. La regle de canonicalisation etait donc sur le point
+d'exister en quatre exemplaires ; une divergence d'un seul separateur rendrait un
+sceau invalide sans que personne ne comprenne pourquoi. Elle vit ici, une fois.
+
+Contrat, identique a celui inscrit dans les artefacts eux-memes :
+  * JSON UTF-8, `sort_keys=True`, separateurs `(',', ':')`, `ensure_ascii=False` ;
+  * le bloc `seal` est RETIRE avant hachage ;
+  * aucun horodatage de generation dans la zone hachee — le hash est reproductible.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+class SceauInvalide(RuntimeError):
+    """Le hash recalcule ne correspond pas au hash declare — l'artefact a ete altere."""
+
+
+def canonique(charge: dict) -> str:
+    """Serialisation canonique de la zone hachee (sceau exclu)."""
+    return json.dumps(charge, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def calculer(document: dict) -> str:
+    """Hash SHA256 de la zone hachee d'un document, sceau exclu."""
+    charge = {k: v for k, v in document.items() if k != "seal"}
+    return hashlib.sha256(canonique(charge).encode("utf-8")).hexdigest()
+
+
+def verifier(document: dict, *, source: str = "artefact") -> str:
+    """Verifie le sceau d'un document deja charge. Rend le hash, ou leve.
+
+    Fail-closed : un artefact sans sceau est refuse au meme titre qu'un artefact
+    altere. L'absence de preuve n'est pas une preuve d'integrite.
+    """
+    sceau = document.get("seal")
+    if not sceau or "sha256" not in sceau:
+        raise SceauInvalide(f"{source} ne porte aucun sceau — refus de le servir")
+    calcule = calculer(document)
+    if calcule != sceau["sha256"]:
+        raise SceauInvalide(
+            f"sceau invalide pour {source}\n"
+            f"  declare  : {sceau['sha256']}\n"
+            f"  recalcule: {calcule}\n"
+            "L'artefact a ete modifie apres scellement. Utilisation REFUSEE."
+        )
+    return calcule

--- a/scripts/test-tecdoc-guards.sh
+++ b/scripts/test-tecdoc-guards.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Tests des gardes du pipeline TecDoc : chargement, identite, conservation, quarantaine.
+#
+# Meme forme que scripts/test-tecdoc-scope.sh : assertions explicites, comptage
+# PASS/FAIL, AUCUN acces base, aucune dependance PROD.
+#
+# Les cas negatifs sont le coeur de cette suite. Une garde qui n'a jamais ete vue
+# REFUSER n'a pas ete testee : elle a seulement ete vue ne rien dire.
+#
+#   bash scripts/test-tecdoc-guards.sh
+set -uo pipefail
+
+RACINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$RACINE/audit/massdoc-tecdoc-preservation-manifest-2026-03.json"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$RACINE/scripts" || exit 3
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+ko()   { FAIL=$((FAIL+1)); printf '  FAIL  %s\n     attendu : %s\n     obtenu  : %s\n' "$1" "$2" "$3"; }
+egal() { if [ "$2" = "$3" ]; then ok "$1"; else ko "$1" "$2" "$3"; fi; }
+
+# Rend "OK" si l'expression python s'evalue sans lever, sinon le nom de l'exception.
+verdict() { python3 -c "
+import sys
+try:
+    exec(sys.argv[1])
+    print('OK')
+except Exception as e:
+    print(type(e).__name__)" "$1" 2>/dev/null; }
+
+echo "=== garde de completude du chargement ==="
+egal "emis == charges : accepte" "OK" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(dlnr=21, emis=790974, charges=790974)")"
+egal "perte massive (BOSCH mars 2026) : REFUSE" "ComptabiliteIncoherente" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(dlnr=30, emis=9357752, charges=69000)")"
+egal "perte d'UNE seule ligne : REFUSE" "ComptabiliteIncoherente" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(emis=1000, charges=999)")"
+egal "dedoublonnage explicitement compte : accepte" "OK" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(emis=1000, charges=900, dedoublonnes=100)")"
+egal "rejets motives et comptes : accepte" "OK" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(emis=100, charges=90, rejets={'ktypnr_absent_du_registre': 10})")"
+egal "rejet non explique (categorie fourre-tout) : REFUSE" "ComptabiliteIncoherente" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(emis=100, charges=90, rejets={'autre': 10})")"
+egal "rejet a raison vide : REFUSE" "ComptabiliteIncoherente" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(emis=100, charges=90, rejets={'   ': 10})")"
+egal "plus de lignes chargees qu'emises : REFUSE" "ComptabiliteIncoherente" \
+     "$(verdict "from tecdoc_load_guard import verifier_lot
+verifier_lot(emis=100, charges=101)")"
+egal "rapport a zero lot n'est pas un succes" "ComptabiliteIncoherente" \
+     "$(verdict "from tecdoc_load_guard import verifier_rapport
+verifier_rapport({'lots': []})")"
+
+echo
+echo "=== garde d'identite ==="
+egal "mapping conserve + cle nouvelle : accepte" "OK" \
+     "$(verdict "from tecdoc_identity_guard import verifier_mapping
+verifier_mapping({'K:1': 60050, 'K:2': 60051}, {'K:1': 60050, 'K:2': 60051, 'K:3': 83457})")"
+egal "un identifiant existant qui change : REFUSE" "IdentiteViolee" \
+     "$(verdict "from tecdoc_identity_guard import verifier_mapping
+verifier_mapping({'K:1': 60050}, {'K:1': 70000})")"
+egal "un identifiant existant donne a une AUTRE cle : REFUSE" "IdentiteViolee" \
+     "$(verdict "from tecdoc_identity_guard import verifier_mapping
+verifier_mapping({'K:1': 60050}, {'K:1': 60050, 'K:9': 60050})")"
+egal "rejeu partiel : identite intacte, absences signalees" "1" \
+     "$(python3 -c "
+from tecdoc_identity_guard import verifier_mapping
+print(len(verifier_mapping({'K:1': 60050, 'K:2': 60051}, {'K:1': 60050}).absentes))" 2>/dev/null)"
+
+echo
+echo "=== conservation applicative (sur le manifeste reel, sans base) ==="
+# Mesures « APRES » construites depuis le manifeste lui-meme : AVANT == APRES.
+python3 - "$MANIFEST" "$TMP/mesures-identiques.json" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1], encoding='utf-8'))
+out = {}
+for e in m['ensembles_figes']:
+    nom = e.get('nom')
+    out[nom] = {k: e.get(k) for k in ('cardinal', 'borne_min', 'borne_max', 'empreinte_md5')}
+json.dump(out, open(sys.argv[2], 'w', encoding='utf-8'), indent=2, ensure_ascii=False)
+PY
+python3 tecdoc_preservation.py --manifest "$MANIFEST" --mesures "$TMP/mesures-identiques.json" >/dev/null 2>&1
+egal "avant == apres : conservation intacte (exit 0)" "0" "$?"
+
+# Trois suppressions simulees, une par nature d'objet du patrimoine.
+simuler_suppression() {   # $1 = fragment du nom d'ensemble, $2 = fichier de sortie
+  python3 - "$TMP/mesures-identiques.json" "$1" "$2" <<'PY'
+import json, sys
+mes = json.load(open(sys.argv[1], encoding='utf-8'))
+cible = next(k for k in mes if sys.argv[2] in k)
+mes[cible]['cardinal'] -= 1                      # une ligne de moins
+mes[cible]['empreinte_md5'] = '0' * 32           # donc un contenu different
+json.dump(mes, open(sys.argv[3], 'w', encoding='utf-8'), indent=2, ensure_ascii=False)
+PY
+}
+for cible in "pieces_gamme:d.une gamme" "auto_type:d.un vehicule" "pieces — cohorte:d.une piece"; do
+  frag="${cible%%:*}"; label="${cible##*:}"
+  simuler_suppression "$frag" "$TMP/moins-un.json"
+  python3 tecdoc_preservation.py --manifest "$MANIFEST" --mesures "$TMP/moins-un.json" >/dev/null 2>&1
+  egal "suppression simulee $label : REFUSE (exit 7)" "7" "$?"
+done
+
+# Fail-closed : ne pas mesurer un ensemble n'est pas la meme chose que le conserver.
+python3 - "$TMP/mesures-identiques.json" "$TMP/incomplet.json" <<'PY'
+import json, sys
+mes = json.load(open(sys.argv[1], encoding='utf-8'))
+mes.pop(next(iter(mes)))
+json.dump(mes, open(sys.argv[2], 'w', encoding='utf-8'), indent=2, ensure_ascii=False)
+PY
+python3 tecdoc_preservation.py --manifest "$MANIFEST" --mesures "$TMP/incomplet.json" >/dev/null 2>&1
+egal "un ensemble non mesure est un ECHEC, pas un saut (exit 7)" "7" "$?"
+
+# Le manifeste lui-meme est scelle : l'alterer le rend inutilisable.
+python3 - "$MANIFEST" "$TMP/manifest-altere.json" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1], encoding='utf-8'))
+m['ensembles_figes'][0]['cardinal'] = 1          # sceau NON recalcule
+json.dump(m, open(sys.argv[2], 'w', encoding='utf-8'), indent=2, ensure_ascii=False)
+PY
+python3 tecdoc_preservation.py --manifest "$TMP/manifest-altere.json" --mesures "$TMP/mesures-identiques.json" >/dev/null 2>&1
+egal "manifeste altere : REFUSE (exit 2)" "2" "$?"
+
+echo
+echo "=== reconciliation et quarantaine ==="
+egal "source-truth qui AJOUTE (cas BOSCH) : inclusion respectee" "True" \
+     "$(python3 -c "
+from tecdoc_reconcile import reconcilier
+print(reconcilier({'A': 1}, {'A': 1, 'B': 2, 'C': 3}).inclusion_respectee)" 2>/dev/null)"
+egal "les ajouts partent en quarantaine, pas en activation" "2" \
+     "$(python3 -c "
+from tecdoc_reconcile import reconcilier
+print(reconcilier({'A': 1}, {'A': 1, 'B': 2, 'C': 3}).total('NEW_FROM_SOURCE'))" 2>/dev/null)"
+egal "a_activer ne rend que EXISTING_PROD" "['A']" \
+     "$(python3 -c "
+from tecdoc_reconcile import reconcilier, a_activer
+print(a_activer(reconcilier({'A': 1}, {'A': 1, 'B': 2})))" 2>/dev/null)"
+egal "activer la quarantaine : REFUSE" "ActivationInterdite" \
+     "$(verdict "from tecdoc_reconcile import reconcilier, a_activer
+a_activer(reconcilier({'A': 1}, {'A': 1, 'B': 2}), inclure_quarantaine=True)")"
+egal "une cle servie en PROD que le rejeu perd : inclusion ROMPUE" "False" \
+     "$(python3 -c "
+from tecdoc_reconcile import reconcilier
+print(reconcilier({'A': 1, 'B': 2}, {'A': 1}).inclusion_respectee)" 2>/dev/null)"
+egal "une valeur qui diverge : CONFLICT, inclusion ROMPUE" "False" \
+     "$(python3 -c "
+from tecdoc_reconcile import reconcilier
+print(reconcilier({'A': 1}, {'A': 9}).inclusion_respectee)" 2>/dev/null)"
+egal "valeur manquante d'un cote : UNKNOWN, jamais activee" "1" \
+     "$(python3 -c "
+from tecdoc_reconcile import reconcilier
+print(reconcilier({'A': None}, {'A': 1}).total('UNKNOWN'))" 2>/dev/null)"
+
+echo
+echo "PASS=$PASS  FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test-tecdoc-scope.sh
+++ b/scripts/test-tecdoc-scope.sh
@@ -100,5 +100,36 @@ egal "9 ensembles applicatifs figes" "9" \
      "$(python3 -c "import json;print(len(json.load(open('$MANIFEST',encoding='utf-8'))['ensembles_figes']))")"
 
 echo
+echo "=== deux modes de perimetre, aucun repli de l'un vers l'autre ==="
+egal "historical + artefact = les 110 projetes" "110" \
+     "$(cd "$RACINE/scripts" && python3 -c "
+from tecdoc_scope import resoudre_dlnr
+print(len(resoudre_dlnr('historical', '$SCOPE')))" 2>/dev/null)"
+egal "historical + selection charges = les 149" "149" \
+     "$(cd "$RACINE/scripts" && python3 -c "
+from tecdoc_scope import resoudre_dlnr
+print(len(resoudre_dlnr('historical', '$SCOPE', selection='charges')))" 2>/dev/null)"
+egal "historical SANS scope-file est REFUSE" "PerimetreManquant" \
+     "$(cd "$RACINE/scripts" && python3 -c "
+from tecdoc_scope import resoudre_dlnr, PerimetreManquant
+try: resoudre_dlnr('historical')
+except PerimetreManquant: print('PerimetreManquant')" 2>/dev/null)"
+egal "historical sur artefact altere est REFUSE" "SceauInvalide" \
+     "$(cd "$RACINE/scripts" && python3 -c "
+from tecdoc_scope import resoudre_dlnr, SceauInvalide
+try: resoudre_dlnr('historical', '$TMP/altere.json')
+except SceauInvalide: print('SceauInvalide')" 2>/dev/null)"
+egal "current + scope-file est REFUSE (sources contradictoires)" "ValueError" \
+     "$(cd "$RACINE/scripts" && python3 -c "
+from tecdoc_scope import resoudre_dlnr
+try: resoudre_dlnr('current', '$SCOPE')
+except ValueError: print('ValueError')" 2>/dev/null)"
+egal "un mode inconnu est REFUSE" "ValueError" \
+     "$(cd "$RACINE/scripts" && python3 -c "
+from tecdoc_scope import resoudre_dlnr
+try: resoudre_dlnr('historique')
+except ValueError: print('ValueError')" 2>/dev/null)"
+
+echo
 echo "PASS=$PASS  FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
> ⚠️ **Cette PR a mis au jour un incident de sécurité indépendant de son objet. Voir §0 — il demande une action owner.**

## 0. Un mot de passe PROD est public depuis 5,5 mois

`scripts/fix-vehicles-massdoc.py:46` porte, **en clair sur `origin/main`**, le mot de passe du superutilisateur PostgreSQL de la PROD MassDoc. Introduit par `756e619c4` le 2026-03-27. Dépôt **public**. **Toujours valide** — l'empreinte SHA256 du littéral publié est identique à celle du `SUPABASE_DB_PASSWORD` courant de `backend/.env` (comparé sans afficher les valeurs).

**Pourquoi aucune garde n'a parlé** — diagnostiqué, pas supposé. Le job gitleaks existait depuis le 2026-02-22, donc *avant* la fuite. Mais le `.gitleaks.toml` de l'époque n'avait pas de bloc `[extend] useDefault = true`, et une config gitleaks personnalisée **remplace** le jeu de règles par défaut au lieu de l'étendre. Le job tournait **sans aucune règle**. Même fichier, même binaire 8.21.2 :

```
config du 2026-03-27  →  no leaks found
config actuelle       →  leaks found: 1   (generic-api-key, ligne 46, entropie 3.58)
```

`[extend] useDefault = true` est arrivé le 2026-05-07 (#380). Le job était donc **vacant par construction** de février à mai, et la fuite tombe pile dans la fenêtre. Depuis, la garde voit la fuite — mais le scan par PR est *incrémental* et ne re-scanne jamais un commit mergé, et le scan hebdomadaire d'historique est `continue-on-error: true` : son run du 2026-09-07 affiche **`leaks found: 394`** et se conclut en `success`.

Ce n'est ni une exemption abusive ni un détecteur cassé. C'est une garde sans règles, puis une garde qui mesure sans assurer.

**Cette PR retire le littéral** et le remplace par une lecture d'environnement. **Cela ne réduit pas l'exposition passée** : l'historique git public conserve la valeur. **Seule une rotation ferme la brèche** — je ne l'ai pas faite, c'est une décision owner.

---

## 1. Ce que la PR livre

Les 16 scripts qui ont réalisé la campagne TecDoc de mars 2026 vivaient **uniquement** dans `/opt/automecanik/data/tecdoc/`, sur un disque à 74 %, sans sauvegarde versionnée. Ils sont la seule description exécutable de ce qui a produit l'état actuel de la base.

**16/16 rapatriés verbatim**, SHA256 identiques à l'original. Avec `fix-vehicles-massdoc.py` déjà présent, **17/17 sont sous git, 0 manquant**.

La fidélité prime sur la propreté : les corriger en les rapatriant aurait détruit leur valeur de preuve. **Récupération et modernisation sont séparées**, comme demandé — les scripts sont en quarantaine documentée, les gardes sont écrites et testées mais **pas câblées**.

## 2. Ce que la lecture des 16 a établi

**Le pipeline entier est piloté par des drapeaux d'affichage marchand.** Le problème dépasse le périmètre fournisseur identifié en #1416 :

| drapeau | ce qu'il gouverne réellement | scripts |
|---|---|---|
| `pieces_marque.pm_display` | quels fournisseurs sont chargés/projetés | 5 direct + 1 via vue |
| `auto_marque.marque_display` | quelles marques reçoivent des véhicules | 1 |
| `auto_type.type_display` | quels véhicules reçoivent des liaisons | 4 |
| `pieces.piece_display` | quelles pièces sont activées | 5 |

**Aucun des 16 n'a d'appelant** — ni cron, ni systemd, ni wrapper, ni référence dans le dépôt. L'ordre d'exécution de mars 2026 n'existait que dans la tête de l'opérateur.

**Des chemins concurrents et contradictoires** : trois scripts écrivent `pieces.piece_display` avec des critères d'éligibilité **différents et non réconciliés** ; trois portent le même `INSERT` vers `pieces_relation_type`. Lequel fait autorité n'est écrit nulle part.

## 3. La perte de mars : expliquée, plus seulement constatée

Mesure sur `_source_row_no`, le numéro de ligne source écrit par le parseur :

| DLNR | marque | émis par le parseur | en base | plage | contigu |
|---:|---|---:|---:|---|:-:|
| 123 | NISSENS | 790 974 | **100** | 1 → 100 | ✅ |
| 30 | BOSCH | 9 357 752 | **69 000** | 1 → 69 000 | ✅ |
| 113 | PAYEN | 1 259 429 | **1 085 500** | 1 → 1 085 500 | ✅ |

**Préfixe contigu depuis la ligne 1, sans trou.** Ni filtrage métier, ni échantillonnage, ni déduplication.

Le mécanisme se déduit du code (`load-t400-active.py:124-165`) :

1. Les 100 lignes de NISSENS sont **inférieures** à `CHUNK_SIZE = 50000` → elles ne peuvent venir que du *flush* final, situé **après** la boucle ;
2. ce flush est **dans le `try`** → il n'est atteint que si la boucle finit **sans exception** ;
3. or le `.meta` du parseur déclare `rows_emitted=790974`, `rows_rejected=0`.

Donc la boucle a lu le fichier **entier, sans erreur**, et seules les 100 premières lignes ont franchi `if len(row) >= 8` (L140) — un filtre **sans `else`, sans compteur, sans log**. 790 874 lignes jetées en silence, code de sortie 0.

Départager les trois causes possibles du décrochage (`open()` sans `newline=''`, limite de champ csv, octet NUL) exigerait de re-parser le shard : **non fait**. L'**amplificateur**, lui, est certain : le saut « déjà chargé » est à granularité DLNR — une seule ligne suffit à figer la perte pour toujours.

**La comptabilité existait déjà.** Le parseur écrit `rows_parsed` / `rows_emitted` / `rows_rejected` dans un sidecar `.meta` et un `SUMMARY` sur stderr. Le chargeur n'en lit **rien**. La garde livrée ici ne crée pas une capacité nouvelle : elle ferme une boucle à moitié construite.

## 4. Décision source-truth — inscrite

```
NISSENS · BOSCH · FEBI · RIDEX · PAYEN  →  source complète
```

`t400` reste la vérité **forensique** ; il n'est pas la vérité **fonctionnelle** du rebuild. Conséquence portée par `tecdoc_reconcile.py` : l'invariant vérifié est **`PROD ⊆ REBUILD`**, jamais `PROD == REBUILD`.

## 5. Gardes livrées — 50 assertions, tous les cas négatifs

| module | garantie |
|---|---|
| `tecdoc_scope.py` *(étendu)* | `--scope-mode historical\|current`, **aucun repli** de l'un vers l'autre |
| `tecdoc_load_guard.py` | `émis == chargées + dédoublonnées + rejets motivés`, sinon STOP |
| `tecdoc_identity_guard.py` | dérive, réemploi et collision d'identifiants refusés |
| `tecdoc_preservation.py` | 9 ensembles vs manifeste ; un ensemble **non mesuré** est un échec |
| `tecdoc_reconcile.py` | `NEW_FROM_SOURCE` / `CONFLICT` **jamais** activés |
| `tecdoc_seal.py` | la canonicalisation existait en 3 exemplaires, allait en avoir 4 — extraite une fois |

Une raison de rejet fourre-tout (`autre`, `erreur`, vide…) est **refusée** : elle permettrait de solder n'importe quel écart et viderait la garde de son sens.

```
$ bash scripts/test-tecdoc-scope.sh     → PASS=24  FAIL=0
$ bash scripts/test-tecdoc-guards.sh    → PASS=26  FAIL=0

  PASS  perte massive (BOSCH mars 2026) : REFUSE
  PASS  perte d'UNE seule ligne : REFUSE
  PASS  rejet non explique (categorie fourre-tout) : REFUSE
  PASS  un identifiant existant donne a une AUTRE cle : REFUSE
  PASS  suppression simulee d'une gamme : REFUSE (exit 7)
  PASS  un ensemble non mesure est un ECHEC, pas un saut (exit 7)
  PASS  historical SANS scope-file est REFUSE
  PASS  activer la quarantaine : REFUSE
```

Une garde qu'on n'a jamais vue **refuser** n'a pas été testée : elle a seulement été vue se taire.

### Une dérivation devinée, prise en défaut puis remplacée

Le vérificateur de conservation construisait d'abord ses requêtes en dérivant la forme documentée dans le manifeste. Confrontée à la base, elle **échouait sur `gamme_registry`** : trier par l'expression texte `pg_id_source||'>'||pg_id` donne `64816aa0…`, le manifeste porte `0a2ef785…` — obtenu par tri **numérique** (« 1000 » avant « 2 » en texte). Même cardinal, empreinte différente. Sur `type_id_remap` elle tombait juste **par accident**, tous les `old_id` ayant six chiffres.

Une requête devinée juste sur 8 cas sur 9 est plus dangereuse qu'une table écrite : elle aurait un jour fait échouer un contrôle sur une base intacte, et l'écart aurait été imputé à la donnée. Remplacée par **9 requêtes explicites, chacune vérifiée contre la PROD**.

### Conservation vérifiée contre la PROD du jour

```
$ python3 scripts/tecdoc_preservation.py --manifest audit/…-preservation-manifest-2026-03.json --mesures …
conservation intacte — 9 ensembles applicatifs identiques au manifeste.
```

23 457 véhicules, 7 088 modèles, 119 702 pièces, 876 gammes, 23 457 mappings d'identité, 43 484 cibles de liaison, rollup des 3 240 177 articles : **inchangés**.

## 6. Verdicts

**Rejeu complet possible ? — NON.** Raison unique : aucun environnement isolé n'existe, et les scripts ne sont pas câblés aux gardes. Ils sont sous git — ce qui bloquait avant — mais les lancer aujourd'hui reproduirait le défaut de mars.

**DROP des ~110 Go ? — NON.** 7 conditions vertes, **5 rouges** :

```
[x] scope figé  [x] sources vérifiées  [x] parseur sous git  [x] scripts sous git (17/17)
[x] décision source-truth  [x] gardes 50/50  [x] conservation 9/9 vs PROD
[ ] scripts câblés aux gardes     [ ] rejeu hors PROD exécuté     [ ] comparaison conforme
[ ] dump de sécurité              [ ] mot de passe PROD tourné  ← ACTION OWNER
```

## 7. Prochaine action unique

**Tourner le mot de passe `postgres` de la PROD.** Ce n'est pas la suite du chantier TecDoc, et c'est pourtant la seule action dont le report coûte quelque chose chaque jour. Tout le reste peut attendre ; cela, non.

---

**Aucune mutation PROD.** Lecture seule intégrale : aucun DROP, TRUNCATE, DELETE, UPDATE, INSERT, VACUUM, REINDEX, ALTER, migration, resize. Aucun staging TecDoc supprimé. Aucun rejeu lancé.

Détail complet : [`audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md`](https://github.com/ak125/nestjs-remix-monorepo/blob/feat/tecdoc-pipeline-recovery/audit/massdoc-tecdoc-pipeline-recovery-2026-09-08.md) · quarantaine : [`scripts/tecdoc-pipeline/README.md`](https://github.com/ak125/nestjs-remix-monorepo/blob/feat/tecdoc-pipeline-recovery/scripts/tecdoc-pipeline/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
