### PR TITLE
feat(tecdoc): rendre le rejeu fail-closed et le démontrer sur HIDRIA en PostgreSQL jetable

### DIFF
--- a/.github/workflows/tecdoc-failclosed-guard.yml
+++ b/.github/workflows/tecdoc-failclosed-guard.yml
@@ -1,0 +1,58 @@
+name: TecDoc rejeu fail-closed
+
+# Empêche la réouverture des trois portes qui ont rendu la perte de mars 2026
+# invisible : périmètre dérivé du merchandising vivant, chargement sans garde de
+# comptabilité, résurrection des scripts historiques mis en quarantaine.
+# Voir scripts/lint/check-tecdoc-failclosed-ratchet.sh et
+# audit/massdoc-tecdoc-failclosed-replay-2026-09-08.md.
+#
+# PÉRIMÈTRE DE CE WORKFLOW — à lire avant d'y ajouter un job.
+# Il exécute le ratchet et les deux suites HERMÉTIQUES (périmètre scellé, gardes).
+# Il n'exécute PAS `scripts/test-tecdoc-replay.sh` : ce banc exige Docker et
+# l'archive source de 6 Go, absents d'un runner GitHub. Le déclarer « passé » ici
+# ferait d'un skip une preuve — exactement le vert-mais-faux que ce chantier
+# corrige. Son exécution est un geste DEV, et ses relevés sont consignés dans le
+# rapport d'audit cité plus haut.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/tecdoc_*.py'
+      - 'scripts/tecdoc-replay/**'
+      - 'scripts/tecdoc-pipeline/**'
+      - 'scripts/test-tecdoc-*.sh'
+      - 'scripts/lint/check-tecdoc-failclosed-ratchet.sh'
+      - 'scripts/lint/tecdoc-failclosed-allowlist.txt'
+      - 'audit/massdoc-tecdoc-import-scope-2026-03.json'
+      - 'audit/massdoc-tecdoc-preservation-manifest-2026-03.json'
+      - '.github/workflows/tecdoc-failclosed-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/tecdoc_*.py'
+      - 'scripts/tecdoc-replay/**'
+      - 'scripts/lint/check-tecdoc-failclosed-ratchet.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    name: Ratchet fail-closed (R1 périmètre · R2 comptabilité · R3 quarantaine)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/lint/check-tecdoc-failclosed-ratchet.sh
+
+  suites:
+    name: Suites hermétiques — périmètre scellé et gardes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Périmètre scellé
+        run: bash scripts/test-tecdoc-scope.sh
+      - name: Gardes (comptabilité · identité · conservation · réconciliation)
+        run: bash scripts/test-tecdoc-guards.sh

--- a/audit/massdoc-tecdoc-failclosed-replay-2026-09-08.md
+++ b/audit/massdoc-tecdoc-failclosed-replay-2026-09-08.md
@@ -1,0 +1,305 @@
+# Pipeline TecDoc fail-closed — démonstration sur un DLNR en PostgreSQL jetable
+
+> **Date** : 2026-09-08 · **Base** : `053c1e58b` (PR #1417) · **Périmètre** : rendre le
+> pipeline récupéré *fail-closed* et le démontrer sur un petit DLNR dans un PostgreSQL
+> jetable. **Le rejeu complet n'est pas exécuté par cette mission.**
+>
+> Principe directeur : **une perte de ligne, une dérive d'identité ou une différence de
+> scope ne peut plus produire un run vert.**
+
+---
+
+## 0. Priorité 0 — `BLOCKED_BY_SECRET_ROTATION` (non levé)
+
+**Le mot de passe `postgres` PROD exposé publiquement sur GitHub depuis 2026-03-27 n'a
+pas été tourné.** Vérifié le 2026-09-08 par comparaison d'empreintes SHA-256 tronquées
+entre la valeur littérale de `scripts/fix-vehicles-massdoc.py` avant sa purge (parent de
+`053c1e58b`) et `SUPABASE_DB_PASSWORD` du `.env` courant : **empreintes identiques**.
+
+La valeur n'a été ni affichée, ni copiée, ni journalisée, et aucun secret n'a été modifié.
+C'est une action **owner**, hors du mandat de cette mission.
+
+> Une première passe de vérification, par balayage `git log -S` large, avait conclu
+> « rotation effectuée ». Elle avait matché une chaîne sans rapport dans un commit de
+> #1417 ; le contrôle ciblé sur le fichier réellement fautif la contredit. Seul le second
+> verdict est retenu.
+
+**Décision de poursuite** : les travaux ci-dessous s'exécutent intégralement dans un
+PostgreSQL jetable. Les seuls accès à MassDoc PROD sont des `SELECT` de comparaison
+(§6, §7). Aucun n'utilise le compte `postgres` en écriture.
+
+---
+
+## 1. Implémentation de référence — et une correction à PR #1417
+
+### 1.1 Correction : l'attribution publiée dans #1417 était trop affirmative
+
+**PR #1417 §3 attribuait la perte de mars 2026 au filtre `if len(row) >= 8` de
+`load-t400-active.py`. C'est réfuté.** La colonne `_source_row_no`, remplie par le
+parseur avec un compteur incrémental, le prouve directement :
+
+| DLNR | lignes en base | `_source_row_no` | `count(distinct)` | forme |
+|------|---------------:|------------------|------------------:|-------|
+| 4523 (HIDRIA, sain) | 13 057 | `[1, 13057]` | 13 057 | préfixe contigu |
+| 30 (divergent) | 69 000 | `[1, 69000]` | 69 000 | préfixe contigu |
+| 123 (divergent) | 100 | `[1, 100]` | 100 | préfixe contigu |
+
+**Un filtre disperse les pertes ; il ne tronque pas.** Si `len(row) >= 8` avait éliminé
+des lignes, les numéros survivants seraient troués. Ils sont contigus de 1 à N : le
+chargement s'est **arrêté net**.
+
+### 1.2 Le loader qui a réellement écrit `t400`
+
+`T400_COLUMNS` (L119-122 de `load-t400-active.py`) mappe les 13 champs du CSV, dont
+`_source_filename`, `_source_row_no` et `_raw_hash`. Aucun autre loader candidat ne les
+écrit : `load-all-suppliers-v3.py` remplit ses colonnes par position avec `None`. Mesure
+en PROD : ces trois colonnes sont remplies à **100 %** sur les trois DLNR ci-dessus,
+tandis que `_batch_id` et `_loaded_at` sont **NULL partout**. Cette signature est celle
+de `load-t400-active.py`, et d'aucun autre. Il est donc bien l'implémentation de
+référence — mais pour des raisons différentes de celles avancées en #1417.
+
+### 1.3 Le mécanisme réel — trois lignes de code
+
+```python
+conn.autocommit = True                     # L33 — chaque COPY est committé isolément
+...
+    except Exception as e:                 # L155
+        log(f"  ERROR DLNR={dlnr}: {e}")   # L156 — avalée, jamais re-levée
+    ...
+    return total                           # L161 — rend les lignes DÉJÀ committées
+```
+
+Une interruption en cours de fichier laisse un **préfixe committé**, l'exception est
+journalisée puis oubliée, et `process_dlnr` annonce `DLNR=X: +N rows`. Le script sort
+avec le code 0. Aucune comparaison n'est faite avec `rows_emitted` du `.meta` :
+9 357 752 émises et 69 000 chargées coexistent sans alerte.
+
+**Reste ouvert et assumé** : l'arithmétique exacte des points d'arrêt (69 000 et 100 ne
+sont multiples ni de `CHUNK_SIZE = 50000`, ni l'un de l'autre) n'est pas reproductible
+depuis le code seul. Ce n'est pas nécessaire : le correctif ne dépend pas de la cause de
+l'interruption, il rend toute interruption **fatale et non committée**.
+
+### 1.4 Décision
+
+| Statut | Script | Raison |
+|--------|--------|--------|
+| **Retenu comme modèle** | `load-t400-active.py` | Seul loader dont la signature de provenance corresponde à `t400` en PROD. Sert de **modèle**, pas de base : il reste en quarantaine, inchangé, comme pièce à conviction. |
+| **Chemin canonique** | **`scripts/tecdoc_replay.py`** (nouveau) | Réécriture fail-closed. Une transaction par lot, comptabilité vérifiée **avant** commit, aucune exception avalée. |
+| Déprécié | `load-all-suppliers.py`, `-v2`, `-v3` | N'ont pas écrit `t400` en PROD. Périmètre dérivé de `__tecdoc_supplier_mapping`, lots de 500 en autocommit, `finally` qui efface le `.meta` — la seule preuve d'émission. |
+| Auxiliaires | `tecdoc-mysql-to-csv.py` (parseur), `load-vehicle-tables.py` | Le parseur est conservé **tel quel** : c'est lui qui produit `rows_emitted` et `_source_row_no`, les deux termes de la garde. |
+
+---
+
+## 2. Périmètre scellé, câblé et obligatoire
+
+`tecdoc_replay.py` n'accepte que `--scope-mode historical` avec `--scope-file`. Trois
+refus explicites, tous éprouvés (§10) :
+
+- `historical` sans artefact → `PerimetreManquant`, **jamais** de repli sur le vivant ;
+- artefact altéré d'une seule valeur → `SceauInvalide` ;
+- `--scope-mode current` → **refusé pour ce script** : le mode vivant ne porte ni le nom
+  du shard ni son CRC32, donc rien n'y prouverait que la source rejouée est celle de
+  mars 2026.
+
+S'y ajoute un contrôle que le périmètre seul ne donnait pas : le **CRC32 du shard extrait
+est comparé à celui scellé** avant toute analyse. Une source qui ne correspond pas au
+sceau n'est pas la source de mars 2026.
+
+## 3. Garde de comptabilité, câblée avant le commit
+
+`verifier_lot(emis, charges, dedoublonnes, rejets)` est appelée **à l'intérieur de la
+transaction**, avant `conn.commit()`. `emis` vient du `.meta` du parseur ; `charges` est
+recompté **en base**, jamais depuis un compteur en mémoire. L'absence du `.meta` est
+fatale : sans lui, l'égalité n'a pas de terme gauche.
+
+Trois contrôles supplémentaires portent sur ce que la base contient réellement — ce
+qu'aucun compteur en mémoire ne peut prouver : `count(*)` conforme, numéros de ligne
+source **distincts**, borne max ≤ `rows_emitted`. L'égalité
+`émis = chargées + dédoublonnées + rejetées` reste portée par `verifier_lot` **et par lui
+seul** : y ajouter un second détecteur créerait la SoT dupliquée que l'invariant #2 interdit.
+
+## 4. Skips silencieux supprimés — quatre états, pas de cinquième
+
+Toute branche qui écartait une ligne rend désormais un état nommé :
+
+| Branche historique | État désormais |
+|--------------------|----------------|
+| `if len(row) >= 8:` (sinon rien) | `rejeté[colonnes_insuffisantes]`, compté |
+| numéro de ligne absent / non entier | `rejeté[numero_de_ligne_source_absent_ou_non_entier]` |
+| empreinte de ligne absente | `rejeté[empreinte_de_ligne_absente]` |
+| `except Exception: log(...)` | **fatal** — rollback, rien n'est committé |
+| `SKIP: file not found`, `CSV parse failed` | **fatal** |
+
+Le dédoublonnage n'a lieu que sur `--dedoublonner-identiques`, explicite, et il est
+**compté séparément**. Par défaut, toute ligne source est chargée.
+`tecdoc_load_guard.RAISONS_INTERDITES` refuse par ailleurs les motifs fourre-tout
+(`autre`, `erreur`, `divers`…) qui permettraient de solder n'importe quel écart.
+
+## 5 à 7. Identité, conservation, réconciliation
+
+`scripts/tecdoc_replay_controls.py` est la **porte à franchir avant toute projection**.
+
+- **Identité** — compare les cinq registres protégés entre le rejeu et la référence.
+  Un registre que le rejeu n'a pas encore peuplé rend `non_applicable`, **jamais `OK`** :
+  annoncer conforme une absence de contrôle ferait passer un vide pour une preuve.
+- **Conservation** — `tecdoc_preservation` sur le manifeste scellé. `--manifeste` absent
+  = code 3, refus de déclarer le contrôle passé.
+- **Réconciliation** — classe chaque ligne en `EXISTING_PROD` / `NEW_FROM_SOURCE` /
+  `CONFLICT` / `UNKNOWN`. Les trois dernières partent en **quarantaine** :
+  `a_activer()` ne rend que `EXISTING_PROD`, et lève si on lui demande la quarantaine.
+  L'inclusion **PROD ⊆ REBUILD** est vérifiée ; un `CONFLICT` la rompt.
+
+## 8. DLNR de test et environnement jetable
+
+**DLNR 4523 — HIDRIA.** Le plus petit candidat satisfaisant tous les critères : 13 057
+lignes `t400`, 119 140 liaisons présentes, shards `400` et `232` dans l'archive, `.meta`
+présent et concordant, **hors des 5 fournisseurs massivement divergents**.
+
+Environnement : `postgres:17-alpine` (PostgreSQL **17.11**), container dédié, **tmpfs**
+(rien ne survit à sa suppression), écoute `127.0.0.1` uniquement. Schéma calqué sur le DDL
+réel relevé en PROD, `_loaded_at DEFAULT now()` compris. **La base MassDoc partagée n'est
+jamais utilisée.**
+
+## 9. Rejeu minimal, reproductible
+
+```
+$ python3 tecdoc_replay.py --scope-mode historical --scope-file <artefact> \
+      --dlnr 4523 --table 400 --cible-dsn <jetable> --workdir <tmp>
+OK  DLNR 4523 : 13057 emis = 13057 charges  (100.00% charge)
+    lot 5df6aa4716dd1944fbf3746d5890852c · 400.4523.sql · CRC32 79F794A2
+```
+
+Réconciliation contre MassDoc PROD (lecture seule) :
+
+```json
+{ "identites_conservees": 13057, "absentes_de_prod": 0, "en_trop_dans_prod": 0,
+  "conflits": 0, "indecidables": 0, "candidats_en_quarantaine": 0,
+  "inclusion_respectee": true }
+```
+
+Les 13 057 lignes rejouées portent les **mêmes numéros de ligne source et les mêmes
+empreintes** que celles servies en PROD. Le rejeu source-truth reproduit PROD à
+l'identique sur ce fournisseur.
+
+Conservation, mesurée contre PROD le même jour : **9 ensembles figés intacts** (7,2 s).
+
+## 10. Injections de panne — le vert ne se prouve que par le rouge
+
+`scripts/test-tecdoc-replay.sh`, **hermétique** (monte son propre PostgreSQL 17, ne lit
+jamais PROD, n'exige aucun secret) : **24 assertions, 0 rouge, 36 s.**
+
+| # | Injection | Attendu | Obtenu |
+|---|-----------|---------|--------|
+| 1 | **Perte de lignes** — CSV tronqué à 5 000, `.meta` intact | échec + **0 ligne committée** | code 5, 0 ligne ✓ |
+| 2 | **Source altérée** — un octet ajouté au shard | échec avant tout chargement | code 3, base vide ✓ |
+| 3 | **Périmètre** — sans artefact / DLNR hors scope / mode `current` | refus | code 4 ×3 ✓ |
+| 3b | **Sceau** — une valeur modifiée dans l'artefact | refus | code 2 ✓ |
+| 4 | **Dérive d'identité** — un `new_id` changé, puis un identifiant réemployé | refus | code 6 ×2 ✓ |
+| 5 | **Conservation rompue** — une ligne retirée d'un ensemble figé | refus | code 7 ✓ |
+| 6 | **Inclusion rompue** — ligne servie absente du rejeu, puis contenu contredit | refus | code 8 ×2 ✓ |
+
+L'injection 1 est la reproduction fidèle du défaut de mars 2026 : le parseur rend compte
+de 13 057 lignes émises, la base n'en reçoit que 5 000. **Le rejeu s'arrête, et la
+transaction est annulée — pas une ligne n'est committée.** C'était l'inverse en mars.
+
+## 11. Idempotence — mécanisme par étape, pas un `ON CONFLICT` global
+
+| Étape | Mécanisme | Rejouer deux fois |
+|-------|-----------|-------------------|
+| Extraction | CRC32 + taille vérifiés contre le sceau | même octet, ou fatal |
+| Analyse | parseur déterministe, `.meta` regénéré | même CSV |
+| **Chargement** | **`_batch_id` déterministe** = `sha256(table\|dlnr\|crc32\|version)[:32]` | **refus explicite** (code 3), base inchangée |
+
+`_batch_id` existe dans le schéma depuis l'origine et **n'a jamais été écrite** — la
+remplir étend l'existant au lieu d'inventer un registre parallèle. Elle répond à « ce lot
+est-il déjà chargé ? » là où `SELECT DISTINCT col_2` répondait « oui » dès la première
+ligne présente : c'est ce qui a **figé** les chargements tronqués de mars, jamais retentés.
+
+Vérifié : après un second rejeu identique, `13057` lignes, **1 seul lot**.
+Effet de bord acquis : `_batch_id` et `_loaded_at` sont désormais remplies à 100 %, alors
+que PROD les porte NULL partout (le loader historique poussait un NULL explicite, ce qui
+**écrase** le `DEFAULT now()` au lieu de le laisser s'appliquer).
+
+## 12. Rapport de réconciliation
+
+Tous les nombres se recoupent : `13057 = 13057 + 0 + 0 + 0`, quarantaine vide, inclusion
+respectée, `activables_sans_decision_humaine = 13057` — c'est-à-dire exactement les
+lignes déjà servies par PROD, et rien d'autre.
+
+## 13-14. Ce qui n'a pas été fait
+
+**Zéro écriture PROD.** Aucun `INSERT` / `UPDATE` / `DELETE` / `DROP` / `TRUNCATE` /
+`VACUUM` / `REINDEX` / migration / rejeu. Les seuls accès PROD sont des `SELECT` de
+comparaison : structure des tables, provenance de trois DLNR, réconciliation du DLNR 4523,
+et les 9 empreintes de conservation.
+
+**Zéro DROP.** `tecdoc_rebuild`, `tecdoc_raw`, `source_linkages` et
+`source_linkage_criteria` sont intacts. Le seul `DELETE` du banc porte sur son propre
+PostgreSQL jetable.
+
+**Rejeu complet non exécuté**, conformément au mandat.
+
+## 15. CI et gouvernance
+
+`.github/workflows/tecdoc-failclosed-guard.yml` — deux jobs :
+
+1. **Ratchet** `scripts/lint/check-tecdoc-failclosed-ratchet.sh`
+   - **R1** aucun script vivant ne dérive son périmètre du merchandising vivant ;
+   - **R2** aucune écriture dans `tecdoc_raw` sans `verifier_lot` ;
+   - **R3** la quarantaine reste une quarantaine — R3 vise les références
+     **exécutables** (import, `sys.path`, invocation d'un `.py`), jamais la prose : citer
+     les scripts historiques pour les expliquer reste légitime.
+   Le garde **ne lint pas** `scripts/tecdoc-pipeline/**`, conservé tel quel comme pièce à
+   conviction, et ne doit jamais être étendu pour le faire.
+2. **Suites hermétiques** — `test-tecdoc-scope.sh` (24) + `test-tecdoc-guards.sh` (26).
+
+Le banc `test-tecdoc-replay.sh` **n'est pas exécuté en CI** : il exige Docker et l'archive
+source de 6 Go, absents d'un runner GitHub. Le déclarer « passé » ferait d'un skip une
+preuve — précisément le vert-mais-faux que ce chantier corrige. C'est un geste DEV, et ses
+relevés sont ci-dessus.
+
+### Exemptions — motivées, vivantes, symétriques
+
+`scripts/lint/tecdoc-failclosed-allowlist.txt`, format de
+`tecdoc-api-surface-allowlist.txt` (motif obligatoire). Le ratchet **échoue aussi sur une
+exemption morte** : une exemption qui ne correspond plus à rien étoufferait la règle le
+jour où quelqu'un retire le correctif.
+
+| Règle | Fichier | Nature |
+|-------|---------|--------|
+| R1 | `tecdoc_scope.py` | Fournisseur du mode `current` — porte la requête par construction |
+| R1 | `tecdoc-scope-build/build_scope.py` | Producteur de l'artefact ; enregistre `pm_display` comme donnée d'époque |
+| R1 | `tecdoc-import.py` | **Dette réelle**, préexistante (`df8f5a4d3`) |
+| R2 | `tecdoc-batch-load.py` | **Dette réelle**, écrit `tecdoc_raw` sans garde (#1412) |
+
+> Les deux dernières sont des **dettes**, pas des exemptions de confort. Tant qu'elles ne
+> sont pas soldées, le principe « une perte de ligne ne peut plus produire un run vert »
+> vaut pour le **chemin canonique**, pas pour tout le dépôt. Les solder — câbler
+> `resoudre_dlnr` et `verifier_lot` — sort du périmètre de cette mission.
+
+Preuve que le ratchet mord (les deux sens) : un script de test violant R1+R2 le fait
+passer rouge (2 violations) ; une entrée d'allowlist volontairement morte aussi (1
+violation). Les deux ont été exécutés puis retirés.
+
+---
+
+## Verdict — 11 points
+
+| # | Point | Verdict |
+|---|-------|---------|
+| 1 | Rotation du secret PROD | **`BLOCKED_BY_SECRET_ROTATION` — non levé.** Empreintes identiques. Action owner. |
+| 2 | Implémentation de référence | **Tranchée.** `load-t400-active.py` = modèle ; `tecdoc_replay.py` = chemin canonique. Attribution de #1417 **corrigée**. |
+| 3 | Périmètre scellé obligatoire | **Vérifié.** 4 refus éprouvés, plus le CRC32 du shard. |
+| 4 | Garde de comptabilité | **Vérifié.** Appelée avant `commit`, `charges` recompté en base. |
+| 5 | Skips silencieux | **Vérifié.** 4 états, pas de cinquième ; motifs fourre-tout refusés. |
+| 6 | Identité / conservation / réconciliation | **Vérifié**, dont 9 ensembles figés intacts contre PROD. Un registre non peuplé rend `non_applicable`, pas `OK`. |
+| 7 | Environnement jetable | **Vérifié.** PG 17.11 sur tmpfs, local-only. MassDoc jamais utilisée. |
+| 8 | Rejeu de bout en bout | **Vérifié.** 13 057 = 13 057, identique à PROD (numéros + empreintes). |
+| 9 | Injections de panne | **Vérifié.** 24 assertions, 0 rouge ; les 6 familles échouent **avant** toute projection. |
+| 10 | Idempotence | **Vérifié.** `_batch_id` déterministe, 2ᵉ rejeu refusé, base inchangée. |
+| 11 | Rejeu complet | **Non exécuté** — conforme au mandat. |
+
+**Couverture** : Vérifié — §1 à §12, §15 (74 assertions + relevés PROD reproduits ci-dessus).
+Partiellement vérifié — §15, deux dettes réelles exemptées et nommées.
+Non-vérifiable ici — l'arithmétique exacte des points d'arrêt de mars 2026 (§1.3), et la
+rotation du secret, qui n'appartient pas à cette mission.

--- a/scripts/lint/check-tecdoc-failclosed-ratchet.sh
+++ b/scripts/lint/check-tecdoc-failclosed-ratchet.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Ratchets du rejeu TecDoc fail-closed.
+#
+# CE QUE CES GARDES AFFIRMENT, ET RIEN DE PLUS
+# --------------------------------------------
+# R1  Aucun script vivant du pipeline TecDoc ne derive son perimetre d'une requete
+#     de merchandising vivante. Le perimetre vient de l'artefact scelle, via
+#     `tecdoc_scope.resoudre_dlnr(mode, scope_file)`. En mars 2026, `pm_display='1'`
+#     etait la seule definition du perimetre ; elle a change depuis, et un rejeu
+#     ainsi pilote perdrait DIEDERICHS (253) et RIDEX (6358) tout en cherchant
+#     VDO (4836), qui n'a aucun shard source.
+#
+# R2  Aucun script vivant n'ecrit dans `tecdoc_raw` sans la garde de comptabilite
+#     `tecdoc_load_guard.verifier_lot`. C'est le defaut de mars 2026 : 9 357 752
+#     lignes emises par le parseur, 69 000 arrivees en base, statut « OK ».
+#
+# R3  La zone de quarantaine reste une quarantaine : rien, hors d'elle, n'IMPORTE ni
+#     n'EXECUTE les scripts historiques. Ils sont conserves a titre FORENSIQUE. R3
+#     porte sur les references executables (import, sys.path, invocation d'un .py),
+#     jamais sur la prose : citer la quarantaine pour l'expliquer est legitime.
+#
+# PERIMETRE : `scripts/**.py`, hors `scripts/tecdoc-pipeline/**` (quarantaine
+# assumee, cf. `scripts/tecdoc-pipeline/README.md`). Ce garde ne lint PAS les
+# scripts historiques et ne doit jamais etre etendu pour le faire : ils sont
+# conserves tels quels comme piece a conviction.
+#
+# EXCEPTIONS : scripts/lint/tecdoc-failclosed-allowlist.txt, motif obligatoire.
+# Le ratchet est SYMETRIQUE — une entree qui ne viole plus rien echoue aussi.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+
+QUARANTAINE="scripts/tecdoc-pipeline"
+ALLOW="scripts/lint/tecdoc-failclosed-allowlist.txt"
+echecs=0
+declare -A VU=()
+
+autorise() { grep -qxF "$1 $2" "$ALLOW" 2>/dev/null; }
+marquer()  { VU["$1 $2"]=1; }
+
+fichiers_tecdoc() {
+  grep -rl --include='*.py' -e 'tecdoc_raw' -e 'tecdoc_map' scripts/ 2>/dev/null \
+    | grep -v "^${QUARANTAINE}/" | sort
+}
+
+signaler() { # signaler <regle> <fichier> <message> <remede>
+  if autorise "$1" "$2"; then marquer "$1" "$2"; echo "  · exempte ($1) $2"; return; fi
+  echo "  ✗ $2 : $3"
+  echo "      $4"
+  echecs=$((echecs+1))
+}
+
+echo "== R1 — perimetre scelle, jamais derive du merchandising vivant =="
+avant=$echecs
+for f in $(fichiers_tecdoc); do
+  grep -qE "pm_display|__tecdoc_supplier_mapping" "$f" || continue
+  signaler R1 "$f" \
+    "perimetre derive d'une requete vivante (pm_display / __tecdoc_supplier_mapping)" \
+    "Utiliser tecdoc_scope.resoudre_dlnr(mode, scope_file) avec un mode explicite."
+done
+[ "$echecs" -eq "$avant" ] && echo "  ✓ aucun perimetre derive du vivant"
+
+echo "== R2 — aucun chargement sans garde de comptabilite =="
+avant=$echecs
+for f in $(fichiers_tecdoc); do
+  grep -qE "copy_from|copy_expert|INSERT INTO tecdoc_raw|INSERT INTO t[0-9]" "$f" || continue
+  grep -qE "verifier_lot|tecdoc_load_guard" "$f" && continue
+  signaler R2 "$f" \
+    "ecrit dans tecdoc_raw sans verifier_lot (tecdoc_load_guard)" \
+    "Un lot qui ne se solde pas ne doit jamais etre committe."
+done
+[ "$echecs" -eq "$avant" ] && echo "  ✓ tout chemin d'ecriture passe par la garde de comptabilite"
+
+echo "== R3 — la quarantaine reste une quarantaine =="
+avant=$echecs
+fuites=$(grep -rnE --include='*.py' --include='*.sh' --include='*.ts' --include='*.yml' \
+           -e "${QUARANTAINE}/[A-Za-z0-9_.-]+\.py" \
+           -e "sys\.path.*tecdoc-pipeline" \
+           scripts/ backend/ .github/ 2>/dev/null \
+         | grep -v "^${QUARANTAINE}/" \
+         | grep -v 'check-tecdoc-failclosed-ratchet.sh' || true)
+if [ -n "$fuites" ]; then
+  echo "  ✗ la quarantaine est importee ou executee depuis l'exterieur :"
+  printf '%s\n' "$fuites" | sed 's/^/      /'
+  echecs=$((echecs+1))
+else
+  echo "  ✓ aucun appelant exterieur des scripts historiques"
+fi
+
+echo "== Symetrie — aucune exemption morte =="
+avant=$echecs
+while read -r regle chemin; do
+  [ -z "${regle:-}" ] && continue
+  case "$regle" in \#*) continue;; esac
+  if [ -z "${VU[$regle $chemin]:-}" ]; then
+    echo "  ✗ exemption morte : « $regle $chemin » ne correspond a aucune violation."
+    echo "      La retirer de $ALLOW — une exemption morte etouffera la regle plus tard."
+    echecs=$((echecs+1))
+  fi
+done < <(grep -E '^R[0-9] ' "$ALLOW" 2>/dev/null)
+[ "$echecs" -eq "$avant" ] && echo "  ✓ les $(grep -cE '^R[0-9] ' "$ALLOW") exemptions sont toutes vivantes"
+
+echo
+if [ "$echecs" -ne 0 ]; then
+  echo "RATCHET ROUGE — $echecs violation(s). Une perte de ligne, une derive d'identite"
+  echo "ou une difference de scope ne doit plus pouvoir produire un run vert."
+  exit 1
+fi
+echo "RATCHET VERT — R1, R2, R3 tenus ; exemptions vivantes et motivees."

--- a/scripts/lint/tecdoc-failclosed-allowlist.txt
+++ b/scripts/lint/tecdoc-failclosed-allowlist.txt
@@ -1,0 +1,35 @@
+# Exceptions gouvernées au ratchet scripts/lint/check-tecdoc-failclosed-ratchet.sh
+#
+# Une ligne = "<règle> <chemin>", précédée d'une ligne "# motif : ..." qui explique
+# pourquoi la règle ne s'applique pas, ou pourquoi la dette est assumée et par quoi
+# elle sera soldée. Une entrée sans motif est une dette, pas une exception.
+#
+# Le ratchet est SYMÉTRIQUE : une entrée qui ne viole plus rien fait échouer le
+# garde. Une exemption morte est pire qu'inutile — elle étoufferait la règle le jour
+# où quelqu'un retire le correctif.
+
+# motif : fournisseur du mode `current`. C'est ce fichier qui PORTE, par construction,
+# la requête de merchandising vivante que R1 interdit à ses appelants. `resoudre_dlnr`
+# exige un mode explicite et lève `PerimetreManquant` plutôt que de se replier sur le
+# vivant : l'exemption porte sur le fournisseur du mode, jamais sur un consommateur.
+R1 scripts/tecdoc_scope.py
+
+# motif : producteur de l'artefact scellé (PR #1416). N'interroge aucune base — il
+# lit `suppliers.json` et ENREGISTRE `pm_display` comme donnée d'époque dans le
+# périmètre figé. Les occurrences sont des noms de champs et de la prose décrivant
+# le critère de mars 2026, pas une dérivation de périmètre.
+R1 scripts/tecdoc-scope-build/build_scope.py
+
+# motif : DETTE ASSUMÉE, préexistante (commit df8f5a4d3, avant ce chantier). Dérive
+# réellement sa liste de fournisseurs de `__tecdoc_supplier_mapping` (L118-129).
+# Hors périmètre de la mission fail-closed, qui ne devait pas refactorer les scripts
+# existants. À solder en câblant `tecdoc_scope.resoudre_dlnr` — suivi :
+# audit/massdoc-tecdoc-failclosed-replay-2026-09-08.md §9.
+R1 scripts/tecdoc-import.py
+
+# motif : DETTE ASSUMÉE, rapatriée en PR #1412. Écrit dans `tecdoc_raw` (L66) sans
+# garde de comptabilité. Chemin d'écriture réel, donc dette RÉELLE et non un faux
+# positif : tant qu'elle n'est pas soldée, le principe « une perte de ligne ne peut
+# plus produire un run vert » ne vaut que pour le chemin canonique `tecdoc_replay.py`.
+# À solder en câblant `verifier_lot` — même suivi.
+R2 scripts/tecdoc-batch-load.py

--- a/scripts/tecdoc-replay/generer-manifeste-synthetique.py
+++ b/scripts/tecdoc-replay/generer-manifeste-synthetique.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Genere le manifeste scelle du banc a partir de la reference synthetique.
+
+Les empreintes sont MESUREES sur la base, jamais ecrites a la main : c'est la meme
+discipline que pour le manifeste reel de mars 2026. A relancer si
+`reference-synthetique.sql` change.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from tecdoc_preservation import REQUETES          # noqa: E402
+from tecdoc_seal import calculer                  # noqa: E402
+
+import psycopg2                                   # noqa: E402
+
+CLES = {
+    "auto_type — types crees/remappes par la campagne": ("public.auto_type", "type_id_i"),
+    "auto_modele — modeles ajoutes": ("public.auto_modele", "modele_id"),
+    "pieces — cohorte introduite par la campagne": ("public.pieces", "piece_id"),
+    "pieces — sous-ensemble affiche de la cohorte": ("public.pieces", "piece_id"),
+    "pieces_gamme — gammes creees par la campagne (bande reservee)": ("public.pieces_gamme", "pg_id"),
+    "tecdoc_map.type_id_remap — mapping d'identite vehicule (ancien -> nouveau)":
+        ("tecdoc_map.type_id_remap", "old_id"),
+    "tecdoc_map.gamme_registry — filiation gamme source -> pg_id":
+        ("tecdoc_map.gamme_registry", "pg_id"),
+    "tecdoc_map.linkage_target_registry — cibles de liaison":
+        ("tecdoc_map.linkage_target_registry", "id"),
+    "tecdoc_map.article_registry — ancrage piece_id <-> ARTNR/DLNR":
+        ("tecdoc_map.article_registry", "piece_id"),
+}
+
+dsn = sys.argv[1]
+sortie = Path(sys.argv[2])
+
+ensembles = []
+with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+    for nom, requete in REQUETES.items():
+        cur.execute(requete)
+        cardinal, bmin, bmax, empreinte = cur.fetchone()
+        table, cle = CLES[nom]
+        ensembles.append({"nom": nom, "table": table, "cle": cle,
+                          "cardinal": cardinal, "borne_min": bmin, "borne_max": bmax,
+                          "empreinte_md5": empreinte, "confidence": "SYNTHETIQUE"})
+
+doc = {
+    "manifest_version": "banc-synthetique-v1",
+    "objet": "Manifeste du banc de rejeu — mesure sur reference-synthetique.sql. "
+             "N'a AUCUNE valeur sur MassDoc PROD ; il ne sert qu'a eprouver la garde.",
+    "invariant": "Les ensembles figes ne changent pas entre deux rejeux.",
+    "methode_de_controle": "identique au manifeste reel : cardinal, bornes, empreinte md5.",
+    "ensembles_figes": ensembles,
+}
+doc["seal"] = {"algorithm": "sha256",
+               "canonicalization": "sort_keys, UTF-8, separateurs (',',':'), bloc seal exclu.",
+               "sha256": calculer(doc)}
+sortie.write_text(json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                  encoding="utf-8")
+print(f"{sortie.name} : {len(ensembles)} ensembles, sceau {doc['seal']['sha256'][:16]}…")

--- a/scripts/tecdoc-replay/manifeste-synthetique.json
+++ b/scripts/tecdoc-replay/manifeste-synthetique.json
@@ -1,0 +1,103 @@
+{
+  "ensembles_figes": [
+    {
+      "borne_max": 60009,
+      "borne_min": 60000,
+      "cardinal": 10,
+      "cle": "type_id_i",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "8dc56ce4e3beaa89f87daf2253685e64",
+      "nom": "auto_type — types crees/remappes par la campagne",
+      "table": "public.auto_type"
+    },
+    {
+      "borne_max": 5,
+      "borne_min": 1,
+      "cardinal": 5,
+      "cle": "modele_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "afe805e5a3c3ec7fa05645a6a2a6e607",
+      "nom": "auto_modele — modeles ajoutes",
+      "table": "public.auto_modele"
+    },
+    {
+      "borne_max": 8,
+      "borne_min": 1,
+      "cardinal": 8,
+      "cle": "piece_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "b5ca3ba695d8ec8ce47bf6e7a2b579d0",
+      "nom": "pieces — cohorte introduite par la campagne",
+      "table": "public.pieces"
+    },
+    {
+      "borne_max": 5,
+      "borne_min": 1,
+      "cardinal": 5,
+      "cle": "piece_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "afe805e5a3c3ec7fa05645a6a2a6e607",
+      "nom": "pieces — sous-ensemble affiche de la cohorte",
+      "table": "public.pieces"
+    },
+    {
+      "borne_max": 60004,
+      "borne_min": 60000,
+      "cardinal": 5,
+      "cle": "pg_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "52db30b1f40326df222da7de43773eeb",
+      "nom": "pieces_gamme — gammes creees par la campagne (bande reservee)",
+      "table": "public.pieces_gamme"
+    },
+    {
+      "borne_max": "100002",
+      "borne_min": "100001",
+      "cardinal": 2,
+      "cle": "old_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "03cd88fb11e57cd6332ec3985c1d0d2c",
+      "nom": "tecdoc_map.type_id_remap — mapping d'identite vehicule (ancien -> nouveau)",
+      "table": "tecdoc_map.type_id_remap"
+    },
+    {
+      "borne_max": 60002,
+      "borne_min": 60000,
+      "cardinal": 3,
+      "cle": "pg_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "9ef256df14185e9f45cb321e6b4b52ec",
+      "nom": "tecdoc_map.gamme_registry — filiation gamme source -> pg_id",
+      "table": "tecdoc_map.gamme_registry"
+    },
+    {
+      "borne_max": 4,
+      "borne_min": 1,
+      "cardinal": 4,
+      "cle": "id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "f8ef5bbac13edd1c0251d9200be10bf6",
+      "nom": "tecdoc_map.linkage_target_registry — cibles de liaison",
+      "table": "tecdoc_map.linkage_target_registry"
+    },
+    {
+      "borne_max": null,
+      "borne_min": null,
+      "cardinal": 3,
+      "cle": "piece_id",
+      "confidence": "SYNTHETIQUE",
+      "empreinte_md5": "df9683fa7afa5872f9a92cdc664e4b45",
+      "nom": "tecdoc_map.article_registry — ancrage piece_id <-> ARTNR/DLNR",
+      "table": "tecdoc_map.article_registry"
+    }
+  ],
+  "invariant": "Les ensembles figes ne changent pas entre deux rejeux.",
+  "manifest_version": "banc-synthetique-v1",
+  "methode_de_controle": "identique au manifeste reel : cardinal, bornes, empreinte md5.",
+  "objet": "Manifeste du banc de rejeu — mesure sur reference-synthetique.sql. N'a AUCUNE valeur sur MassDoc PROD ; il ne sert qu'a eprouver la garde.",
+  "seal": {
+    "algorithm": "sha256",
+    "canonicalization": "sort_keys, UTF-8, separateurs (',',':'), bloc seal exclu.",
+    "sha256": "b30a1b480691290b6b724dccefee0c056fddc0ff1e3a1386626b3d8df4def357"
+  }
+}

--- a/scripts/tecdoc-replay/parseur-tronqueur.py
+++ b/scripts/tecdoc-replay/parseur-tronqueur.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Stub d'INJECTION : analyse normalement, puis tronque le CSV en gardant le .meta.
+
+Reproduit exactement la situation de mars 2026 — le parseur a rendu compte de
+`rows_emitted` lignes, la base n'en a recu qu'un prefixe — sans toucher au chemin
+canonique. N'est utilise QUE par `test-tecdoc-replay.sh`.
+
+Variable d'environnement : INJECTION_GARDER = nombre de lignes CSV conservees.
+"""
+import os
+import subprocess
+import sys
+
+REEL = "/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py"
+
+argv = sys.argv[1:]
+code = subprocess.run(["python3", REEL, *argv]).returncode
+if code != 0:
+    sys.exit(code)
+
+garder = int(os.environ["INJECTION_GARDER"])
+csv_path = argv[argv.index("-o") + 1]
+with open(csv_path, "r", encoding="utf-8") as f:
+    lignes = [next(f) for _ in range(garder)]
+with open(csv_path, "w", encoding="utf-8") as f:
+    f.writelines(lignes)
+print(f"INJECTION : CSV tronque a {garder} lignes, .meta laisse intact",
+      file=sys.stderr)

--- a/scripts/tecdoc-replay/reference-synthetique.sql
+++ b/scripts/tecdoc-replay/reference-synthetique.sql
@@ -1,0 +1,43 @@
+-- Base de REFERENCE synthetique du banc de rejeu.
+--
+-- Le banc doit pouvoir tourner en CI sans MassDoc PROD et sans aucun secret. Cette
+-- base joue le role de « ce qui est servi aujourd'hui » face auquel les controles
+-- d'identite, de conservation et de reconciliation sont eprouves.
+--
+-- Les volumes sont minuscules et FIGES : les empreintes de `manifeste-synthetique.json`
+-- en decoulent. Modifier une ligne ici sans regenerer le manifeste fait echouer le banc
+-- — c'est voulu, c'est exactement ce que le controle de conservation doit detecter.
+CREATE DATABASE reference;
+\c reference
+
+CREATE SCHEMA IF NOT EXISTS tecdoc_raw;
+CREATE SCHEMA IF NOT EXISTS tecdoc_map;
+
+CREATE TABLE tecdoc_raw.t400 (
+  col_1 text, col_2 text, col_3 text, col_4 text,
+  col_5 text, col_6 text, col_7 text, col_8 text,
+  _source_filename text, _batch_id text, _loaded_at timestamptz DEFAULT now(),
+  _source_row_no integer, _raw_hash text
+);
+
+CREATE TABLE public.auto_type    (type_id_i integer PRIMARY KEY);
+CREATE TABLE public.auto_modele  (modele_id integer PRIMARY KEY, modele_is_new text);
+CREATE TABLE public.pieces       (piece_id integer PRIMARY KEY, piece_year text, piece_display boolean);
+CREATE TABLE public.pieces_gamme (pg_id integer PRIMARY KEY);
+
+CREATE TABLE tecdoc_map.type_id_remap           (old_id text PRIMARY KEY, new_id text NOT NULL);
+CREATE TABLE tecdoc_map.modele_id_remap         (old_id text PRIMARY KEY, new_id text NOT NULL);
+CREATE TABLE tecdoc_map.pg_id_remap             (old_id text PRIMARY KEY, new_id text NOT NULL);
+CREATE TABLE tecdoc_map.gamme_registry          (pg_id_source text PRIMARY KEY, pg_id integer);
+CREATE TABLE tecdoc_map.linkage_target_registry (id bigint PRIMARY KEY, target_key text);
+CREATE TABLE tecdoc_map.article_registry        (piece_id bigint PRIMARY KEY, source_artnr text, source_dlnr text);
+
+INSERT INTO public.auto_type    SELECT generate_series(60000, 60009);
+INSERT INTO public.auto_modele  SELECT generate_series(1, 5), '1';
+INSERT INTO public.pieces       SELECT g, '2025', (g <= 5) FROM generate_series(1, 8) g;
+INSERT INTO public.pieces_gamme SELECT generate_series(60000, 60004);
+
+INSERT INTO tecdoc_map.type_id_remap  VALUES ('100001','60001'), ('100002','60002');
+INSERT INTO tecdoc_map.gamme_registry VALUES ('2', 60000), ('10', 60001), ('1000', 60002);
+INSERT INTO tecdoc_map.linkage_target_registry SELECT g, 'cible_'||g FROM generate_series(1, 4) g;
+INSERT INTO tecdoc_map.article_registry VALUES (1,'H1 656','4523'), (2,'H1 657','4523'), (3,'X','30');

--- a/scripts/tecdoc-replay/schema-jetable.sql
+++ b/scripts/tecdoc-replay/schema-jetable.sql
@@ -1,0 +1,35 @@
+-- Schema du banc de rejeu JETABLE. Calque sur le DDL reel de MassDoc PROD
+-- (information_schema, releve 2026-09-08). N'est JAMAIS applique a PROD.
+CREATE SCHEMA IF NOT EXISTS tecdoc_raw;
+CREATE SCHEMA IF NOT EXISTS tecdoc_map;
+
+-- t400 : 8 colonnes metier + 5 colonnes de provenance.
+-- `_loaded_at DEFAULT now()` est reproduit a l'identique : c'est le defaut que le
+-- loader historique neutralisait en poussant un NULL explicite.
+CREATE TABLE IF NOT EXISTS tecdoc_raw.t400 (
+  col_1 text, col_2 text, col_3 text, col_4 text,
+  col_5 text, col_6 text, col_7 text, col_8 text,
+  _source_filename text,
+  _batch_id        text,
+  _loaded_at       timestamptz DEFAULT now(),
+  _source_row_no   integer,
+  _raw_hash        text
+);
+CREATE INDEX IF NOT EXISTS t400_batch_idx ON tecdoc_raw.t400 (_batch_id);
+CREATE INDEX IF NOT EXISTS t400_dlnr_idx  ON tecdoc_raw.t400 (col_2);
+
+CREATE TABLE IF NOT EXISTS tecdoc_raw.t232 (
+  artnr text NOT NULL, dlnr text NOT NULL, sa text, sortnr text, lkz text,
+  exclude_flag text, bildnr text NOT NULL, dokumentenart text, losch_flag text,
+  _source_filename text, _batch_id text, _loaded_at text,
+  _source_row_no text, _raw_hash text
+);
+CREATE INDEX IF NOT EXISTS t232_batch_idx ON tecdoc_raw.t232 (_batch_id);
+
+-- Registres d'identite proteges (ADR : jamais de renumerotation).
+CREATE TABLE IF NOT EXISTS tecdoc_map.type_id_remap          (old_id text PRIMARY KEY, new_id text NOT NULL);
+CREATE TABLE IF NOT EXISTS tecdoc_map.article_registry       (piece_id bigint PRIMARY KEY, source_artnr text, source_dlnr text);
+CREATE TABLE IF NOT EXISTS tecdoc_map.linkage_target_registry(id bigint PRIMARY KEY, target_key text);
+CREATE TABLE IF NOT EXISTS tecdoc_map.gamme_registry         (pg_id_source text PRIMARY KEY, pg_id integer);
+CREATE TABLE IF NOT EXISTS tecdoc_map.modele_id_remap        (old_id text PRIMARY KEY, new_id text NOT NULL);
+CREATE TABLE IF NOT EXISTS tecdoc_map.pg_id_remap            (old_id text PRIMARY KEY, new_id text NOT NULL);

--- a/scripts/tecdoc_replay.py
+++ b/scripts/tecdoc_replay.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Rejeu TecDoc fail-closed — extraction, analyse, chargement et controles.
+
+Chemin canonique du rejeu. Remplace `load-t400-active.py`, conserve en quarantaine
+sous `tecdoc-pipeline/` a titre forensique, dont il corrige les trois defauts qui ont
+rendu la perte de mars 2026 invisible :
+
+  1. L'exception avalee (`except Exception: log(...)`) laissait le script rendre le
+     nombre de lignes deja committees comme s'il s'agissait d'un succes.
+  2. `autocommit = True` committait chaque COPY : un arret en cours de fichier laissait
+     un PREFIXE de lignes en base, definitivement pris pour un chargement complet.
+  3. Aucune comparaison entre ce que le parseur avait emis et ce qui etait arrive en
+     base. `rows_emitted=9357752` et `69000` lignes chargees coexistaient sans alerte.
+
+Ici : une seule transaction par lot, la comptabilite verifiee AVANT le commit, et
+toute anomalie leve. Un lot qui ne se solde pas n'est jamais committe.
+
+Etats possibles d'une ligne source — il n'y en a pas de cinquieme :
+  charge · dedoublonne · rejete(raison nommee) · fatal (leve, rien n'est committe)
+
+Usage :
+  tecdoc_replay.py --scope-mode historical --scope-file <artefact scelle> \\
+                   --dlnr 4523 --table 400 --cible-dsn <dsn jetable>
+
+Codes de sortie :
+  0 rejeu conforme · 2 sceau invalide · 3 artefact/source illisible
+  4 perimetre refuse · 5 comptabilite incoherente · 9 integrite de lot rompue
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import os
+import subprocess
+import sys
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tecdoc_load_guard import Bilan, ComptabiliteIncoherente, verifier_lot
+from tecdoc_scope import (SceauInvalide, ajouter_arguments_perimetre,
+                          charger_perimetre, resoudre_dlnr)
+
+#: Les quatre etats d'une ligne source. Toute branche qui ignore une ligne doit en
+#: choisir un — c'est ce qui interdit le « skip » silencieux.
+ETATS = ("charge", "dedoublonne", "rejete", "fatal")
+
+ARCHIVE_DEFAUT = "/opt/automecanik/app/.github/SQL-CONVERTED.7z"
+PARSEUR_DEFAUT = "/opt/automecanik/app/scripts/tecdoc-mysql-to-csv.py"
+
+#: Colonnes ecrites par le COPY. `_loaded_at` est volontairement ABSENTE : la colonne
+#: porte `DEFAULT now()`, et le loader historique la neutralisait en poussant un NULL
+#: explicite (un NULL fourni ecrase le defaut). En ne la citant pas, le defaut
+#: s'applique et chaque lot devient datable.
+COLONNES_COPY = ["col_1", "col_2", "col_3", "col_4", "col_5", "col_6", "col_7", "col_8",
+                 "_source_filename", "_batch_id", "_source_row_no", "_raw_hash"]
+
+#: Position des champs dans le CSV du parseur : 8 colonnes metier puis
+#: _source_filename, _batch_id (vide), _loaded_at (vide), _source_row_no, _raw_hash.
+CHAMPS_METIER = 8
+IDX_FICHIER, IDX_ROW_NO, IDX_HASH = 8, 11, 12
+CHAMPS_ATTENDUS = 13
+
+
+class RejeuFatal(RuntimeError):
+    """Anomalie qui interdit de committer. Jamais rattrapee pour continuer."""
+
+
+class IntegriteLotRompue(RejeuFatal):
+    """Ce qui est en base ne correspond pas a ce que le lot pretend avoir charge."""
+
+
+class PerimetreRefuse(RejeuFatal):
+    """Le DLNR demande n'appartient pas au perimetre resolu."""
+
+
+@dataclass
+class Lot:
+    """Un couple (table, DLNR) traverse le rejeu. Immuable une fois solde."""
+
+    dlnr: int
+    table: str
+    fichier: str
+    batch_id: str
+    emis: int = 0
+    charges: int = 0
+    dedoublonnes: int = 0
+    rejets: dict = field(default_factory=dict)
+    numeros_rejetes: set = field(default_factory=set)
+    bilan: Bilan | None = None
+
+    def rejeter(self, raison: str, numero: int | None) -> None:
+        """Enregistre un rejet MOTIVE. Aucune ligne ne disparait sans raison nommee."""
+        self.rejets[raison] = self.rejets.get(raison, 0) + 1
+        if numero is not None:
+            self.numeros_rejetes.add(numero)
+
+
+# ---------------------------------------------------------------------------
+# Identite de lot — la cle d'idempotence
+# ---------------------------------------------------------------------------
+
+def batch_id(*, dlnr: int, table: str, crc32: str, version_perimetre: str) -> str:
+    """Identifiant DETERMINISTE d'un lot : meme source + meme perimetre = meme id.
+
+    Sert a repondre a « ce lot est-il deja charge ? » sans compter des lignes ni
+    interroger `DISTINCT col_2`, qui repondait « oui » des la premiere ligne presente
+    et a fige les chargements tronques de mars 2026 (un DLNR partiel n'etait jamais
+    retente). La colonne `_batch_id` existe depuis l'origine et n'a jamais ete ecrite.
+    """
+    graine = f"{table}|{dlnr}|{crc32.lower()}|{version_perimetre}"
+    return hashlib.sha256(graine.encode("utf-8")).hexdigest()[:32]
+
+
+# ---------------------------------------------------------------------------
+# Etape 1 — extraction, verifiee contre le sceau
+# ---------------------------------------------------------------------------
+
+def crc32_fichier(chemin: Path) -> str:
+    """CRC32 au format de l'index 7z (8 hexa majuscules)."""
+    somme = 0
+    with chemin.open("rb") as f:
+        for bloc in iter(lambda: f.read(1 << 20), b""):
+            somme = zlib.crc32(bloc, somme)
+    return f"{somme & 0xFFFFFFFF:08X}"
+
+
+def etape_extraire(*, dlnr: int, table: str, perimetre, archive: str,
+                   workdir: Path) -> tuple[Path, dict]:
+    """Extrait le shard et VERIFIE son CRC32 contre l'artefact scelle.
+
+    Une source qui ne correspond pas au sceau n'est pas la source de mars 2026 :
+    rejouer dessus produirait un resultat qu'on croirait comparable et qui ne l'est pas.
+    """
+    shard = perimetre.shard(dlnr, table)
+    nom = shard["name"]
+    workdir.mkdir(parents=True, exist_ok=True)
+    cible = workdir / nom
+
+    if not cible.exists():
+        r = subprocess.run(["7z", "e", "-y", f"-o{workdir}", archive, nom],
+                           capture_output=True, timeout=600)
+        if r.returncode != 0:
+            raise RejeuFatal(f"extraction de {nom} echouee (code {r.returncode}) : "
+                             f"{r.stderr.decode('utf-8', 'replace')[:300]}")
+    if not cible.exists():
+        raise RejeuFatal(f"{nom} absent apres extraction — source introuvable, STOP.")
+
+    obtenu = crc32_fichier(cible)
+    attendu = str(shard["crc32"]).upper()
+    if obtenu != attendu:
+        raise RejeuFatal(
+            f"{nom} : CRC32 {obtenu} != {attendu} scelle dans le perimetre.\n"
+            "La source ne correspond pas a celle de mars 2026 — rejeu refuse."
+        )
+    taille = cible.stat().st_size
+    if taille != shard["size"]:
+        raise RejeuFatal(f"{nom} : taille {taille} != {shard['size']} scellee.")
+    return cible, shard
+
+
+# ---------------------------------------------------------------------------
+# Etape 2 — analyse
+# ---------------------------------------------------------------------------
+
+def lire_meta(chemin: Path) -> dict:
+    """Lit le .meta du parseur. Son absence est FATALE : sans `rows_emitted`, la
+    comptabilite n'a pas de terme gauche et la garde ne peut rien prouver."""
+    if not chemin.exists():
+        raise RejeuFatal(f"{chemin.name} absent : le parseur n'a pas rendu de compte "
+                         "d'emission. Sans lui, aucun ecart n'est demontrable — STOP.")
+    meta: dict = {}
+    for ligne in chemin.read_text(encoding="utf-8").splitlines():
+        if "=" in ligne:
+            cle, _, val = ligne.partition("=")
+            meta[cle.strip()] = int(val) if val.strip().lstrip("-").isdigit() else val.strip()
+    for requis in ("rows_parsed", "rows_emitted", "rows_rejected"):
+        if requis not in meta:
+            raise RejeuFatal(f"{chemin.name} : champ {requis} manquant.")
+    return meta
+
+
+def etape_analyser(sql: Path, parseur: str) -> tuple[Path, dict]:
+    """Analyse le shard en CSV. Un code retour non nul du parseur est FATAL.
+
+    Le loader historique se contentait de journaliser `Parser error:` et continuait
+    avec le CSV partiel eventuellement produit.
+    """
+    csv_path = sql.with_suffix(".csv")
+    meta_path = sql.with_suffix(".meta")
+    r = subprocess.run(["python3", parseur, str(sql), "-o", str(csv_path)],
+                       capture_output=True, text=True, timeout=3600)
+    if r.returncode != 0:
+        raise RejeuFatal(
+            f"parseur en echec sur {sql.name} (code {r.returncode}) : "
+            f"{(r.stderr or '')[-500:]}\nAucun chargement sur analyse incomplete."
+        )
+    if not csv_path.exists():
+        raise RejeuFatal(f"{csv_path.name} non produit par le parseur — STOP.")
+    return csv_path, lire_meta(meta_path)
+
+
+# ---------------------------------------------------------------------------
+# Etape 3 — chargement transactionnel
+# ---------------------------------------------------------------------------
+
+def _normaliser(champs: list[str], lot: Lot) -> list[str] | None:
+    """Rend la ligne prete pour le COPY, ou None si elle est REJETEE (motif compte).
+
+    C'est ici que vivait le `if len(row) >= 8:` du loader historique : une ligne trop
+    courte etait ignoree, sans compteur, sans trace, sans raison.
+    """
+    numero = None
+    if len(champs) > IDX_ROW_NO and champs[IDX_ROW_NO].strip().isdigit():
+        numero = int(champs[IDX_ROW_NO])
+
+    if len(champs) < CHAMPS_ATTENDUS:
+        lot.rejeter("colonnes_insuffisantes", numero)
+        return None
+    if numero is None:
+        lot.rejeter("numero_de_ligne_source_absent_ou_non_entier", None)
+        return None
+    if not champs[IDX_HASH].strip():
+        lot.rejeter("empreinte_de_ligne_absente", numero)
+        return None
+
+    metier = champs[:CHAMPS_METIER]
+    return metier + [champs[IDX_FICHIER], lot.batch_id, str(numero), champs[IDX_HASH]]
+
+
+def _tsv(valeurs: list[str]) -> str:
+    """Encode pour COPY texte. Les separateurs presents dans une valeur sont echappes
+    au lieu d'etre laisses casser l'alignement des colonnes silencieusement."""
+    sortie = []
+    for v in valeurs:
+        if v == "":
+            sortie.append("\\N")
+        else:
+            sortie.append(v.replace("\\", "\\\\").replace("\t", "\\t")
+                           .replace("\n", "\\n").replace("\r", "\\r"))
+    return "\t".join(sortie)
+
+
+def etape_charger(*, conn, csv_path: Path, lot: Lot, meta: dict, schema: str,
+                  dedoublonner: bool, taille_bloc: int) -> Lot:
+    """Charge le lot dans UNE transaction et ne commit que s'il se solde.
+
+    Contrairement au chemin historique, `conn.autocommit` reste False : une exception
+    a n'importe quel moment annule TOUT le lot. Un prefixe partiel n'est plus un etat
+    atteignable.
+    """
+    lot.emis = int(meta["rows_emitted"])
+    if lot.emis == 0:
+        raise RejeuFatal(f"DLNR {lot.dlnr} : le parseur n'a emis aucune ligne — STOP.")
+
+    table = f"{schema}.t{lot.table}"
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    cur.execute(f"SELECT count(*) FROM {table} WHERE _batch_id = %s", (lot.batch_id,))
+    if cur.fetchone()[0]:
+        conn.rollback()
+        raise RejeuFatal(
+            f"lot {lot.batch_id} deja present dans {table}. Le rejeu est idempotent : "
+            "il refuse de recharger par-dessus. Purger explicitement ce lot pour le refaire."
+        )
+
+    vus: set[str] = set()
+    bloc: list[str] = []
+    csv.field_size_limit(1 << 24)
+
+    def vider() -> None:
+        if not bloc:
+            return
+        cur.copy_from(io.StringIO("\n".join(bloc) + "\n"), f"t{lot.table}",
+                      sep="\t", columns=COLONNES_COPY, null="\\N")
+        bloc.clear()
+
+    try:
+        cur.execute(f"SET LOCAL search_path TO {schema}")
+        with csv_path.open("r", encoding="utf-8", newline="") as f:
+            for champs in csv.reader(f):
+                pret = _normaliser(champs, lot)
+                if pret is None:
+                    continue
+                if dedoublonner:
+                    empreinte = pret[-1]  # _raw_hash, dernier champ du COPY
+                    if empreinte in vus:
+                        lot.dedoublonnes += 1
+                        continue
+                    vus.add(empreinte)
+                bloc.append(_tsv(pret))
+                lot.charges += 1
+                if len(bloc) >= taille_bloc:
+                    vider()
+            vider()
+    except Exception as e:
+        conn.rollback()
+        # Re-leve TOUJOURS. C'est la ligne que le chemin historique n'avait pas.
+        raise RejeuFatal(
+            f"DLNR {lot.dlnr} : chargement interrompu apres {lot.charges} lignes sur "
+            f"{lot.emis} emises — transaction annulee, rien n'est en base.\n"
+            f"  cause : {type(e).__name__}: {e}"
+        ) from e
+
+    # --- controles AVANT commit -------------------------------------------
+    try:
+        lot.bilan = verifier_lot(emis=lot.emis, charges=lot.charges,
+                                 dedoublonnes=lot.dedoublonnes, rejets=lot.rejets,
+                                 dlnr=lot.dlnr)
+    except ComptabiliteIncoherente:
+        conn.rollback()
+        raise
+
+    cur.execute(
+        f"""SELECT count(*), count(DISTINCT _source_row_no),
+                   min(_source_row_no), max(_source_row_no)
+            FROM {table} WHERE _batch_id = %s""", (lot.batch_id,))
+    en_base, distincts, borne_min, borne_max = cur.fetchone()
+
+    anomalies = []
+    if en_base != lot.charges:
+        anomalies.append(f"{en_base} lignes en base != {lot.charges} annoncees chargees")
+    if distincts != en_base:
+        anomalies.append(f"{en_base - distincts} numero(s) de ligne source en double")
+    if borne_max is not None and borne_max > lot.emis:
+        anomalies.append(f"numero de ligne max {borne_max} > {lot.emis} emis")
+    # L'egalite emis = charges + dedoublonnes + rejets est portee par `verifier_lot`
+    # ci-dessus, et par lui seul. Les controles ci-dessous portent sur ce que la BASE
+    # contient reellement — ce qu'aucun compteur en memoire ne peut prouver.
+
+    if anomalies:
+        conn.rollback()
+        raise IntegriteLotRompue(
+            f"DLNR {lot.dlnr} : le contenu charge ne correspond pas au compte rendu.\n  "
+            + "\n  ".join(anomalies)
+            + "\nTransaction annulee. Le compteur du script ne fait jamais foi contre la base."
+        )
+
+    conn.commit()
+    return lot
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ajouter_arguments_perimetre(ap)
+    ap.add_argument("--dlnr", type=int, required=True, help="fournisseur a rejouer")
+    ap.add_argument("--table", default="400", help="table shardee (defaut : 400)")
+    ap.add_argument("--cible-dsn", required=True,
+                    help="DSN de la base JETABLE. Jamais la base MassDoc partagee.")
+    ap.add_argument("--schema", default="tecdoc_raw")
+    ap.add_argument("--archive", default=ARCHIVE_DEFAUT)
+    ap.add_argument("--parseur", default=PARSEUR_DEFAUT)
+    ap.add_argument("--workdir", default=None, help="repertoire de travail (obligatoire)")
+    ap.add_argument("--taille-bloc", type=int, default=50000)
+    ap.add_argument("--dedoublonner-identiques", action="store_true",
+                    help="fusionne les lignes de meme empreinte, COMPTEES separement. "
+                         "Par defaut inactif : toute ligne source est chargee.")
+    ap.add_argument("--json", action="store_true", help="rapport machine sur stdout")
+    args = ap.parse_args(argv)
+
+    if not args.workdir:
+        ap.error("--workdir est obligatoire (aucun repertoire par defaut suppose)")
+
+    if args.scope_mode != "historical":
+        print("PERIMETRE REFUSE : le rejeu d'un shard d'archive exige "
+              "--scope-mode historical. Le mode `current` ne porte ni le nom du shard, "
+              "ni son CRC32 : sans eux, rien ne prouve que la source rejouee est celle "
+              "de mars 2026.", file=sys.stderr)
+        return 4
+
+    try:
+        dlnrs = resoudre_dlnr(args.scope_mode, args.scope_file,
+                             selection=args.scope_selection)
+    except SceauInvalide as e:
+        print(f"SCEAU INVALIDE : {e}", file=sys.stderr)
+        return 2
+    except Exception as e:
+        print(f"PERIMETRE : {e}", file=sys.stderr)
+        return 4
+
+    if args.dlnr not in dlnrs:
+        print(f"PERIMETRE REFUSE : DLNR {args.dlnr} hors du perimetre resolu "
+              f"({len(dlnrs)} fournisseurs, mode {args.scope_mode}/{args.scope_selection}).",
+              file=sys.stderr)
+        return 4
+
+    perimetre = charger_perimetre(args.scope_file)
+
+    try:
+        import psycopg2
+        sql, shard = etape_extraire(dlnr=args.dlnr, table=args.table,
+                                    perimetre=perimetre, archive=args.archive,
+                                    workdir=Path(args.workdir))
+        csv_path, meta = etape_analyser(sql, args.parseur)
+        lot = Lot(dlnr=args.dlnr, table=args.table, fichier=shard["name"],
+                  batch_id=batch_id(dlnr=args.dlnr, table=args.table,
+                                    crc32=shard["crc32"],
+                                    version_perimetre=perimetre.version))
+        with psycopg2.connect(args.cible_dsn) as conn:
+            etape_charger(conn=conn, csv_path=csv_path, lot=lot, meta=meta,
+                          schema=args.schema,
+                          dedoublonner=args.dedoublonner_identiques,
+                          taille_bloc=args.taille_bloc)
+    except ComptabiliteIncoherente as e:
+        print(f"COMPTABILITE INCOHERENTE\n{e}", file=sys.stderr)
+        return 5
+    except IntegriteLotRompue as e:
+        print(f"INTEGRITE DE LOT ROMPUE\n{e}", file=sys.stderr)
+        return 9
+    except RejeuFatal as e:
+        print(f"REJEU FATAL\n{e}", file=sys.stderr)
+        return 3
+
+    if args.json:
+        import json
+        print(json.dumps({"dlnr": lot.dlnr, "table": lot.table,
+                          "batch_id": lot.batch_id, "fichier": lot.fichier,
+                          "emis": lot.emis, "charges": lot.charges,
+                          "dedoublonnes": lot.dedoublonnes, "rejets": lot.rejets},
+                         ensure_ascii=False, sort_keys=True))
+    else:
+        print(f"OK  {lot.bilan}")
+        print(f"    lot {lot.batch_id} · {lot.fichier} · CRC32 {shard['crc32']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tecdoc_replay_controls.py
+++ b/scripts/tecdoc_replay_controls.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Porte de controle du rejeu TecDoc — a franchir AVANT toute projection.
+
+Le chargement (`tecdoc_replay.py`) prouve qu'aucune ligne n'a ete perdue. Cette porte
+prouve les trois autres proprietes exigees avant qu'une donnee rejouee ne touche quoi
+que ce soit d'applicatif :
+
+  identite      aucun identifiant deja attribue n'est modifie ni reattribue
+  conservation  aucun ensemble applicatif de mars 2026 n'a bouge
+  reconciliation PROD actuelle est INCLUSE dans le rejeu source-truth, et tout ce que
+                le rejeu ajoute part en QUARANTAINE
+
+Les lectures de la base de reference (MassDoc PROD) sont exclusivement des SELECT.
+Aucune ecriture, aucun DDL, aucune migration n'est emise vers elle.
+
+Codes de sortie :
+  0 porte franchie · 2 sceau invalide · 3 illisible
+  6 identite violee · 7 conservation rompue · 8 activation interdite / inclusion rompue
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from tecdoc_identity_guard import (REGISTRES_PROTEGES, IdentiteViolee,
+                                   verifier_mapping)
+from tecdoc_preservation import (ConservationRompue, charger_manifeste, mesurer,
+                                 verifier)
+from tecdoc_reconcile import ActivationInterdite, a_activer, reconcilier
+from tecdoc_scope import SceauInvalide
+
+#: Cle naturelle de chaque registre protege : (requete, colonne cle, colonne identite).
+#: Une entree par registre — pas de derivation, meme motif que `tecdoc_preservation`.
+LECTURES_REGISTRES = {
+    "tecdoc_map.type_id_remap":
+        "SELECT old_id::text, new_id::text FROM tecdoc_map.type_id_remap",
+    "tecdoc_map.modele_id_remap":
+        "SELECT old_id::text, new_id::text FROM tecdoc_map.modele_id_remap",
+    "tecdoc_map.pg_id_remap":
+        "SELECT old_id::text, new_id::text FROM tecdoc_map.pg_id_remap",
+    "tecdoc_map.gamme_registry":
+        "SELECT pg_id_source::text, pg_id::text FROM tecdoc_map.gamme_registry "
+        "WHERE pg_id IS NOT NULL",
+    "tecdoc_map.linkage_target_registry":
+        "SELECT id::text, target_key::text FROM tecdoc_map.linkage_target_registry",
+    # Filtre par DLNR : le registre porte 3,24 M d'ancrages, dont seul le fournisseur
+    # rejoue est en jeu. Le lire en entier des deux cotes n'apprendrait rien de plus.
+    "tecdoc_map.article_registry":
+        "SELECT source_artnr::text, piece_id::text FROM tecdoc_map.article_registry "
+        "WHERE source_dlnr::text = %(dlnr)s",
+}
+
+
+def _lire(dsn: str, requete: str, params: dict | None = None) -> dict:
+    """Rend {cle: identite}. LECTURE SEULE."""
+    import psycopg2
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute("SET statement_timeout = 250000")
+        cur.execute(requete, params)
+        return {str(k): (None if v is None else str(v)) for k, v in cur.fetchall()}
+
+
+def controle_identite(*, reference_dsn: str, rejeu_dsn: str, dlnr: int | None = None,
+                      registres: tuple = REGISTRES_PROTEGES) -> list:
+    """Compare les registres du rejeu a ceux de la reference. Leve au premier ecart.
+
+    Un registre que le rejeu n'a pas encore peuple rend `non_applicable`, jamais `OK` :
+    tant qu'aucune projection n'a tourne, il n'y a rien a comparer, et l'annoncer
+    conforme reviendrait a faire passer une absence de controle pour un controle.
+    """
+    rapports = []
+    for registre in registres:
+        requete = LECTURES_REGISTRES.get(registre)
+        if requete is None:
+            raise KeyError(
+                f"{registre} est protege mais aucune lecture n'est definie pour lui. "
+                "Ajouter la requete explicitement plutot que de deviner sa cle : un "
+                "registre non controle est un registre ou l'identite peut deriver."
+            )
+        params = {"dlnr": str(dlnr)} if "%(dlnr)s" in requete else None
+        if params is None and "%(dlnr)s" in requete:
+            raise ValueError(f"{registre} exige --dlnr")
+        propose = _lire(rejeu_dsn, requete, params)
+        if not propose:
+            rapports.append(f"{registre} : non_applicable — le rejeu n'a produit "
+                            "aucune entree (aucune projection n'a encore tourne)")
+            continue
+        rapports.append(verifier_mapping(_lire(reference_dsn, requete, params), propose,
+                                         registre=registre))
+    return rapports
+
+
+def controle_conservation(*, manifeste_path: str, reference_dsn: str) -> int:
+    """Verifie que les ensembles applicatifs figes n'ont pas bouge en reference."""
+    manifeste = charger_manifeste(manifeste_path)
+    return verifier(manifeste, mesurer(manifeste, reference_dsn))
+
+
+def _lignes_t400(dsn: str, dlnr: int, *, schema: str = "tecdoc_raw") -> dict:
+    """{numero de ligne source: empreinte de ligne} pour un DLNR."""
+    import psycopg2
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute("SET statement_timeout = 250000")
+        cur.execute(
+            f"SELECT _source_row_no::text, _raw_hash FROM {schema}.t400 WHERE col_2 = %s",
+            (str(dlnr),))
+        return {k: v for k, v in cur.fetchall()}
+
+
+def controle_reconciliation(*, reference_dsn: str, rejeu_dsn: str, dlnr: int) -> dict:
+    """Classe chaque ligne et REFUSE toute activation de la quarantaine."""
+    rec = reconcilier(_lignes_t400(reference_dsn, dlnr),
+                      _lignes_t400(rejeu_dsn, dlnr), dlnr=dlnr)
+    resume = rec.resume()
+    resume["activables_sans_decision_humaine"] = len(a_activer(rec))
+    return resume
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--reference-dsn", required=True,
+                    help="base de reference, LUE uniquement (MassDoc PROD).")
+    ap.add_argument("--rejeu-dsn", required=True, help="base jetable du rejeu.")
+    ap.add_argument("--manifeste", default=None,
+                    help="manifeste de preservation scelle (controle conservation).")
+    ap.add_argument("--dlnr", type=int, default=None,
+                    help="fournisseur a reconcilier.")
+    ap.add_argument("--controles", default="identite,conservation,reconciliation",
+                    help="sous-ensemble a executer, separe par des virgules.")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    demandes = [c.strip() for c in args.controles.split(",") if c.strip()]
+    inconnus = set(demandes) - {"identite", "conservation", "reconciliation"}
+    if inconnus:
+        ap.error(f"controle(s) inconnu(s) : {sorted(inconnus)}")
+
+    rapport: dict = {}
+    try:
+        if "identite" in demandes:
+            rapports = controle_identite(reference_dsn=args.reference_dsn,
+                                         rejeu_dsn=args.rejeu_dsn, dlnr=args.dlnr)
+            rapport["identite"] = [str(r) for r in rapports]
+
+        if "conservation" in demandes:
+            if not args.manifeste:
+                print("CONSERVATION : --manifeste est obligatoire pour ce controle. "
+                      "Refus de le declarer passe sans l'avoir execute.", file=sys.stderr)
+                return 3
+            rapport["conservation"] = (
+                f"{controle_conservation(manifeste_path=args.manifeste, reference_dsn=args.reference_dsn)}"
+                " ensembles figes intacts")
+
+        if "reconciliation" in demandes:
+            if args.dlnr is None:
+                print("RECONCILIATION : --dlnr est obligatoire pour ce controle.",
+                      file=sys.stderr)
+                return 3
+            resume = controle_reconciliation(reference_dsn=args.reference_dsn,
+                                             rejeu_dsn=args.rejeu_dsn, dlnr=args.dlnr)
+            rapport["reconciliation"] = resume
+            if not resume["inclusion_respectee"]:
+                print("INCLUSION ROMPUE — la reference sert des lignes que le rejeu ne "
+                      "reproduit pas, ou en contredit le contenu.\n"
+                      f"{json.dumps(resume, ensure_ascii=False, indent=2)}", file=sys.stderr)
+                return 8
+
+    except SceauInvalide as e:
+        print(f"SCEAU INVALIDE : {e}", file=sys.stderr)
+        return 2
+    except IdentiteViolee as e:
+        print(f"IDENTITE VIOLEE\n{e}", file=sys.stderr)
+        return 6
+    except ConservationRompue as e:
+        print(f"CONSERVATION ROMPUE\n{e}", file=sys.stderr)
+        return 7
+    except ActivationInterdite as e:
+        print(f"ACTIVATION INTERDITE\n{e}", file=sys.stderr)
+        return 8
+
+    if args.json:
+        print(json.dumps(rapport, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        for cle, val in rapport.items():
+            print(f"OK  {cle}")
+            for ligne in (val if isinstance(val, list) else [val]):
+                print(f"      {ligne}" if not isinstance(ligne, dict)
+                      else json.dumps(ligne, ensure_ascii=False, indent=6))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-tecdoc-replay.sh
+++ b/scripts/test-tecdoc-replay.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Banc de rejeu fail-closed — cas nominal, idempotence et injections de panne.
+#
+# HERMETIQUE : monte son propre PostgreSQL 17 jetable, ne lit jamais MassDoc PROD et
+# n'exige aucun secret. Executable en CI comme sur le poste DEV.
+#
+# Regle du banc : une injection qui rendrait 0 est un ECHEC du banc. Le vert ne se
+# prouve pas en verifiant que le nominal passe, mais que les pannes ARRETENT le rejeu.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+ARCHIVE="${TECDOC_ARCHIVE:-/opt/automecanik/app/.github/SQL-CONVERTED.7z}"
+SCOPE="${TECDOC_SCOPE:-../audit/massdoc-tecdoc-import-scope-2026-03.json}"
+MANIFESTE="${TECDOC_MANIFESTE:-../audit/massdoc-tecdoc-preservation-manifest-2026-03.json}"
+CONTENEUR="tecdoc-banc-$$"
+PORT="${TECDOC_BANC_PORT:-55433}"
+TMP="$(mktemp -d)"
+DLNR_TEST=4523          # HIDRIA — 13 057 lignes, shard present, .meta concordant
+ok=0; ko=0
+
+nettoyer() { docker rm -f "$CONTENEUR" >/dev/null 2>&1; rm -rf "$TMP"; }
+trap nettoyer EXIT
+
+# attendu_code <libelle> <code attendu> <commande...>
+cas() {
+  local libelle="$1" attendu="$2"; shift 2
+  local sortie; sortie="$("$@" 2>&1)"; local code=$?
+  if [ "$code" -eq "$attendu" ]; then
+    ok=$((ok+1)); printf '  ✓ %-52s (code %s)\n' "$libelle" "$code"
+  else
+    ko=$((ko+1)); printf '  ✗ %-52s attendu %s, obtenu %s\n' "$libelle" "$attendu" "$code"
+    printf '%s\n' "$sortie" | sed 's/^/      /' | head -6
+  fi
+}
+
+# egal <libelle> <attendu> <obtenu>
+egal() {
+  if [ "$2" = "$3" ]; then ok=$((ok+1)); printf '  ✓ %-52s (%s)\n' "$1" "$3"
+  else ko=$((ko+1)); printf '  ✗ %-52s attendu %s, obtenu %s\n' "$1" "$2" "$3"; fi
+}
+
+sql() { docker exec "$CONTENEUR" psql -U postgres -d "$1" -tAc "$2" 2>/dev/null | tr -d ' '; }
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker absent — banc de rejeu non executable"; exit 2
+fi
+if [ ! -f "$ARCHIVE" ]; then
+  echo "archive source absente ($ARCHIVE) — banc de rejeu non executable"; exit 2
+fi
+
+echo "=== Banc de rejeu fail-closed — PostgreSQL 17 jetable ==="
+docker run -d --name "$CONTENEUR" -e POSTGRES_PASSWORD=jetable -e POSTGRES_DB=banc \
+  -p "127.0.0.1:${PORT}:5432" --tmpfs /var/lib/postgresql/data:rw,size=4g \
+  postgres:17-alpine -c fsync=off -c full_page_writes=off >/dev/null || exit 2
+for _ in $(seq 1 60); do
+  docker exec "$CONTENEUR" pg_isready -U postgres -d banc >/dev/null 2>&1 && break; sleep 1
+done
+docker exec -i "$CONTENEUR" psql -U postgres -d banc -q -v ON_ERROR_STOP=1 \
+  < tecdoc-replay/schema-jetable.sql >/dev/null || exit 2
+docker exec -i "$CONTENEUR" psql -U postgres -d banc -q -v ON_ERROR_STOP=1 \
+  < tecdoc-replay/reference-synthetique.sql >/dev/null || exit 2
+
+BANC="postgresql://postgres:jetable@127.0.0.1:${PORT}/banc"
+REF="postgresql://postgres:jetable@127.0.0.1:${PORT}/reference"
+
+echo
+echo "-- Cas nominal et idempotence --"
+cas "rejeu nominal DLNR $DLNR_TEST" 0 \
+  python3 tecdoc_replay.py --scope-mode historical --scope-file "$SCOPE" \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP" --archive "$ARCHIVE"
+egal "lignes chargees" "13057" "$(sql banc 'select count(*) from tecdoc_raw.t400')"
+egal "numeros de ligne source distincts" "13057" \
+  "$(sql banc 'select count(distinct _source_row_no) from tecdoc_raw.t400')"
+egal "prefixe contigu 1..13057" "t" \
+  "$(sql banc 'select (min(_source_row_no)=1 and max(_source_row_no)=13057) from tecdoc_raw.t400')"
+egal "_batch_id renseigne (PROD le laisse NULL)" "13057" \
+  "$(sql banc 'select count(_batch_id) from tecdoc_raw.t400')"
+egal "_loaded_at renseigne (PROD le laisse NULL)" "13057" \
+  "$(sql banc 'select count(_loaded_at) from tecdoc_raw.t400')"
+cas "2e rejeu identique refuse (idempotence)" 3 \
+  python3 tecdoc_replay.py --scope-mode historical --scope-file "$SCOPE" \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP" --archive "$ARCHIVE"
+egal "base inchangee apres le 2e rejeu" "13057" "$(sql banc 'select count(*) from tecdoc_raw.t400')"
+egal "un seul lot en base" "1" "$(sql banc 'select count(distinct _batch_id) from tecdoc_raw.t400')"
+
+echo
+echo "-- Injection 1 : perte de lignes (le defaut de mars 2026) --"
+docker exec "$CONTENEUR" psql -U postgres -d banc -q -c 'DELETE FROM tecdoc_raw.t400' >/dev/null
+rm -f "$TMP"/400.*.csv "$TMP"/400.*.meta
+INJECTION_GARDER=5000 cas "chargement tronque refuse" 5 \
+  env INJECTION_GARDER=5000 python3 tecdoc_replay.py --scope-mode historical --scope-file "$SCOPE" \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP" --archive "$ARCHIVE" \
+    --parseur tecdoc-replay/parseur-tronqueur.py
+egal "AUCUNE ligne committee apres troncature" "0" "$(sql banc 'select count(*) from tecdoc_raw.t400')"
+
+echo
+echo "-- Injection 2 : source alteree (CRC32) --"
+cp "$SCOPE" "$TMP/scope-ok.json"
+rm -f "$TMP"/400.*.sql "$TMP"/400.*.csv "$TMP"/400.*.meta
+7z e -y -o"$TMP" "$ARCHIVE" "400.${DLNR_TEST}.sql" >/dev/null 2>&1
+printf '\n-- octet injecte --\n' >> "$TMP/400.${DLNR_TEST}.sql"
+cas "shard altere refuse avant tout chargement" 3 \
+  python3 tecdoc_replay.py --scope-mode historical --scope-file "$SCOPE" \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP" --archive "$ARCHIVE"
+egal "base toujours vide" "0" "$(sql banc 'select count(*) from tecdoc_raw.t400')"
+rm -f "$TMP"/400.*.sql
+
+echo
+echo "-- Injection 3 : perimetre --"
+cas "historical sans --scope-file" 4 \
+  python3 tecdoc_replay.py --scope-mode historical \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP"
+cas "DLNR hors du perimetre scelle" 4 \
+  python3 tecdoc_replay.py --scope-mode historical --scope-file "$SCOPE" \
+    --dlnr 999999 --table 400 --cible-dsn "$BANC" --workdir "$TMP"
+cas "mode current refuse (ni nom de shard, ni CRC32)" 4 \
+  python3 tecdoc_replay.py --scope-mode current \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP"
+python3 - "$TMP/scope-ok.json" "$TMP/scope-altere.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["suppliers"][0]["t400_rows"] = -1          # une seule valeur modifiee
+json.dump(d, open(sys.argv[2], "w"), ensure_ascii=False)
+PY
+cas "artefact de perimetre altere (sceau)" 2 \
+  python3 tecdoc_replay.py --scope-mode historical --scope-file "$TMP/scope-altere.json" \
+    --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP"
+
+echo
+echo "-- Injection 4 : derive d'identite --"
+docker exec "$CONTENEUR" psql -U postgres -d banc -q \
+  -c "INSERT INTO tecdoc_map.type_id_remap(old_id,new_id) VALUES ('100001','60001'),('100002','99999')" >/dev/null
+cas "identite derivee refusee" 6 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --dlnr "$DLNR_TEST" --controles identite
+docker exec "$CONTENEUR" psql -U postgres -d banc -q \
+  -c "UPDATE tecdoc_map.type_id_remap SET new_id='60002' WHERE old_id='100002'" >/dev/null
+cas "identite conforme acceptee" 0 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --dlnr "$DLNR_TEST" --controles identite
+docker exec "$CONTENEUR" psql -U postgres -d banc -q \
+  -c "INSERT INTO tecdoc_map.type_id_remap(old_id,new_id) VALUES ('100003','60001')" >/dev/null
+cas "reemploi d'un identifiant deja attribue refuse" 6 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --dlnr "$DLNR_TEST" --controles identite
+docker exec "$CONTENEUR" psql -U postgres -d banc -q -c 'DELETE FROM tecdoc_map.type_id_remap' >/dev/null
+
+echo
+echo "-- Injection 5 : conservation rompue --"
+cas "manifeste absent : refus de declarer le controle passe" 3 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --controles conservation
+docker exec "$CONTENEUR" psql -U postgres -d reference -q \
+  -c "DELETE FROM public.auto_type WHERE type_id_i = 60000" >/dev/null
+cas "ensemble applicatif modifie refuse" 7 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --manifeste tecdoc-replay/manifeste-synthetique.json --controles conservation
+
+echo
+echo "-- Injection 6 : inclusion PROD ⊆ REBUILD rompue --"
+docker exec "$CONTENEUR" psql -U postgres -d banc -q -c 'DELETE FROM tecdoc_raw.t400' >/dev/null
+rm -f "$TMP"/400.*.csv "$TMP"/400.*.meta
+python3 tecdoc_replay.py --scope-mode historical --scope-file "$SCOPE" \
+  --dlnr "$DLNR_TEST" --table 400 --cible-dsn "$BANC" --workdir "$TMP" --archive "$ARCHIVE" >/dev/null 2>&1
+docker exec "$CONTENEUR" psql -U postgres -d reference -q \
+  -c "INSERT INTO tecdoc_raw.t400(col_2,_source_row_no,_raw_hash) VALUES ('$DLNR_TEST',999999,'ligne_servie_absente_du_rejeu')" >/dev/null
+cas "reference servant une ligne absente du rejeu refusee" 8 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --dlnr "$DLNR_TEST" --controles reconciliation
+docker exec "$CONTENEUR" psql -U postgres -d reference -q \
+  -c "UPDATE tecdoc_raw.t400 SET _raw_hash='contredit_le_rejeu', _source_row_no=1 WHERE _source_row_no=999999" >/dev/null
+cas "contenu servi contredisant le rejeu refuse (CONFLICT)" 8 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --dlnr "$DLNR_TEST" --controles reconciliation
+
+echo
+echo "=== $ok assertions vertes, $ko rouges ==="
+[ "$ko" -eq 0 ] || exit 1


### PR DESCRIPTION
## Le défaut, en trois lignes

Le pipeline récupéré en #1417 pouvait encore perdre des lignes en silence :

```python
conn.autocommit = True                     # L33  — chaque COPY committé isolément
    except Exception as e:                 # L155
        log(f"  ERROR DLNR={dlnr}: {e}")   # L156 — avalée, jamais re-levée
    return total                           # L161 — rend les lignes DÉJÀ committées
```

Une interruption en cours de fichier laissait un **préfixe committé**, l'exception était journalisée puis oubliée, et le script sortait avec le code 0. `rows_emitted=9357752` et `69000` lignes en base coexistaient sans alerte.

## Correction d'une affirmation de #1417

**#1417 §3 attribuait la perte au filtre `if len(row) >= 8`. C'est réfuté.** La colonne `_source_row_no`, remplie par le parseur, le prouve :

| DLNR | lignes | `_source_row_no` | forme |
|------|-------:|------------------|-------|
| 4523 (sain) | 13 057 | `[1, 13057]` | préfixe contigu |
| 30 (divergent) | 69 000 | `[1, 69000]` | préfixe contigu |
| 123 (divergent) | 100 | `[1, 100]` | préfixe contigu |

Un filtre **disperse** les pertes ; il ne tronque pas. Les numéros sont contigus de 1 à N : le chargement s'est arrêté net. La signature de provenance (`_source_filename` / `_source_row_no` / `_raw_hash` remplies, `_batch_id` / `_loaded_at` NULL) identifie par ailleurs `load-t400-active.py` comme le seul loader ayant écrit `t400`.

## Ce que la PR livre

- **`scripts/tecdoc_replay.py`** — chemin canonique. Une transaction par lot, comptabilité vérifiée **avant** le commit, `charges` recompté **en base**, aucune exception avalée, CRC32 du shard confronté au sceau. `--scope-mode historical` obligatoire.
- **`scripts/tecdoc_replay_controls.py`** — porte avant projection : identité · conservation · réconciliation + quarantaine.
- **Quatre états par ligne** — chargée / dédoublonnée / rejetée(motif) / fatale. Pas de cinquième.
- **Idempotence par `_batch_id` déterministe** — colonne présente depuis l'origine, **jamais écrite** jusqu'ici.
- **Ratchet R1/R2/R3** + workflow, allowlist à motif obligatoire et **symétrique**.

## Preuves

Rejeu nominal, DLNR 4523 (HIDRIA), PostgreSQL 17.11 jetable sur tmpfs :

```
OK  DLNR 4523 : 13057 emis = 13057 charges  (100.00% charge)
    lot 5df6aa4716dd1944fbf3746d5890852c · 400.4523.sql · CRC32 79F794A2
```

Réconciliation contre PROD (lecture seule) — mêmes numéros de ligne, mêmes empreintes :

```json
{ "identites_conservees": 13057, "absentes_de_prod": 0, "en_trop_dans_prod": 0,
  "conflits": 0, "candidats_en_quarantaine": 0, "inclusion_respectee": true }
```

Conservation contre PROD : **9 ensembles figés intacts**.

**74 assertions vertes** — 24 périmètre + 26 gardes + 24 banc de rejeu. Les 6 familles d'injections échouent **avant** toute projection :

| Injection | Obtenu |
|-----------|--------|
| Perte de lignes (CSV tronqué, `.meta` intact) | code 5, **0 ligne committée** |
| Source altérée (un octet) | code 3, base vide |
| Périmètre absent / hors scope / mode `current` | code 4 ×3 |
| Sceau altéré | code 2 |
| Dérive puis réemploi d'identité | code 6 ×2 |
| Conservation rompue | code 7 |
| Inclusion PROD ⊆ REBUILD rompue | code 8 ×2 |

Ratchet éprouvé dans les deux sens : un script violant R1+R2 le fait rougir ; une exemption morte aussi.

## Ce que la PR ne fait pas

- **Rejeu complet non exécuté** — conforme au mandat.
- **Zéro écriture PROD**, zéro `DROP`. Seuls des `SELECT` de comparaison.
- `test-tecdoc-replay.sh` **n'est pas en CI** (Docker + archive 6 Go absents d'un runner) — le déclarer « passé » ferait d'un skip une preuve.
- **Deux dettes réelles exemptées et nommées** : `tecdoc-import.py` (R1) et `tecdoc-batch-load.py` (R2). Le principe vaut pour le chemin canonique, pas encore pour tout le dépôt.

## ⚠️ Priorité 0 — `BLOCKED_BY_SECRET_ROTATION` non levé

**Le mot de passe `postgres` PROD exposé publiquement depuis 2026-03-27 n'a pas été tourné** — empreintes SHA-256 identiques entre la valeur purgée en #1417 et le `.env` courant. Valeur ni affichée, ni copiée, ni journalisée ; aucun secret modifié. **Action owner.**

Détail complet : `audit/massdoc-tecdoc-failclosed-replay-2026-09-08.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)