### PR TITLE
feat(tecdoc): rejeu par vagues — pic disque 250 Go → ~5 Go, et vérificateur de rotation

### DIFF
--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -183,3 +183,59 @@ Ordre des opérations, une fois le nouvel identifiant en place :
 4. **alors seulement**, supprimer les copies locales que le vérificateur inventorie —
    les purger avant la rotation détruirait une sauvegarde d'un identifiant encore en
    service, sans rien réduire.
+
+### 8.1 Exécuter la rotation — pourquoi l'API et pas `ALTER USER`
+
+`scripts/tourner-secret-db.py` exécute la rotation ; `verifier-rotation-secret.py` la
+constate après coup. Les deux sont séparés à dessein : un outil qui juge son propre
+travail ne prouve rien.
+
+Le mot de passe de la base vit à **deux endroits** : le rôle PostgreSQL, et
+l'identifiant que le pooler (Supavisor) conserve côté plan de contrôle pour ouvrir ses
+connexions amont. Un `ALTER USER` émis en direct ne change que le premier — le pooler
+garde l'ancien et cesse de fonctionner. Sur une base qui sert du trafic, c'est une
+coupure du site. `PATCH /v1/projects/{ref}/database/password` est l'opération
+qu'appelle le bouton du tableau de bord : elle change les deux ensemble. C'est la
+seule voie qui laisse le système cohérent, et c'est pour ça que l'outil n'expose pas
+de chemin SQL.
+
+Ordre des étapes, choisi pour qu'aucune panne ne verrouille la base :
+
+| # | Étape | Ce qu'elle protège |
+|---|---|---|
+| 1 | prouver qu'un identifiant de référence ouvre la base | sans lui, on ne pourra pas prouver qu'il cesse de fonctionner |
+| 2 | engendrer et déposer en `0600` **avant** tout changement | un plantage ne peut pas perdre le nouveau secret |
+| 3 | appeler l'API | — |
+| 4 | nouveau accepté **et** ancien refusé en `28P01` | un `200` de l'API n'est pas une preuve de rotation |
+| 5 | écrire le `.env`, atomiquement, après sauvegarde | le `.env` ne devance jamais l'état réel de la base |
+
+Codes de sortie : `0` rotation prouvée · `2` état de départ inexploitable · `3` erreur
+d'E/S · `4` le changement n'a pas pris · `5` l'ancien est encore accepté · `6` l'API a
+refusé. Aux codes 2, 4, 6 le `.env` n'est pas touché — vérifié par le banc.
+
+Le jeton d'API est lu dans `SUPABASE_ACCESS_TOKEN`, jamais dans un fichier de
+configuration ni en `argv`. Le script ne contient aucune référence de projet, de dépôt
+ni de chemin de secret : tout est paramètre, pour que sa présence dans un dépôt public
+ne désigne rien.
+
+`scripts/test-tourner-secret-db.sh` — **23 assertions, banc hermétique**. Un
+PostgreSQL jetable, l'API remplacée par un double qui applique réellement le
+changement. Sont vérifiés le cas nominal, les trois refus (2, 6, clé absente), la
+préservation des autres lignes du `.env`, le contenu de la sauvegarde, et surtout que
+le secret **n'apparaît jamais** dans la sortie — seulement trois empreintes de douze
+hexadécimaux.
+
+### 8.2 Le point d'entrée direct n'est pas utilisable ici
+
+Mesuré : `db.<ref>.supabase.co:5432` ne résout plus qu'en IPv6 et **refuse activement**
+la connexion (RST immédiat, pas un délai d'attente), route IPv6 valide côté appelant.
+Le pooler répond sur les deux ports, en mode session comme en mode transaction.
+
+Conséquence pratique : la vérification comme la rotation passent par le pooler, avec
+l'utilisateur au format `postgres.<ref>`. Une erreur de région se signale par
+`ENOTFOUND tenant/user … not found` — c'est un message de routage, **pas** un refus
+d'authentification, et le confondre avec un `28P01` ferait conclure à une rotation
+réussie alors qu'on frappe la mauvaise porte.
+
+Les scripts du dépôt qui ouvrent une connexion directe sont à recenser séparément :
+c'est une dette distincte de la rotation, et elle ne doit pas la retarder.

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -203,6 +203,7 @@ Ordre des étapes, choisi pour qu'aucune panne ne verrouille la base :
 
 | # | Étape | Ce qu'elle protège |
 |---|---|---|
+| 0 | le jeton ouvre-t-il ce projet ? (`GET`, lecture seule) | un jeton absent ou erroné ne laisse aucun secret orphelin derrière lui |
 | 1 | prouver qu'un identifiant de référence ouvre la base | sans lui, on ne pourra pas prouver qu'il cesse de fonctionner |
 | 2 | engendrer et déposer en `0600` **avant** tout changement | un plantage ne peut pas perdre le nouveau secret |
 | 3 | appeler l'API | — |
@@ -212,6 +213,22 @@ Ordre des étapes, choisi pour qu'aucune panne ne verrouille la base :
 Codes de sortie : `0` rotation prouvée · `2` état de départ inexploitable · `3` erreur
 d'E/S · `4` le changement n'a pas pris · `5` l'ancien est encore accepté · `6` l'API a
 refusé. Aux codes 2, 4, 6 le `.env` n'est pas touché — vérifié par le banc.
+
+L'étape 0 diagnostique sans sur-affirmer : un `403` couvre à la fois le jeton malformé
+rejeté en amont et le jeton valide sans droit sur le projet. Le script nomme les deux
+et montre la réponse, plutôt que d'envoyer chercher au mauvais endroit.
+
+**Saisie du jeton — le piège du collage.** `read -rs VAR` lit l'entrée standard. Si la
+commande est collée avec les lignes suivantes, `read` avale la ligne d'après au lieu
+d'attendre la frappe, et la variable est exportée **vide**. D'où :
+
+```bash
+read -rsp "Jeton : " SUPABASE_ACCESS_TOKEN < /dev/tty && export SUPABASE_ACCESS_TOKEN && echo
+```
+
+Le `< /dev/tty` force la lecture sur le terminal. Le script rend ce diagnostic lui-même
+quand la variable est vide — sinon l'erreur se relit comme « jeton refusé » alors qu'il
+n'a jamais été saisi.
 
 Le jeton d'API est lu dans `SUPABASE_ACCESS_TOKEN`, jamais dans un fichier de
 configuration ni en `argv`. Le script ne contient aucune référence de projet, de dépôt

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -85,9 +85,20 @@ base pour le diagnostic. Un DLNR n'est purgé que **lorsque sa preuve est écrit
 | Inclusion PROD ⊄ REBUILD | 8 | vague arrêtée, **matière conservée** |
 | Purge non confirmée | 9 | vague arrêtée |
 
-Éprouvé : `test-tecdoc-replay.sh` — **32 assertions, 0 rouge**, dont la vague nominale
+Éprouvé : `test-tecdoc-replay.sh` — **35 assertions, 0 rouge**, dont la vague nominale
 avec purge, la relance idempotente, l'inclusion rompue et la conservation de la matière
 sur échec.
+
+Trois de ces assertions portent sur la **preuve elle-même**, pas sur le chargement :
+
+- les **13 champs** du contrat de registre sont présents et non nuls — une preuve
+  incomplète est une preuve qu'on ne peut pas refaire ;
+- la **partition de la réconciliation** : tout ce que le rejeu produit est soit déjà
+  identique en PROD, soit en quarantaine ; aucune troisième catégorie silencieusement
+  activable ;
+- le **sceau est un vrai sceau** — recalculé sur le contenu il concorde, recalculé après
+  modification d'une seule valeur (`rows_loaded += 1`) il diverge. Sans cette seconde
+  moitié, le sceau n'atteste que de lui-même.
 
 ## 5. Environnement
 
@@ -108,11 +119,38 @@ PostgreSQL 17 isolé — 127.0.0.1 uniquement, aucun accès PROD
 | Isolé | `-p 127.0.0.1:<port>:5432` | `provision-rebuild-env.sh` |
 | Jetable | tout l'état sous le point de montage | — |
 | Aucun accès PROD | refus si une variable d'accès PROD est exportée | garde §2 du script |
-| Capacité | seuil paramétrable, refus en dessous | `check-rebuild-capacity.sh` |
+| Capacité | deux modes, deux seuils, deux périmètres physiques — refus en dessous | `check-rebuild-capacity.sh`, banc `test-check-rebuild-capacity.sh` |
 
-`provision-rebuild-env.sh` reste utilisable tel quel ; en mode vagues, le seuil de
-capacité se règle par `TECDOC_REBUILD_MIN_GO` (≈ 10 Go suffisent, contre 210 en mode
-matérialisé). Le mot de passe local est généré sur place, `0600`, jamais affiché.
+`provision-rebuild-env.sh` reste utilisable tel quel. Le mot de passe local est généré
+sur place, `0600`, jamais affiché.
+
+**La porte de capacité a deux modes**, parce que les deux stratégies de rebuild ont des
+besoins disque de nature différente et qu'une porte unique ne peut pas juger les deux
+honnêtement. Desserrer le seuil du mode matérialisé pour faire passer un rejeu par vagues
+masquerait le besoin réel du premier.
+
+| | `materialise` (défaut) | `vagues` |
+|---|---|---|
+| Sélection | `TECDOC_REBUILD_MODE` non défini | `TECDOC_REBUILD_MODE=vagues` |
+| Besoin disque | la **somme** des 110 DLNR | le **plus gros DLNR seul** |
+| Cible par défaut | `/mnt/tecdoc-rebuild` | `/` (stockage Docker) |
+| Seuil de refus | `TECDOC_REBUILD_MIN_GO` — **210 Go** | `TECDOC_REBUILD_VAGUE_MIN_GO` — **20 Go** (4× le pic mesuré) |
+| Cible de provisionnement | `TECDOC_REBUILD_CIBLE_GO` — 250 Go | sans objet |
+| Volume dédié obligatoire | **oui** | **non** |
+| Mode inconnu | refusé, code 2 — jamais interprété | idem |
+
+L'exigence de volume dédié n'a jamais protégé de la *taille* mais du *blast radius* : un
+rebuild de ~139 Go qui remplit `/` arrête le runtime DEV et la session opérateur. Un pic
+de ~5 Go ne menace pas `/`, donc la lever en mode vagues n'assouplit rien — l'imposer
+reviendrait à refuser précisément les configurations bien dimensionnées. Le seuil des
+vagues reste une **vraie porte** : sous 20 Go libres, elle rend `NO_GO` et chiffre le
+manque.
+
+Cette double-lecture est le risque propre à une porte à deux modes — on la desserre par
+inadvertance. `test-check-rebuild-capacity.sh` existe pour que cela se voie : **25
+assertions, 0 rouge**, dont la paire décisive *même cible `/`, mode matérialisé refuse,
+mode vagues accepte*, et la vérification que le refus « volume non dédié » n'existe
+**que** en matérialisé.
 
 ## 6. Plan de lots
 

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -203,7 +203,7 @@ Ordre des étapes, choisi pour qu'aucune panne ne verrouille la base :
 
 | # | Étape | Ce qu'elle protège |
 |---|---|---|
-| 0 | le jeton ouvre-t-il ce projet ? (`GET`, lecture seule) | un jeton absent ou erroné ne laisse aucun secret orphelin derrière lui |
+| 0 | le jeton porte-t-il la permission voulue ? (`GET`, lecture seule) | un jeton absent ou erroné ne laisse aucun secret orphelin derrière lui |
 | 1 | prouver qu'un identifiant de référence ouvre la base | sans lui, on ne pourra pas prouver qu'il cesse de fonctionner |
 | 2 | engendrer et déposer en `0600` **avant** tout changement | un plantage ne peut pas perdre le nouveau secret |
 | 3 | appeler l'API | — |
@@ -214,9 +214,20 @@ Codes de sortie : `0` rotation prouvée · `2` état de départ inexploitable ·
 d'E/S · `4` le changement n'a pas pris · `5` l'ancien est encore accepté · `6` l'API a
 refusé. Aux codes 2, 4, 6 le `.env` n'est pas touché — vérifié par le banc.
 
-L'étape 0 diagnostique sans sur-affirmer : un `403` couvre à la fois le jeton malformé
-rejeté en amont et le jeton valide sans droit sur le projet. Le script nomme les deux
-et montre la réponse, plutôt que d'envoyer chercher au mauvais endroit.
+**Permission requise sur le jeton : « Database Config », en lecture-écriture.** C'est
+elle qui porte `v1-update-database-password`. Un jeton classique (accès complet du
+compte) convient aussi, mais un jeton restreint est préférable et se révoque après usage.
+
+L'étape 0 interroge `GET /v1/projects/{ref}/config/database/postgres`, et ce choix n'est
+pas anodin : `GET /v1/projects/{ref}` relève de « Project Settings », pas de « Database
+Config ». Une première version l'utilisait — un jeton correctement restreint à la tâche
+aurait donc été refusé par le préflight lui-même. **Une garde doit éprouver la même
+permission que ce qu'elle précède**, sinon elle bloque exactement les cas les mieux
+configurés.
+
+Le diagnostic ne sur-affirme pas : un `403` couvre à la fois le jeton malformé rejeté en
+amont et le jeton valide sans la permission. Le script nomme les deux et montre la
+réponse, plutôt que d'envoyer chercher au mauvais endroit.
 
 **Saisie du jeton — pourquoi le script le demande lui-même.** La voie évidente était
 `read -rs VAR && export VAR` puis la commande. Elle échoue silencieusement : `read` lit

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -1,0 +1,175 @@
+# Environnement de rebuild TecDoc isolé — spécification et plan de lots
+
+> **Date** : 2026-09-08 · **Base** : `33d0049` (PR #1418 mergée) · **Statut** : `NO_GO`
+> — le volume dédié n'existe pas encore. Le rejeu complet **n'est pas lancé**.
+>
+> Ce document couvre l'environnement et le découpage. Il ne traite d'aucun secret.
+
+---
+
+## 1. Architecture cible
+
+```
+archive TecDoc (SQL-CONVERTED.7z, 5,8 Go)
+        ↓  extraction + CRC32 confronté au périmètre scellé
+volume dédié /mnt/tecdoc-rebuild  (~250 Go, hors /)
+        ↓
+PostgreSQL 17 isolé — 127.0.0.1 uniquement, aucun accès PROD
+        ↓  scripts/tecdoc_replay.py (fail-closed)
+tecdoc_raw.t400 / t232
+        ↓
+tecdoc_map.source_linkages
+        ↓  projection
+réconciliation — scripts/tecdoc_replay_controls.py
+```
+
+**Aucun chemin d'écriture vers PROD n'existe dans cette chaîne.** Le container ne reçoit
+aucune variable d'accès PROD, et `provision-rebuild-env.sh` **refuse de démarrer** si
+`SUPABASE_DB_PASSWORD`, `DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` ou `PGPASSWORD` sont
+exportées dans le shell appelant.
+
+## 2. Chiffrage de la capacité
+
+Mesures PROD du 2026-09-08 (lecture seule) :
+
+| Objet | Total | dont index |
+|---|---:|---:|
+| `tecdoc_map.source_linkages` | 90,0 Go | 33,7 Go |
+| `tecdoc_raw.t400` | 17,4 Go | 924 Mo |
+| `tecdoc_raw.t232` | 1,7 Go | — |
+| `tecdoc_map.source_linkage_criteria` | 356 Mo | 157 Mo |
+| **Staging PROD** | **109,5 Go** | 34,7 Go |
+
+Le rebuild charge la **source complète**, plus volumineuse que la PROD tronquée. Facteur
+mesuré depuis l'artefact scellé : **×1,20** (149 DLNR chargés) et **×1,28** (110 projetés).
+
+```
+données + index en rebuild ........... ~139 Go
++ WAL, tri de construction d'index,
+  scratch de parsing, archive 5,8 Go
++ marge de sécurité 20 %
+
+besoin minimal ....................... 160 Go
+besoin recommandé .................... 210 Go   ← seuil de la garde
+cible de provisionnement ............. 250 Go
+```
+
+> **Borne inférieure assumée** : seuls **66/110** DLNR projetés (et 83/149 chargés) portent
+> un `.meta` de parsing. Pour les autres, la valeur PROD — donc éventuellement tronquée — a
+> été retenue. Le facteur source-truth réel est **supérieur** à ×1,28, et ces seuils sont
+> des planchers, pas des estimations centrales.
+
+## 3. État de la machine DEV — pourquoi c'est `NO_GO`
+
+```
+hôte ................. dev-automecanik (Hetzner Cloud vServer, instance 115238775)
+disque physique ...... /dev/sda — 152,6 Go   ← total, pas disponible
+partition / .......... /dev/sda1 — 150 Go, 106 Go utilisés, 39 Go libres (74 %)
+espace non alloué .... 0,00 Go
+volume additionnel ... aucun
+```
+
+Le disque **entier** fait 152,6 Go, soit moins que le besoin minimal de 160 Go. Même en
+libérant tout `/opt/automecanik` (~38 Go), on plafonnerait vers 77 Go. **Le rebuild ne peut
+pas tenir sur cette machine sans volume supplémentaire.**
+
+## 4. Provisionnement — action hébergeur (owner)
+
+Attacher un disque est une opération chez l'hébergeur, hors de portée d'un agent.
+
+```bash
+# 1. Créer et attacher un volume de 250 Go dans la même zone que le serveur
+hcloud volume create --name tecdoc-rebuild --size 250 --server dev-automecanik --format ext4
+# (ou : Console Hetzner → Volumes → Create Volume → 250 GB → attach to dev-automecanik)
+
+# 2. Repérer le device (Hetzner l'expose sous /dev/disk/by-id/scsi-0HC_Volume_<id>)
+ls -l /dev/disk/by-id/ | grep HC_Volume
+
+# 3. Monter sur un chemin dédié — jamais sous /tmp
+sudo mkdir -p /mnt/tecdoc-rebuild
+sudo mount -o discard,defaults,noatime /dev/disk/by-id/scsi-0HC_Volume_<id> /mnt/tecdoc-rebuild
+
+# 4. Rendre le montage persistant
+echo '/dev/disk/by-id/scsi-0HC_Volume_<id> /mnt/tecdoc-rebuild ext4 discard,defaults,noatime,nofail 0 0' \
+  | sudo tee -a /etc/fstab
+
+# 5. Vérifier la capacité — rend GO ou NO_GO, jamais « probablement »
+bash scripts/tecdoc-replay/check-rebuild-capacity.sh /mnt/tecdoc-rebuild
+
+# 6. Provisionner (idempotent, refuse si la capacité est insuffisante)
+env -u DATABASE_URL -u SUPABASE_DB_PASSWORD -u SUPABASE_SERVICE_ROLE_KEY -u PGPASSWORD \
+  bash scripts/tecdoc-replay/provision-rebuild-env.sh
+```
+
+`noatime` évite des écritures inutiles pendant le chargement massif ; `nofail` empêche un
+volume absent de bloquer le démarrage de la machine.
+
+## 5. Contrat de l'environnement
+
+| Contrainte | Mise en œuvre | Vérifiée par |
+|---|---|---|
+| PostgreSQL 17 | image `postgres:17-alpine` (17.11 constatée) | contrôle final du provisionnement |
+| Isolé | `-p 127.0.0.1:55440:5432`, jamais d'écoute publique | `provision-rebuild-env.sh` |
+| Jetable | tout l'état vit sous `/mnt/tecdoc-rebuild` | — |
+| Aucun accès PROD | refus si une variable d'accès PROD est exportée | garde §2 du script |
+| Volume dédié | refus si le point de montage partage le device de `/` | `check-rebuild-capacity.sh` |
+| Capacité | refus sous 210 Go libres | `check-rebuild-capacity.sh` |
+
+Arborescence créée : `pgdata/` (PGDATA, uid 70), `scratch/` (parsing), `archive/` (source),
+`rapports/` (comptabilité par lot). Le mot de passe local est généré sur place (32 octets
+d'entropie), stocké en `0600` sur le volume, **jamais affiché ni journalisé**.
+
+**Réglages** : `shared_buffers=2GB`, `maintenance_work_mem=2GB`, `max_wal_size=8GB`,
+`checkpoint_timeout=30min`, `synchronous_commit=off`, `--shm-size=2g`.
+`fsync` reste **actif** par défaut : un crash hôte avec `fsync=off` corromprait le cluster et
+ferait perdre des heures de rejeu, alors que l'idempotence par `_batch_id` permet sinon de
+reprendre au DLNR près. `--rapide` l'ouvre explicitement, avec l'avertissement associé.
+
+## 6. Plan de lots — préparé, non exécuté
+
+Généré depuis l'artefact scellé par `generer-plan-lots.py` → `plan-lots.json`.
+**110/110 DLNR couverts**, volumétrie croissante, divergents placés par poids.
+
+| Lot | DLNR | Lignes source attendues | Divergents |
+|---|---:|---:|---|
+| 0 — fumée | 1 | 13 057 | — (HIDRIA, déjà validé en #1418) |
+| 1 — 5 DLNR | 5 | 2 179 199 | NISSENS, PAYEN |
+| 2 — 20 DLNR | 20 | 7 932 092 | RIDEX |
+| 3 — divergents lourds isolés | 2 | 26 779 184 | BOSCH, FEBI |
+| 4 — reste | 30 | 9 404 364 | — |
+| 5 — reste | 30 | 25 567 877 | — |
+| 6 — reste | 22 | 59 056 373 | — |
+
+Les cinq divergents sont traités **tôt et par poids croissant** : ce sont les cas de
+non-régression prioritaires, et les rencontrer tard signifierait découvrir un défaut après
+des heures de rejeu.
+
+**Contrat de chaque lot** :
+
+- **Checkpoint** — `_batch_id` déterministe `(table, DLNR, CRC32, version)`. Un lot
+  interrompu se reprend au DLNR près, sans doublon.
+- **Comptabilité** — `émis = chargées + dédoublonnées + rejets explicites`, vérifiée
+  **avant** commit. Sinon `FAIL` + `ROLLBACK` + `STOP`.
+- **Rollback** — une transaction par DLNR ; aucun préfixe partiel n'est committable.
+- **Rapport** — `/mnt/tecdoc-rebuild/rapports/lot-<n>.json`.
+- **Condition de passage** — un lot ne s'ouvre que si le précédent est intégralement vert.
+
+## 7. Cibles de non-régression des 5 divergents
+
+| DLNR | Fournisseur | t400 PROD | Source émise | Delta attendu | Chargé en mars |
+|---:|---|---:|---:|---:|---:|
+| 123 | NISSENS | 100 | 790 974 | +790 874 | 0,01 % |
+| 30 | BOSCH | 69 000 | 9 357 752 | +9 288 752 | 0,74 % |
+| 101 | FEBI | 2 558 500 | 17 421 432 | +14 862 932 | 14,69 % |
+| 6358 | RIDEX | 2 323 000 | 5 662 767 | +3 339 767 | 41,02 % |
+| 113 | PAYEN | 1 085 500 | 1 259 429 | +173 929 | 86,19 % |
+| | **Total** | **6 036 100** | **34 492 354** | **+28 456 254** | |
+
+Le rebuild doit atteindre la colonne « source émise ». Les préfixes tronqués de `t400` sont
+de la **vérité forensique historique**, jamais une cible.
+
+## 8. Ce que ce document ne dit pas
+
+Il ne mentionne aucun état de secret, aucune empreinte, aucune valeur : ce dépôt est public,
+et y consigner l'état d'un identifiant vivant l'exposerait davantage. Ces éléments sont
+transmis hors dépôt.

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -1,158 +1,138 @@
-# Environnement de rebuild TecDoc isolé — spécification et plan de lots
+# Rebuild TecDoc par vagues — environnement, dimensionnement, plan
 
-> **Date** : 2026-09-08 · **Base** : `33d0049` (PR #1418 mergée) · **Statut** : `NO_GO`
-> — le volume dédié n'existe pas encore. Le rejeu complet **n'est pas lancé**.
+> **Date** : 2026-09-08, révisé 2026-09-09 · **Base** : `33d0049` (PR #1418 mergée)
+> **Statut** : environnement **GO** sur la machine existante. Le rejeu complet des
+> 110 DLNR **n'est pas lancé**.
 >
-> Ce document couvre l'environnement et le découpage. Il ne traite d'aucun secret.
+> Ce document ne consigne aucun état de secret : ce dépôt est public.
 
 ---
 
-## 1. Architecture cible
+## 1. Correction du dimensionnement — de 250 Go à ~5 Go
+
+La première version de cette spécification exigeait un volume dédié de **250 Go** et
+concluait `NO_GO`. Ce chiffre ne venait pas des données : il venait d'une hypothèse non
+soumise — **matérialiser les 110 DLNR simultanément** dans une seule instance.
+
+Or l'invariant à démontrer — `PROD actuelle ⊆ REBUILD source-truth`, sans perte de ligne
+ni dérive d'identité — se vérifie **DLNR par DLNR**. On rejoue un fournisseur, on le
+réconcilie, on scelle la preuve, **puis on jette la matière**. Le pic disque devient celui
+du plus gros fournisseur seul, pas leur somme.
+
+**Mesure réelle** (rejeu HIDRIA, PostgreSQL 17 jetable) : `2 654 208` octets pour
+`13 057` lignes, index compris → **203 octets/ligne**.
+
+| | lignes source | occupation en base |
+|---|---:|---:|
+| FEBI (DLNR 101) — cas dimensionnant | 17 421 432 | 3,3 Go |
+| BOSCH (DLNR 30) | 9 357 752 | 1,8 Go |
+| VALEO (DLNR 21) | 6 369 779 | 1,2 Go |
+
+```
+pic en base (FEBI seul) ........... 3,3 Go
++ CSV de parsing (transitoire) .... 1,5 Go
++ archive 7z (déjà présente) ...... 5,8 Go, non dupliquée
+PIC ESTIMÉ ....................... ~5 Go
+libre sur / aujourd'hui .......... 39 Go        → GO
+```
+
+Un volume de 250 Go n'est nécessaire **que** si l'on souhaite conserver un rebuild
+matérialisé à inspecter après coup. Pour démontrer l'invariant, les preuves suffisent.
+
+## 2. Ce que le rejeu par vagues démontre — et ce qu'il ne démontre pas
+
+**Démontré, au niveau RAW (`tecdoc_raw.t400`)** : aucune ligne source n'est perdue
+(comptabilité vérifiée avant commit), la PROD est incluse dans le rejeu, les registres
+d'identité ne bougent pas, les 9 ensembles figés sont intacts. C'est exactement là que la
+perte de mars 2026 s'est produite.
+
+**Non démontré** : rien sur la projection `source_linkages`. Aucun projecteur vérifié
+n'existe à ce jour — les projecteurs historiques sont en quarantaine, dont celui qui a
+pollué `pieces_relation_type` de ~219 M lignes fantômes. Ce sera un chantier séparé.
+Annoncer ici une preuve de projection serait le vert-mais-faux que ce pipeline combat.
+
+## 3. Le registre de preuve
+
+Puisque la matière est jetée, **la preuve est le livrable**. Chaque DLNR y laisse :
+
+```json
+{ "dlnr": 4523, "fichier": "400.4523.sql", "batch_id": "5df6aa47…",
+  "comptabilite":       { "rows_emitted": 13057, "rows_loaded": 13057,
+                          "rows_deduplicated": 0, "rows_rejected": {} },
+  "empreinte_du_charge":{ "lignes": 13057, "borne_min": 1, "borne_max": 13057,
+                          "empreinte_md5": "0f46f853577f32c79303bc8505e034ca" },
+  "reconciliation":     { "identites_conservees": 13057, "conflits": 0,
+                          "inclusion_respectee": true } }
+```
+
+Le registre est **scellé** (SHA-256, canonicalisation identique aux autres artefacts).
+Vérifié : falsifier une seule valeur fait diverger le sceau. Une preuve qu'on peut
+réécrire n'en est pas une.
+
+L'empreinte du contenu chargé survit à la purge : elle permet de constater qu'un second
+rejeu produit exactement le même contenu, sans conserver la donnée.
+
+## 4. Fail-closed — ce qui se passe quand ça casse
+
+Toute anomalie arrête la vague et **ne purge pas** le DLNR fautif : sa matière reste en
+base pour le diagnostic. Un DLNR n'est purgé que **lorsque sa preuve est écrite**.
+
+| Situation | Code | Effet |
+|---|---:|---|
+| Comptabilité déséquilibrée | 5 | rollback du DLNR, vague arrêtée |
+| Dérive d'identité | 6 | vague arrêtée |
+| Conservation rompue | 7 | vague arrêtée |
+| Inclusion PROD ⊄ REBUILD | 8 | vague arrêtée, **matière conservée** |
+| Purge non confirmée | 9 | vague arrêtée |
+
+Éprouvé : `test-tecdoc-replay.sh` — **32 assertions, 0 rouge**, dont la vague nominale
+avec purge, la relance idempotente, l'inclusion rompue et la conservation de la matière
+sur échec.
+
+## 5. Environnement
 
 ```
 archive TecDoc (SQL-CONVERTED.7z, 5,8 Go)
         ↓  extraction + CRC32 confronté au périmètre scellé
-volume dédié /mnt/tecdoc-rebuild  (~250 Go, hors /)
-        ↓
 PostgreSQL 17 isolé — 127.0.0.1 uniquement, aucun accès PROD
-        ↓  scripts/tecdoc_replay.py (fail-closed)
-tecdoc_raw.t400 / t232
-        ↓
-tecdoc_map.source_linkages
-        ↓  projection
-réconciliation — scripts/tecdoc_replay_controls.py
+        ↓  tecdoc_replay.py (fail-closed)      un DLNR
+        ↓  tecdoc_replay_controls.py           réconciliation + identité
+        ↓  registre scellé                     la preuve
+        ↓  purge vérifiée                      la matière repart
+        ↺  DLNR suivant
 ```
-
-**Aucun chemin d'écriture vers PROD n'existe dans cette chaîne.** Le container ne reçoit
-aucune variable d'accès PROD, et `provision-rebuild-env.sh` **refuse de démarrer** si
-`SUPABASE_DB_PASSWORD`, `DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` ou `PGPASSWORD` sont
-exportées dans le shell appelant.
-
-## 2. Chiffrage de la capacité
-
-Mesures PROD du 2026-09-08 (lecture seule) :
-
-| Objet | Total | dont index |
-|---|---:|---:|
-| `tecdoc_map.source_linkages` | 90,0 Go | 33,7 Go |
-| `tecdoc_raw.t400` | 17,4 Go | 924 Mo |
-| `tecdoc_raw.t232` | 1,7 Go | — |
-| `tecdoc_map.source_linkage_criteria` | 356 Mo | 157 Mo |
-| **Staging PROD** | **109,5 Go** | 34,7 Go |
-
-Le rebuild charge la **source complète**, plus volumineuse que la PROD tronquée. Facteur
-mesuré depuis l'artefact scellé : **×1,20** (149 DLNR chargés) et **×1,28** (110 projetés).
-
-```
-données + index en rebuild ........... ~139 Go
-+ WAL, tri de construction d'index,
-  scratch de parsing, archive 5,8 Go
-+ marge de sécurité 20 %
-
-besoin minimal ....................... 160 Go
-besoin recommandé .................... 210 Go   ← seuil de la garde
-cible de provisionnement ............. 250 Go
-```
-
-> **Borne inférieure assumée** : seuls **66/110** DLNR projetés (et 83/149 chargés) portent
-> un `.meta` de parsing. Pour les autres, la valeur PROD — donc éventuellement tronquée — a
-> été retenue. Le facteur source-truth réel est **supérieur** à ×1,28, et ces seuils sont
-> des planchers, pas des estimations centrales.
-
-## 3. État de la machine DEV — pourquoi c'est `NO_GO`
-
-```
-hôte ................. dev-automecanik (Hetzner Cloud vServer, instance 115238775)
-disque physique ...... /dev/sda — 152,6 Go   ← total, pas disponible
-partition / .......... /dev/sda1 — 150 Go, 106 Go utilisés, 39 Go libres (74 %)
-espace non alloué .... 0,00 Go
-volume additionnel ... aucun
-```
-
-Le disque **entier** fait 152,6 Go, soit moins que le besoin minimal de 160 Go. Même en
-libérant tout `/opt/automecanik` (~38 Go), on plafonnerait vers 77 Go. **Le rebuild ne peut
-pas tenir sur cette machine sans volume supplémentaire.**
-
-## 4. Provisionnement — action hébergeur (owner)
-
-Attacher un disque est une opération chez l'hébergeur, hors de portée d'un agent.
-
-```bash
-# 1. Créer et attacher un volume de 250 Go dans la même zone que le serveur
-hcloud volume create --name tecdoc-rebuild --size 250 --server dev-automecanik --format ext4
-# (ou : Console Hetzner → Volumes → Create Volume → 250 GB → attach to dev-automecanik)
-
-# 2. Repérer le device (Hetzner l'expose sous /dev/disk/by-id/scsi-0HC_Volume_<id>)
-ls -l /dev/disk/by-id/ | grep HC_Volume
-
-# 3. Monter sur un chemin dédié — jamais sous /tmp
-sudo mkdir -p /mnt/tecdoc-rebuild
-sudo mount -o discard,defaults,noatime /dev/disk/by-id/scsi-0HC_Volume_<id> /mnt/tecdoc-rebuild
-
-# 4. Rendre le montage persistant
-echo '/dev/disk/by-id/scsi-0HC_Volume_<id> /mnt/tecdoc-rebuild ext4 discard,defaults,noatime,nofail 0 0' \
-  | sudo tee -a /etc/fstab
-
-# 5. Vérifier la capacité — rend GO ou NO_GO, jamais « probablement »
-bash scripts/tecdoc-replay/check-rebuild-capacity.sh /mnt/tecdoc-rebuild
-
-# 6. Provisionner (idempotent, refuse si la capacité est insuffisante)
-env -u DATABASE_URL -u SUPABASE_DB_PASSWORD -u SUPABASE_SERVICE_ROLE_KEY -u PGPASSWORD \
-  bash scripts/tecdoc-replay/provision-rebuild-env.sh
-```
-
-`noatime` évite des écritures inutiles pendant le chargement massif ; `nofail` empêche un
-volume absent de bloquer le démarrage de la machine.
-
-## 5. Contrat de l'environnement
 
 | Contrainte | Mise en œuvre | Vérifiée par |
 |---|---|---|
-| PostgreSQL 17 | image `postgres:17-alpine` (17.11 constatée) | contrôle final du provisionnement |
-| Isolé | `-p 127.0.0.1:55440:5432`, jamais d'écoute publique | `provision-rebuild-env.sh` |
-| Jetable | tout l'état vit sous `/mnt/tecdoc-rebuild` | — |
+| PostgreSQL 17 | `postgres:17-alpine` (17.11 constatée) | contrôle final du provisionnement |
+| Isolé | `-p 127.0.0.1:<port>:5432` | `provision-rebuild-env.sh` |
+| Jetable | tout l'état sous le point de montage | — |
 | Aucun accès PROD | refus si une variable d'accès PROD est exportée | garde §2 du script |
-| Volume dédié | refus si le point de montage partage le device de `/` | `check-rebuild-capacity.sh` |
-| Capacité | refus sous 210 Go libres | `check-rebuild-capacity.sh` |
+| Capacité | seuil paramétrable, refus en dessous | `check-rebuild-capacity.sh` |
 
-Arborescence créée : `pgdata/` (PGDATA, uid 70), `scratch/` (parsing), `archive/` (source),
-`rapports/` (comptabilité par lot). Le mot de passe local est généré sur place (32 octets
-d'entropie), stocké en `0600` sur le volume, **jamais affiché ni journalisé**.
+`provision-rebuild-env.sh` reste utilisable tel quel ; en mode vagues, le seuil de
+capacité se règle par `TECDOC_REBUILD_MIN_GO` (≈ 10 Go suffisent, contre 210 en mode
+matérialisé). Le mot de passe local est généré sur place, `0600`, jamais affiché.
 
-**Réglages** : `shared_buffers=2GB`, `maintenance_work_mem=2GB`, `max_wal_size=8GB`,
-`checkpoint_timeout=30min`, `synchronous_commit=off`, `--shm-size=2g`.
-`fsync` reste **actif** par défaut : un crash hôte avec `fsync=off` corromprait le cluster et
-ferait perdre des heures de rejeu, alors que l'idempotence par `_batch_id` permet sinon de
-reprendre au DLNR près. `--rapide` l'ouvre explicitement, avec l'avertissement associé.
+## 6. Plan de lots
 
-## 6. Plan de lots — préparé, non exécuté
+`plan-lots.json`, dérivé de l'artefact scellé, régénération déterministe vérifiée.
+**110/110 DLNR couverts.**
 
-Généré depuis l'artefact scellé par `generer-plan-lots.py` → `plan-lots.json`.
-**110/110 DLNR couverts**, volumétrie croissante, divergents placés par poids.
+| Lot | DLNR | Lignes source | Pic disque | Divergents |
+|---|---:|---:|---:|---|
+| 0 — fumée | 1 | 13 057 | < 0,1 Go | — |
+| 1 | 5 | 2 179 199 | ~0,3 Go | NISSENS, PAYEN |
+| 2 | 20 | 7 932 092 | ~1,1 Go | RIDEX |
+| 3 — lourds isolés | 2 | 26 779 184 | ~3,3 Go | BOSCH, FEBI |
+| 4 | 30 | 9 404 364 | ~0,5 Go | — |
+| 5 | 30 | 25 567 877 | ~1,2 Go | — |
+| 6 | 22 | 59 056 373 | ~1,2 Go | — |
 
-| Lot | DLNR | Lignes source attendues | Divergents |
-|---|---:|---:|---|
-| 0 — fumée | 1 | 13 057 | — (HIDRIA, déjà validé en #1418) |
-| 1 — 5 DLNR | 5 | 2 179 199 | NISSENS, PAYEN |
-| 2 — 20 DLNR | 20 | 7 932 092 | RIDEX |
-| 3 — divergents lourds isolés | 2 | 26 779 184 | BOSCH, FEBI |
-| 4 — reste | 30 | 9 404 364 | — |
-| 5 — reste | 30 | 25 567 877 | — |
-| 6 — reste | 22 | 59 056 373 | — |
-
-Les cinq divergents sont traités **tôt et par poids croissant** : ce sont les cas de
-non-régression prioritaires, et les rencontrer tard signifierait découvrir un défaut après
+Le pic est celui du **plus gros DLNR de chaque lot**, la matière étant purgée entre
+chacun. Les 5 divergents arrivent tôt et par poids croissant : ce sont les cas de
+non-régression prioritaires, et les découvrir tard reviendrait à trouver un défaut après
 des heures de rejeu.
-
-**Contrat de chaque lot** :
-
-- **Checkpoint** — `_batch_id` déterministe `(table, DLNR, CRC32, version)`. Un lot
-  interrompu se reprend au DLNR près, sans doublon.
-- **Comptabilité** — `émis = chargées + dédoublonnées + rejets explicites`, vérifiée
-  **avant** commit. Sinon `FAIL` + `ROLLBACK` + `STOP`.
-- **Rollback** — une transaction par DLNR ; aucun préfixe partiel n'est committable.
-- **Rapport** — `/mnt/tecdoc-rebuild/rapports/lot-<n>.json`.
-- **Condition de passage** — un lot ne s'ouvre que si le précédent est intégralement vert.
 
 ## 7. Cibles de non-régression des 5 divergents
 
@@ -165,11 +145,41 @@ des heures de rejeu.
 | 113 | PAYEN | 1 085 500 | 1 259 429 | +173 929 | 86,19 % |
 | | **Total** | **6 036 100** | **34 492 354** | **+28 456 254** | |
 
-Le rebuild doit atteindre la colonne « source émise ». Les préfixes tronqués de `t400` sont
-de la **vérité forensique historique**, jamais une cible.
+Les préfixes tronqués de `t400` sont de la **vérité forensique historique**, jamais une
+cible.
 
-## 8. Ce que ce document ne dit pas
+## 8. Rotation d'un identifiant de base — procédure vérifiable
 
-Il ne mentionne aucun état de secret, aucune empreinte, aucune valeur : ce dépôt est public,
-et y consigner l'état d'un identifiant vivant l'exposerait davantage. Ces éléments sont
-transmis hors dépôt.
+`scripts/verifier-rotation-secret.py` établit mécaniquement qu'une rotation a eu lieu.
+Une rotation n'est pas prouvée parce qu'on l'a faite : elle l'est quand **l'ancien
+identifiant est refusé** *et* que le nouveau fonctionne.
+
+```bash
+python3 scripts/verifier-rotation-secret.py \
+  --env /chemin/vers/backend/.env --commit <sha> --chemin <fichier>
+```
+
+| Sortie | Signification |
+|---|---|
+| `ROTATED` (0) | ancien refusé en `28P01`, nouveau accepté |
+| `ROTATION_FAIL` (1) | l'ancien ouvre encore la base |
+| `BLOCKED_BY_SECRET_ROTATION` (2) | actif == publié, rien n'a changé |
+| `INDETERMINE` (3) | une vérification n'a pas pu être menée — jamais supposée |
+
+Aucune valeur n'est affichée, journalisée, passée en `argv` ni écrite : seules des
+empreintes SHA-256 tronquées à 12 hexadécimaux apparaissent. La référence du blob publié
+est fournie **à l'exécution** et n'est pas inscrite dans le dépôt — l'y figer en ferait un
+panneau indicateur.
+
+Le distinguo refus d'authentification / panne réseau est **éprouvé** : un `INDETERMINE`
+est rendu si l'ancien identifiant échoue autrement qu'en `28P01`, parce qu'une coupure
+réseau ressemble à un refus sans en être un.
+
+Ordre des opérations, une fois le nouvel identifiant en place :
+
+1. mettre à jour le `.env` de la machine opérateur ;
+2. mettre à jour le secret CI correspondant (saisie interactive) ;
+3. lancer le vérificateur → doit rendre `ROTATED` ;
+4. **alors seulement**, supprimer les copies locales que le vérificateur inventorie —
+   les purger avant la rotation détruirait une sauvegarde d'un identifiant encore en
+   service, sans rien réduire.

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -218,17 +218,20 @@ L'étape 0 diagnostique sans sur-affirmer : un `403` couvre à la fois le jeton 
 rejeté en amont et le jeton valide sans droit sur le projet. Le script nomme les deux
 et montre la réponse, plutôt que d'envoyer chercher au mauvais endroit.
 
-**Saisie du jeton — le piège du collage.** `read -rs VAR` lit l'entrée standard. Si la
-commande est collée avec les lignes suivantes, `read` avale la ligne d'après au lieu
-d'attendre la frappe, et la variable est exportée **vide**. D'où :
+**Saisie du jeton — pourquoi le script le demande lui-même.** La voie évidente était
+`read -rs VAR && export VAR` puis la commande. Elle échoue silencieusement : `read` lit
+l'entrée standard, donc un collage multi-lignes lui fait avaler la ligne suivante au lieu
+d'attendre la frappe, et la variable part **vide**. L'erreur se relit alors comme « jeton
+refusé » alors qu'il n'a jamais été saisi. Constaté deux fois de suite en conditions
+réelles.
 
-```bash
-read -rsp "Jeton : " SUPABASE_ACCESS_TOKEN < /dev/tty && export SUPABASE_ACCESS_TOKEN && echo
-```
-
-Le `< /dev/tty` force la lecture sur le terminal. Le script rend ce diagnostic lui-même
-quand la variable est vide — sinon l'erreur se relit comme « jeton refusé » alors qu'il
-n'a jamais été saisi.
+Ajouter `< /dev/tty` corrige le symptôme mais laisse la cause : un état de shell à porter
+d'une commande à l'autre, donc un ordre à respecter et une session à ne pas changer. Le
+script **demande le jeton directement** (`getpass`, saisie masquée sur `/dev/tty`) — plus
+d'`export`, plus d'ordre, la classe d'erreur entière disparaît. `SUPABASE_ACCESS_TOKEN`
+reste lu en priorité pour l'usage non interactif ; sans terminal *et* sans variable, le
+script sort en `3` en nommant la voie non interactive plutôt qu'en ouvrant une saisie
+qui resterait suspendue.
 
 Le jeton d'API est lu dans `SUPABASE_ACCESS_TOKEN`, jamais dans un fichier de
 configuration ni en `argv`. Le script ne contient aucune référence de projet, de dépôt

--- a/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
+++ b/audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md
@@ -225,9 +225,28 @@ aurait donc été refusé par le préflight lui-même. **Une garde doit éprouve
 permission que ce qu'elle précède**, sinon elle bloque exactement les cas les mieux
 configurés.
 
-Le diagnostic ne sur-affirme pas : un `403` couvre à la fois le jeton malformé rejeté en
-amont et le jeton valide sans la permission. Le script nomme les deux et montre la
-réponse, plutôt que d'envoyer chercher au mauvais endroit.
+**Le client HTTP doit s'annoncer.** Sans `User-Agent` explicite, `urllib` s'annonce
+`Python-urllib/3.x` — signature bannie par le pare-feu applicatif devant l'API, qui rend
+`403 · error code: 1010`. Mesuré, même jeton (faux) :
+
+| Client | Réponse |
+|---|---|
+| `urllib` par défaut | `403` · `error code: 1010` |
+| `urllib` + `User-Agent` | `401` · `JWT could not be decoded` |
+| `curl` | `401` · `JWT could not be decoded` |
+
+Le piège est que le `403` sort **à l'identique pour un jeton valide et pour un jeton
+bidon** : la requête n'atteint jamais l'API, et un diagnostic naïf accuse le jeton. C'est
+arrivé en conditions réelles, et le message du script a envoyé chercher du côté des
+permissions un défaut qui était dans le client HTTP.
+
+Deux gardes en découlent : toute requête porte l'en-tête (assertion de couverture au
+banc, pour qu'une requête ajoutée plus tard ne rejoue pas l'incident), et **une réponse
+qui n'est pas du JSON est imputée au pare-feu, jamais au jeton** — l'API répond en JSON,
+le filtrage en amont non.
+
+Le diagnostic ne sur-affirme pas non plus sur le reste : le script nomme la permission
+attendue et montre la réponse, plutôt que d'envoyer chercher au mauvais endroit.
 
 **Saisie du jeton — pourquoi le script le demande lui-même.** La voie évidente était
 `read -rs VAR && export VAR` puis la commande. Elle échoue silencieusement : `read` lit

--- a/log.md
+++ b/log.md
@@ -482,3 +482,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-pipeline-recovery`
 - **Décision** : docs(tecdoc): consigner le piege latent de derivation du DLNR par str.replace (+2 other commits)
 - **Sortie** : PR #1417 | commits 9c4b7640f b1dd9aa25 ae0871d03
+
+## 2026-09-08 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : feat(tecdoc): spécifier et outiller l'environnement de rebuild isolé (~250 Go)
+- **Sortie** : PR #1419 | commits e4d4f650e

--- a/log.md
+++ b/log.md
@@ -500,3 +500,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : feat(ops): rotation d'identifiant de base par le chemin supporté, et le piège qu'il évite (+4 other commits)
 - **Sortie** : PR #1419 | commits 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : fix(ops): vérifier le jeton avant d'engendrer un secret, et nommer le piège du collage (+6 other commits)
+- **Sortie** : PR #1419 | commits c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e

--- a/log.md
+++ b/log.md
@@ -518,3 +518,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : fix(ops): le préflight éprouvait la mauvaise permission — il aurait bloqué les jetons bien réglés (+10 other commits)
 - **Sortie** : PR #1419 | commits 3cb6996f2 bb0a1cc46 a2d53a7bc 0a0ebbd79 c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : fix(ops): le client HTTP ne s'annonçait pas — la requête n'atteignait jamais l'API (+12 other commits)
+- **Sortie** : PR #1419 | commits 8564bded9 0e1b6456e 3cb6996f2 bb0a1cc46 a2d53a7bc 0a0ebbd79 c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e

--- a/log.md
+++ b/log.md
@@ -488,3 +488,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : feat(tecdoc): spécifier et outiller l'environnement de rebuild isolé (~250 Go)
 - **Sortie** : PR #1419 | commits e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : feat(tecdoc): rejeu par vagues — le pic disque passe de 250 Go à ~5 Go, et la preuve survit à la donnée (+2 other commits)
+- **Sortie** : PR #1419 | commits 647dc5b6a 01bd9a0c8 e4d4f650e

--- a/log.md
+++ b/log.md
@@ -494,3 +494,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : feat(tecdoc): rejeu par vagues — le pic disque passe de 250 Go à ~5 Go, et la preuve survit à la donnée (+2 other commits)
 - **Sortie** : PR #1419 | commits 647dc5b6a 01bd9a0c8 e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : feat(ops): rotation d'identifiant de base par le chemin supporté, et le piège qu'il évite (+4 other commits)
+- **Sortie** : PR #1419 | commits 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e

--- a/log.md
+++ b/log.md
@@ -506,3 +506,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : fix(ops): vérifier le jeton avant d'engendrer un secret, et nommer le piège du collage (+6 other commits)
 - **Sortie** : PR #1419 | commits c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : fix(ops): le script demande le jeton lui-même — la voie en deux temps échouait (+8 other commits)
+- **Sortie** : PR #1419 | commits a2d53a7bc 0a0ebbd79 c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e

--- a/log.md
+++ b/log.md
@@ -512,3 +512,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : fix(ops): le script demande le jeton lui-même — la voie en deux temps échouait (+8 other commits)
 - **Sortie** : PR #1419 | commits a2d53a7bc 0a0ebbd79 c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : fix(ops): le préflight éprouvait la mauvaise permission — il aurait bloqué les jetons bien réglés (+10 other commits)
+- **Sortie** : PR #1419 | commits 3cb6996f2 bb0a1cc46 a2d53a7bc 0a0ebbd79 c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e

--- a/log.md
+++ b/log.md
@@ -524,3 +524,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/tecdoc-rebuild-environment`
 - **Décision** : fix(ops): le client HTTP ne s'annonçait pas — la requête n'atteignait jamais l'API (+12 other commits)
 - **Sortie** : PR #1419 | commits 8564bded9 0e1b6456e 3cb6996f2 bb0a1cc46 a2d53a7bc 0a0ebbd79 c67f82a31 fed9560b8 716c4085c e28197c57 647dc5b6a 01bd9a0c8 e4d4f650e
+
+## 2026-09-09 — feat/tecdoc-rebuild-environment (auto)
+
+- **Branche** : `feat/tecdoc-rebuild-environment`
+- **Décision** : feat(tecdoc): porte de capacite a deux modes, et un registre de preuve recalculable (+14 other commits)
+- **Sortie** : PR #1419 | commits f73b300c0 d6f3e94a1 93bd601eb a3ec3a602 45e8c6402 fc222949f f1994b30d 08d28175b 5650961cf b4408e7b1 fb9bcd355 90358994c d348f3eec 098be7744 c1ee2d690

--- a/scripts/tecdoc-replay/check-rebuild-capacity.sh
+++ b/scripts/tecdoc-replay/check-rebuild-capacity.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Porte de capacite du rebuild TecDoc complet. Rend GO ou NO_GO, jamais « probablement ».
+#
+# POURQUOI CETTE GARDE EXISTE
+# ---------------------------
+# Le rebuild source-truth est PLUS VOLUMINEUX que le staging PROD : la PROD porte des
+# prefixes tronques (BOSCH 69 000 lignes sur 9 357 752 emises), le rebuild charge la
+# source complete. Lancer un rejeu de 110 DLNR sur un volume trop petit produit un
+# echec a mi-parcours — exactement l'etat « a moitie construit » que ce chantier
+# interdit. La capacite se verifie AVANT, pas quand le disque est plein.
+#
+# CHIFFRAGE (mesures PROD du 2026-09-08, artefact scelle 2026-03-reconstructed)
+#   staging PROD mesure ......................... 109,5 Go
+#     tecdoc_map.source_linkages ..... 90,0 Go (dont 33,7 index)
+#     tecdoc_raw.t400 ................ 17,4 Go
+#     tecdoc_raw.t232 ................  1,7 Go
+#     tecdoc_map.source_linkage_criteria 356 Mo
+#   facteur source-truth ........................ x1,20 (149 DLNR) / x1,28 (110 projetes)
+#   -> donnees + index en rebuild ............... ~139 Go
+#   + WAL, tri de construction d'index, scratch de parsing, archive 5,8 Go
+#   + marge de securite 20 %
+#
+# BORNE INFERIEURE ASSUMEE : seuls 66/110 DLNR projetes portent un `.meta` de parsing.
+# Le facteur source-truth est donc SOUS-ESTIME, et ces seuils sont des planchers.
+set -uo pipefail
+
+MIN_GO="${TECDOC_REBUILD_MIN_GO:-210}"     # en dessous : NO_GO, sans discussion
+CIBLE_GO="${TECDOC_REBUILD_CIBLE_GO:-250}" # provisionnement vise
+MOUNT="${1:-/mnt/tecdoc-rebuild}"
+
+printf '=== Capacite du rebuild TecDoc — point de montage %s ===\n' "$MOUNT"
+
+if [ ! -d "$MOUNT" ]; then
+  echo "  ✗ $MOUNT n'existe pas."
+  echo
+  echo "NO_GO — aucun volume dedie. Voir la section « Provisionnement » de"
+  echo "audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md."
+  exit 1
+fi
+
+read -r dev fstype taille utilise libre pcent cible < <(
+  df -PT --block-size=1 "$MOUNT" | tail -1 | awk '{print $1,$2,$3,$4,$5,$6,$7}')
+libre_go=$(awk -v v="$libre" 'BEGIN{printf "%.1f", v/1024/1024/1024}')
+taille_go=$(awk -v v="$taille" 'BEGIN{printf "%.1f", v/1024/1024/1024}')
+inodes_libres=$(df -iP "$MOUNT" | tail -1 | awk '{print $4}')
+opts=$(findmnt -no OPTIONS --target "$MOUNT" 2>/dev/null || echo "?")
+proprio=$(stat -c '%U:%G %a' "$MOUNT" 2>/dev/null || echo "?")
+
+printf '  device .............. %s\n'    "$dev"
+printf '  filesystem .......... %s\n'    "$fstype"
+printf '  mountpoint .......... %s\n'    "$cible"
+printf '  mount options ....... %s\n'    "$opts"
+printf '  owner / mode ........ %s\n'    "$proprio"
+printf '  taille .............. %s Go\n' "$taille_go"
+printf '  libre ............... %s Go\n' "$libre_go"
+printf '  inodes libres ....... %s\n'    "$inodes_libres"
+printf '  seuil minimal ....... %s Go\n' "$MIN_GO"
+printf '  cible provisionnement %s Go\n' "$CIBLE_GO"
+echo
+
+# Un volume DEDIE : refuser un simple repertoire pose sur la racine, qui ferait
+# partager l'espace avec le systeme et le runtime DEV.
+dev_racine=$(df -PT / | tail -1 | awk '{print $1}')
+if [ "$dev" = "$dev_racine" ]; then
+  echo "  ✗ $MOUNT est sur le MEME systeme de fichiers que / ($dev)."
+  echo "    Un rebuild qui remplit / arrete le runtime DEV et la session operateur."
+  echo
+  echo "NO_GO — volume non dedie."
+  exit 1
+fi
+
+if awk -v l="$libre_go" -v m="$MIN_GO" 'BEGIN{exit !(l < m)}'; then
+  manque=$(awk -v l="$libre_go" -v m="$MIN_GO" 'BEGIN{printf "%.1f", m-l}')
+  echo "  ✗ $libre_go Go libres < $MIN_GO Go requis — il manque $manque Go."
+  echo
+  echo "NO_GO"
+  exit 1
+fi
+
+if awk -v t="$taille_go" -v c="$CIBLE_GO" 'BEGIN{exit !(t < c)}'; then
+  echo "  ⚠ volume de $taille_go Go : au-dessus du minimum, en dessous de la cible de"
+  echo "    $CIBLE_GO Go. Le rejeu tient, la marge d'imprevu est mince."
+fi
+echo "GO"

--- a/scripts/tecdoc-replay/check-rebuild-capacity.sh
+++ b/scripts/tecdoc-replay/check-rebuild-capacity.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
-# Porte de capacite du rebuild TecDoc complet. Rend GO ou NO_GO, jamais « probablement ».
+# Porte de capacite du rebuild TecDoc. Rend GO ou NO_GO, jamais « probablement ».
 #
-# POURQUOI CETTE GARDE EXISTE
-# ---------------------------
-# Le rebuild source-truth est PLUS VOLUMINEUX que le staging PROD : la PROD porte des
-# prefixes tronques (BOSCH 69 000 lignes sur 9 357 752 emises), le rebuild charge la
-# source complete. Lancer un rejeu de 110 DLNR sur un volume trop petit produit un
-# echec a mi-parcours — exactement l'etat « a moitie construit » que ce chantier
-# interdit. La capacite se verifie AVANT, pas quand le disque est plein.
+# DEUX MODES, DEUX PERIMETRES PHYSIQUES DISTINCTS
+# ------------------------------------------------
+# Le mode n'est pas un reglage de confort : les deux strategies de rebuild ont des
+# besoins disque de nature differente, et une seule porte ne peut pas juger les deux
+# honnetement. Assouplir le seuil du mode materialise pour faire passer un rejeu par
+# vagues masquerait le vrai besoin du premier.
 #
-# CHIFFRAGE (mesures PROD du 2026-09-08, artefact scelle 2026-03-reconstructed)
+#   materialise (defaut) — les 110 DLNR coexistent dans une seule instance.
+#     Besoin = la SOMME. Volume dedie obligatoire : un rebuild de ~139 Go qui remplit
+#     la racine arrete le runtime DEV et la session operateur.
+#
+#   vagues — un DLNR est charge, controle, scelle, puis SA MATIERE EST PURGEE avant
+#     le suivant. Besoin = le plus gros DLNR SEUL, pas la somme. Le volume dedie perd
+#     sa raison d'etre : ce n'est pas la taille qui le justifiait mais le risque de
+#     saturer la racine, et un pic de ~5 Go ne la sature pas. Le seuil reste une vraie
+#     porte — il refuse simplement au bon niveau.
+#
+# CHIFFRAGE materialise (mesures PROD du 2026-09-08, artefact scelle 2026-03-reconstructed)
 #   staging PROD mesure ......................... 109,5 Go
 #     tecdoc_map.source_linkages ..... 90,0 Go (dont 33,7 index)
 #     tecdoc_raw.t400 ................ 17,4 Go
@@ -22,19 +31,38 @@
 #
 # BORNE INFERIEURE ASSUMEE : seuls 66/110 DLNR projetes portent un `.meta` de parsing.
 # Le facteur source-truth est donc SOUS-ESTIME, et ces seuils sont des planchers.
+#
+# CHIFFRAGE vagues (rejeu HIDRIA mesure : 203 octets/ligne, index compris)
+#   FEBI, DLNR dimensionnant .... 17 421 432 lignes -> 3,3 Go en base
+#   + CSV de parsing transitoire ................... ~1,5 Go
+#   -> pic reel ..................................... ~5 Go
+#   seuil retenu 20 Go = 4x le pic mesure. L'archive 7z (5,8 Go) est deja sur disque
+#   et n'est pas dupliquee.
 set -uo pipefail
 
-MIN_GO="${TECDOC_REBUILD_MIN_GO:-210}"     # en dessous : NO_GO, sans discussion
-CIBLE_GO="${TECDOC_REBUILD_CIBLE_GO:-250}" # provisionnement vise
-MOUNT="${1:-/mnt/tecdoc-rebuild}"
+MODE="${TECDOC_REBUILD_MODE:-materialise}"
+MIN_GO="${TECDOC_REBUILD_MIN_GO:-210}"           # materialise — en dessous : NO_GO
+CIBLE_GO="${TECDOC_REBUILD_CIBLE_GO:-250}"       # materialise — provisionnement vise
+VAGUE_MIN_GO="${TECDOC_REBUILD_VAGUE_MIN_GO:-20}" # vagues — 4x le pic mesure
 
-printf '=== Capacite du rebuild TecDoc — point de montage %s ===\n' "$MOUNT"
+case "$MODE" in
+  materialise) DEFAUT_MOUNT="/mnt/tecdoc-rebuild" ;;
+  vagues)      DEFAUT_MOUNT="/" ;;  # le PostgreSQL jetable ecrit dans le stockage Docker
+  *) echo "Mode inconnu : $MODE (attendu : materialise | vagues)" >&2; exit 2 ;;
+esac
+MOUNT="${1:-$DEFAUT_MOUNT}"
+
+printf '=== Capacite du rebuild TecDoc — mode %s — cible %s ===\n' "$MODE" "$MOUNT"
 
 if [ ! -d "$MOUNT" ]; then
   echo "  ✗ $MOUNT n'existe pas."
   echo
-  echo "NO_GO — aucun volume dedie. Voir la section « Provisionnement » de"
-  echo "audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md."
+  if [ "$MODE" = "materialise" ]; then
+    echo "NO_GO — aucun volume dedie. Voir la section « Provisionnement » de"
+    echo "audit/massdoc-tecdoc-rebuild-environment-spec-2026-09-08.md."
+  else
+    echo "NO_GO — chemin cible introuvable."
+  fi
   exit 1
 fi
 
@@ -45,6 +73,7 @@ taille_go=$(awk -v v="$taille" 'BEGIN{printf "%.1f", v/1024/1024/1024}')
 inodes_libres=$(df -iP "$MOUNT" | tail -1 | awk '{print $4}')
 opts=$(findmnt -no OPTIONS --target "$MOUNT" 2>/dev/null || echo "?")
 proprio=$(stat -c '%U:%G %a' "$MOUNT" 2>/dev/null || echo "?")
+seuil=$([ "$MODE" = "vagues" ] && echo "$VAGUE_MIN_GO" || echo "$MIN_GO")
 
 printf '  device .............. %s\n'    "$dev"
 printf '  filesystem .......... %s\n'    "$fstype"
@@ -54,30 +83,34 @@ printf '  owner / mode ........ %s\n'    "$proprio"
 printf '  taille .............. %s Go\n' "$taille_go"
 printf '  libre ............... %s Go\n' "$libre_go"
 printf '  inodes libres ....... %s\n'    "$inodes_libres"
-printf '  seuil minimal ....... %s Go\n' "$MIN_GO"
-printf '  cible provisionnement %s Go\n' "$CIBLE_GO"
+printf '  seuil minimal ....... %s Go\n' "$seuil"
+[ "$MODE" = "materialise" ] && printf '  cible provisionnement %s Go\n' "$CIBLE_GO"
 echo
 
-# Un volume DEDIE : refuser un simple repertoire pose sur la racine, qui ferait
-# partager l'espace avec le systeme et le runtime DEV.
-dev_racine=$(df -PT / | tail -1 | awk '{print $1}')
-if [ "$dev" = "$dev_racine" ]; then
-  echo "  ✗ $MOUNT est sur le MEME systeme de fichiers que / ($dev)."
-  echo "    Un rebuild qui remplit / arrete le runtime DEV et la session operateur."
-  echo
-  echo "NO_GO — volume non dedie."
-  exit 1
+# Volume DEDIE — exigence du mode materialise UNIQUEMENT. Elle ne protege pas de la
+# taille mais du blast radius : un rebuild de ~139 Go qui remplit / arrete le runtime
+# DEV. En mode vagues le pic est de ~5 Go, la racine n'est pas menacee, et imposer un
+# volume separe reviendrait a refuser precisement les configurations bien dimensionnees.
+if [ "$MODE" = "materialise" ]; then
+  dev_racine=$(df -PT / | tail -1 | awk '{print $1}')
+  if [ "$dev" = "$dev_racine" ]; then
+    echo "  ✗ $MOUNT est sur le MEME systeme de fichiers que / ($dev)."
+    echo "    Un rebuild qui remplit / arrete le runtime DEV et la session operateur."
+    echo
+    echo "NO_GO — volume non dedie."
+    exit 1
+  fi
 fi
 
-if awk -v l="$libre_go" -v m="$MIN_GO" 'BEGIN{exit !(l < m)}'; then
-  manque=$(awk -v l="$libre_go" -v m="$MIN_GO" 'BEGIN{printf "%.1f", m-l}')
-  echo "  ✗ $libre_go Go libres < $MIN_GO Go requis — il manque $manque Go."
+if awk -v l="$libre_go" -v m="$seuil" 'BEGIN{exit !(l < m)}'; then
+  manque=$(awk -v l="$libre_go" -v m="$seuil" 'BEGIN{printf "%.1f", m-l}')
+  echo "  ✗ $libre_go Go libres < $seuil Go requis — il manque $manque Go."
   echo
   echo "NO_GO"
   exit 1
 fi
 
-if awk -v t="$taille_go" -v c="$CIBLE_GO" 'BEGIN{exit !(t < c)}'; then
+if [ "$MODE" = "materialise" ] && awk -v t="$taille_go" -v c="$CIBLE_GO" 'BEGIN{exit !(t < c)}'; then
   echo "  ⚠ volume de $taille_go Go : au-dessus du minimum, en dessous de la cible de"
   echo "    $CIBLE_GO Go. Le rejeu tient, la marge d'imprevu est mince."
 fi

--- a/scripts/tecdoc-replay/generer-plan-lots.py
+++ b/scripts/tecdoc-replay/generer-plan-lots.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Genere le plan de lots du rejeu complet DEPUIS l'artefact scelle.
+
+Le decoupage n'est pas invente : il derive du perimetre fige de mars 2026 et du
+volume source de chaque fournisseur. Regenerable a l'identique.
+
+Regle de placement :
+  LOT 0  fumee — 1 petit DLNR, deja prouve en PR #1418
+  LOT 1  5 DLNR petits, dont les 2 divergents les plus legers (signal maximal, cout minimal)
+  LOT 2  20 DLNR, dont le divergent moyen
+  LOT 3  les 2 divergents lourds, isoles : ce sont eux qui ont perdu 99 % des lignes
+  LOT 4+ le reste, par tranches de 30
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from tecdoc_scope import charger_perimetre  # noqa: E402
+
+SCOPE = sys.argv[1] if len(sys.argv) > 1 else "../../audit/massdoc-tecdoc-import-scope-2026-03.json"
+SORTIE = Path(sys.argv[2] if len(sys.argv) > 2 else "plan-lots.json")
+
+p = charger_perimetre(SCOPE)
+projetes = set(p.dlnr_projetes())
+DIVERGENTS = {123: "NISSENS", 30: "BOSCH", 101: "FEBI", 6358: "RIDEX", 113: "PAYEN"}
+
+def volume(s):
+    m = s.get("parseur_meta") or {}
+    return m.get("rows_emitted") or s.get("t400_rows") or 0
+
+fournisseurs = {s["dlnr"]: s for s in p.suppliers if s["dlnr"] in projetes}
+par_volume = sorted(fournisseurs.values(), key=volume)
+
+SMOKE = 4523                                     # HIDRIA — valide en #1418
+div_tries = sorted(DIVERGENTS, key=lambda d: volume(fournisseurs[d]) if d in fournisseurs else 0)
+div_legers, div_moyen, div_lourds = div_tries[:2], div_tries[2:3], div_tries[3:]
+
+place, lots = set(), []
+def prendre(n, exclure=()):
+    out = []
+    for s in par_volume:
+        if len(out) >= n: break
+        d = s["dlnr"]
+        if d in place or d in exclure or d == SMOKE: continue
+        out.append(d); place.add(d)
+    return out
+
+place.add(SMOKE)
+lots.append(("LOT 0 — fumee", [SMOKE]))
+for d in div_legers: place.add(d)
+lots.append(("LOT 1 — 5 DLNR, 2 divergents legers", div_legers + prendre(5 - len(div_legers), DIVERGENTS)))
+for d in div_moyen: place.add(d)
+lots.append(("LOT 2 — 20 DLNR, 1 divergent moyen", div_moyen + prendre(20 - len(div_moyen), DIVERGENTS)))
+for d in div_lourds: place.add(d)
+lots.append(("LOT 3 — divergents lourds, isoles", div_lourds))
+reste = [s["dlnr"] for s in par_volume if s["dlnr"] not in place]
+for i in range(0, len(reste), 30):
+    tranche = reste[i:i+30]
+    place.update(tranche)
+    lots.append((f"LOT {4 + i//30} — reste ({len(tranche)} DLNR)", tranche))
+
+doc = {
+    "objet": "Plan de lots du rejeu complet TecDoc. PREPARE, NON EXECUTE.",
+    "perimetre_source": {"fichier": Path(SCOPE).name, "version": p.version,
+                         "dlnr_projetes": len(projetes)},
+    "contrat_par_lot": {
+        "checkpoint": "_batch_id deterministe par (table, DLNR, CRC32, version) — un lot "
+                      "interrompu se reprend au DLNR pres, sans doublon.",
+        "comptabilite": "emis = charges + dedoublonnes + rejets_explicites, verifiee AVANT "
+                        "commit (tecdoc_load_guard.verifier_lot). Sinon FAIL + ROLLBACK + STOP.",
+        "rollback": "une transaction par DLNR : toute anomalie annule le DLNR entier. "
+                    "Aucun prefixe partiel ne peut etre committe.",
+        "rapport": "<volume>/rapports/lot-<n>.json — par DLNR : rows_source, rows_parsed, "
+                   "rows_emitted, rows_loaded, rows_deduplicated, rows_rejected, rows_fatal.",
+        "condition_de_passage": "un lot ne s'ouvre que si le precedent est integralement vert.",
+    },
+    "lots": [],
+}
+for nom, dlnrs in lots:
+    if not dlnrs: continue
+    doc["lots"].append({
+        "nom": nom,
+        "dlnr": sorted(dlnrs),
+        "nombre": len(dlnrs),
+        "lignes_source_attendues": sum(volume(fournisseurs[d]) for d in dlnrs),
+        "divergents_inclus": sorted(DIVERGENTS[d] for d in dlnrs if d in DIVERGENTS),
+    })
+
+couvert = sum(l["nombre"] for l in doc["lots"])
+assert couvert == len(projetes), f"couverture {couvert} != {len(projetes)}"
+doc["couverture"] = {"dlnr_planifies": couvert, "dlnr_du_perimetre": len(projetes),
+                     "lignes_source_totales": sum(l["lignes_source_attendues"] for l in doc["lots"])}
+SORTIE.write_text(json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"{SORTIE.name} : {len(doc['lots'])} lots, {couvert}/{len(projetes)} DLNR couverts")
+for l in doc["lots"]:
+    d = f"  [{', '.join(l['divergents_inclus'])}]" if l["divergents_inclus"] else ""
+    print(f"  {l['nom']:42} {l['nombre']:>3} DLNR  {l['lignes_source_attendues']:>12,} lignes{d}")

--- a/scripts/tecdoc-replay/plan-lots.json
+++ b/scripts/tecdoc-replay/plan-lots.json
@@ -1,0 +1,196 @@
+{
+  "contrat_par_lot": {
+    "checkpoint": "_batch_id deterministe par (table, DLNR, CRC32, version) — un lot interrompu se reprend au DLNR pres, sans doublon.",
+    "comptabilite": "emis = charges + dedoublonnes + rejets_explicites, verifiee AVANT commit (tecdoc_load_guard.verifier_lot). Sinon FAIL + ROLLBACK + STOP.",
+    "condition_de_passage": "un lot ne s'ouvre que si le precedent est integralement vert.",
+    "rapport": "<volume>/rapports/lot-<n>.json — par DLNR : rows_source, rows_parsed, rows_emitted, rows_loaded, rows_deduplicated, rows_rejected, rows_fatal.",
+    "rollback": "une transaction par DLNR : toute anomalie annule le DLNR entier. Aucun prefixe partiel ne peut etre committe."
+  },
+  "couverture": {
+    "dlnr_du_perimetre": 110,
+    "dlnr_planifies": 110,
+    "lignes_source_totales": 130932146
+  },
+  "lots": [
+    {
+      "divergents_inclus": [],
+      "dlnr": [
+        4523
+      ],
+      "lignes_source_attendues": 13057,
+      "nom": "LOT 0 — fumee",
+      "nombre": 1
+    },
+    {
+      "divergents_inclus": [
+        "NISSENS",
+        "PAYEN"
+      ],
+      "dlnr": [
+        79,
+        113,
+        123,
+        220,
+        382
+      ],
+      "lignes_source_attendues": 2179199,
+      "nom": "LOT 1 — 5 DLNR, 2 divergents legers",
+      "nombre": 5
+    },
+    {
+      "divergents_inclus": [
+        "RIDEX"
+      ],
+      "dlnr": [
+        11,
+        15,
+        41,
+        83,
+        96,
+        109,
+        154,
+        175,
+        193,
+        273,
+        310,
+        357,
+        396,
+        492,
+        4368,
+        4819,
+        4828,
+        4849,
+        6277,
+        6358
+      ],
+      "lignes_source_attendues": 7932092,
+      "nom": "LOT 2 — 20 DLNR, 1 divergent moyen",
+      "nombre": 20
+    },
+    {
+      "divergents_inclus": [
+        "BOSCH",
+        "FEBI"
+      ],
+      "dlnr": [
+        30,
+        101
+      ],
+      "lignes_source_attendues": 26779184,
+      "nom": "LOT 3 — divergents lourds, isoles",
+      "nombre": 2
+    },
+    {
+      "divergents_inclus": [],
+      "dlnr": [
+        5,
+        6,
+        13,
+        16,
+        24,
+        31,
+        34,
+        38,
+        43,
+        59,
+        86,
+        137,
+        190,
+        211,
+        215,
+        218,
+        239,
+        240,
+        245,
+        263,
+        292,
+        298,
+        313,
+        408,
+        437,
+        4470,
+        4572,
+        4627,
+        4705,
+        4940
+      ],
+      "lignes_source_attendues": 9404364,
+      "nom": "LOT 4 — reste (30 DLNR)",
+      "nombre": 30
+    },
+    {
+      "divergents_inclus": [],
+      "dlnr": [
+        3,
+        4,
+        32,
+        33,
+        35,
+        42,
+        55,
+        62,
+        65,
+        66,
+        73,
+        85,
+        110,
+        114,
+        134,
+        140,
+        159,
+        192,
+        204,
+        205,
+        226,
+        247,
+        249,
+        260,
+        324,
+        332,
+        393,
+        460,
+        469,
+        4680
+      ],
+      "lignes_source_attendues": 25567877,
+      "nom": "LOT 5 — reste (30 DLNR)",
+      "nombre": 30
+    },
+    {
+      "divergents_inclus": [],
+      "dlnr": [
+        10,
+        21,
+        37,
+        39,
+        50,
+        54,
+        67,
+        75,
+        89,
+        95,
+        127,
+        151,
+        161,
+        244,
+        253,
+        350,
+        440,
+        475,
+        484,
+        4501,
+        4664,
+        4667
+      ],
+      "lignes_source_attendues": 59056373,
+      "nom": "LOT 6 — reste (22 DLNR)",
+      "nombre": 22
+    }
+  ],
+  "objet": "Plan de lots du rejeu complet TecDoc. PREPARE, NON EXECUTE.",
+  "perimetre_source": {
+    "dlnr_projetes": 110,
+    "fichier": "massdoc-tecdoc-import-scope-2026-03.json",
+    "version": "2026-03-reconstructed-v2"
+  }
+}

--- a/scripts/tecdoc-replay/provision-rebuild-env.sh
+++ b/scripts/tecdoc-replay/provision-rebuild-env.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Provisionne l'environnement de rebuild TecDoc isole. Idempotent, fail-closed.
+#
+# Ce script ne cree PAS le volume : attacher un disque est une action chez
+# l'hebergeur, pas une action d'agent. Il refuse tant que le volume dedie n'est pas
+# monte et suffisant (`check-rebuild-capacity.sh`), puis il rend l'environnement
+# reproductible et documente.
+#
+# GARANTIES
+#   * PostgreSQL 17, PGDATA sur le volume dedie — jamais sur /
+#   * ecoute 127.0.0.1 uniquement — jamais expose au reseau
+#   * mot de passe genere localement, jamais affiche, fichier 0600 sur le volume
+#   * AUCUN identifiant PROD n'entre dans le container ; le script echoue s'il en voit
+#   * refus de reinitialiser un PGDATA existant — un rebuild en cours ne se perd pas
+#     par relance distraite
+set -uo pipefail
+cd "$(dirname "$0")"
+
+MOUNT="${TECDOC_REBUILD_MOUNT:-/mnt/tecdoc-rebuild}"
+CONTENEUR="${TECDOC_REBUILD_CONTAINER:-tecdoc-rebuild-pg17}"
+PORT="${TECDOC_REBUILD_PORT:-55440}"
+IMAGE="postgres:17-alpine"
+RAPIDE=0
+for a in "$@"; do case "$a" in
+  --rapide) RAPIDE=1;;
+  --mountpoint=*) MOUNT="${a#*=}";;
+  --port=*) PORT="${a#*=}";;
+  *) echo "option inconnue : $a"; exit 64;;
+esac; done
+
+echo "=== 1/6 — porte de capacite ==="
+bash check-rebuild-capacity.sh "$MOUNT" || {
+  echo; echo "PROVISIONNEMENT REFUSE — capacite insuffisante."; exit 1; }
+
+echo
+echo "=== 2/6 — aucun identifiant PROD dans l'environnement du container ==="
+fuite=0
+for v in SUPABASE_DB_PASSWORD DATABASE_URL SUPABASE_SERVICE_ROLE_KEY PGPASSWORD; do
+  if [ -n "${!v:-}" ]; then echo "  ✗ $v est defini dans le shell appelant"; fuite=1; fi
+done
+if [ "$fuite" -ne 0 ]; then
+  echo "  Le container de rebuild ne doit porter AUCUN acces PROD. Relancer depuis un"
+  echo "  shell propre (env -i) — un rebuild qui peut ecrire en PROD n'est pas isole."
+  echo; echo "PROVISIONNEMENT REFUSE."; exit 1
+fi
+echo "  ✓ aucune variable d'acces PROD exportee"
+
+echo
+echo "=== 3/6 — arborescence sur le volume dedie ==="
+for d in pgdata scratch archive rapports; do
+  mkdir -p "$MOUNT/$d"; printf '  %s\n' "$MOUNT/$d"
+done
+chmod 700 "$MOUNT/pgdata" 2>/dev/null || true
+# L'image officielle tourne en postgres(70). Un PGDATA appartenant a l'operateur fait
+# boucler le container sur « Permission denied » — panne muette, container `restarting`.
+if [ "$(stat -c %u "$MOUNT/pgdata")" != "70" ]; then
+  if ! sudo -n chown 70:70 "$MOUNT/pgdata" 2>/dev/null; then
+    echo "  ✗ $MOUNT/pgdata doit appartenir a l'uid 70 (postgres de l'image)."
+    echo "    Executer : sudo chown 70:70 $MOUNT/pgdata"
+    echo; echo "PROVISIONNEMENT REFUSE."; exit 1
+  fi
+fi
+
+SECRET="$MOUNT/.pgpass-rebuild"
+if [ ! -f "$SECRET" ]; then
+  umask 077; head -c 32 /dev/urandom | base64 | tr -d '\n=+/' > "$SECRET"; chmod 600 "$SECRET"
+  echo "  ✓ mot de passe local genere (32 octets d'entropie, 0600, jamais affiche)"
+else
+  echo "  · mot de passe local deja present, conserve"
+fi
+
+echo
+echo "=== 4/6 — container PostgreSQL 17 isole ==="
+if [ -s "$MOUNT/pgdata/PG_VERSION" ] && ! docker ps -a --format '{{.Names}}' | grep -qx "$CONTENEUR"; then
+  echo "  · PGDATA existant detecte, container absent : re-attachement (aucune reinitialisation)"
+fi
+if docker ps -a --format '{{.Names}}' | grep -qx "$CONTENEUR"; then
+  echo "  · container $CONTENEUR deja present — demarrage sans reinitialisation"
+  docker start "$CONTENEUR" >/dev/null
+else
+  TUNING=(-c shared_buffers=2GB -c work_mem=64MB -c maintenance_work_mem=2GB
+          -c max_wal_size=8GB -c min_wal_size=1GB -c checkpoint_timeout=30min
+          -c synchronous_commit=off -c autovacuum_work_mem=1GB)
+  # `fsync=off` accelere nettement, mais un crash hote corrompt tout le cluster et fait
+  # perdre des heures de rejeu. Avec fsync actif, l'idempotence par `_batch_id` permet de
+  # reprendre au DLNR pres. Le defaut privilegie donc la reprise, pas la vitesse.
+  [ "$RAPIDE" = 1 ] && { TUNING+=(-c fsync=off -c full_page_writes=off)
+                         echo "  ⚠ --rapide : fsync desactive, un crash hote impose de tout rejouer"; }
+  docker run -d --name "$CONTENEUR" \
+    -e POSTGRES_PASSWORD_FILE=/run/secrets/pw -e POSTGRES_DB=rebuild \
+    -e PGDATA=/var/lib/postgresql/data/pgdata \
+    -v "$MOUNT/pgdata":/var/lib/postgresql/data \
+    -v "$MOUNT/scratch":/scratch \
+    -v "$SECRET":/run/secrets/pw:ro \
+    -p 127.0.0.1:"$PORT":5432 \
+    --shm-size=2g \
+    --restart unless-stopped \
+    "$IMAGE" "${TUNING[@]}" >/dev/null || { echo "  ✗ demarrage impossible"; exit 1; }
+  echo "  ✓ $CONTENEUR demarre ($IMAGE), PGDATA sur $MOUNT/pgdata"
+fi
+pret=0
+for _ in $(seq 1 90); do
+  if docker exec "$CONTENEUR" pg_isready -U postgres -d rebuild >/dev/null 2>&1; then pret=1; break; fi
+  sleep 1
+done
+if [ "$pret" -ne 1 ]; then
+  echo "  ✗ PostgreSQL n'a pas repondu en 90 s. Dernieres lignes du journal :"
+  docker logs --tail 12 "$CONTENEUR" 2>&1 | sed 's/^/      /'
+  echo; echo "PROVISIONNEMENT ECHOUE — environnement inutilisable."; exit 1
+fi
+echo "  ✓ PostgreSQL repond"
+
+echo
+echo "=== 5/6 — schema ==="
+if ! docker exec -i "$CONTENEUR" psql -U postgres -d rebuild -q -v ON_ERROR_STOP=1 \
+       < schema-jetable.sql; then
+  echo "  ✗ application du schema en echec."
+  echo; echo "PROVISIONNEMENT ECHOUE."; exit 1
+fi
+tables=$(docker exec "$CONTENEUR" psql -U postgres -d rebuild -tAc \
+  "select count(*) from information_schema.tables where table_schema in ('tecdoc_raw','tecdoc_map')")
+if [ "${tables:-0}" -lt 8 ]; then
+  echo "  ✗ $tables table(s) creees, 8 attendues — schema incomplet."
+  echo; echo "PROVISIONNEMENT ECHOUE."; exit 1
+fi
+echo "  ✓ schema applique — $tables tables (tecdoc_raw, tecdoc_map)"
+
+echo
+echo "=== 6/6 — environnement documente ==="
+docker exec "$CONTENEUR" psql -U postgres -d rebuild -tAc 'select version()' | head -1 | sed 's/^/  /'
+printf '  container ........... %s\n' "$CONTENEUR"
+printf '  ecoute .............. 127.0.0.1:%s (jamais expose)\n' "$PORT"
+printf '  PGDATA .............. %s/pgdata\n' "$MOUNT"
+printf '  scratch parsing ..... %s/scratch\n' "$MOUNT"
+printf '  archive source ...... %s/archive\n' "$MOUNT"
+printf '  rapports de lot ..... %s/rapports\n' "$MOUNT"
+printf '  secret local ........ %s (0600, hors Git, jamais affiche)\n' "$SECRET"
+printf '  acces PROD .......... AUCUN\n'
+df -hPT "$MOUNT" | tail -1 | awk '{printf "  device %s (%s) — %s libres sur %s\n", $1,$2,$5,$3}'
+if ! docker exec "$CONTENEUR" psql -U postgres -d rebuild -tAc 'select 1' >/dev/null 2>&1; then
+  echo; echo "PROVISIONNEMENT ECHOUE — la base ne repond pas au controle final."; exit 1
+fi
+echo
+echo "PROVISIONNE. Le rejeu complet n'est PAS lance par ce script."

--- a/scripts/tecdoc-replay/test-check-rebuild-capacity.sh
+++ b/scripts/tecdoc-replay/test-check-rebuild-capacity.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Banc de la porte de capacite.
+#
+# L'enjeu central de ce banc : prouver que l'ajout du mode `vagues` n'a PAS affaibli
+# le mode `materialise`. Une porte a deux modes est une porte qu'on peut desserrer par
+# inadvertance ; les assertions 3 a 6 existent pour que cela se voie.
+set -uo pipefail
+
+ICI="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORTE="$ICI/check-rebuild-capacity.sh"
+OK=0
+KO=0
+
+verifier() { # libelle, attendu, obtenu
+  if [ "$2" = "$3" ]; then
+    printf '  \033[32mOK\033[0m   %s\n' "$1"; OK=$((OK + 1))
+  else
+    printf '  \033[31mKO\033[0m   %s — attendu «%s», obtenu «%s»\n' "$1" "$2" "$3"; KO=$((KO + 1))
+  fi
+}
+
+verdict() { # sortie complete -> dernier verdict rendu (un refus porte son motif :
+            # « NO_GO — volume non dedie »), donc on ancre le debut de ligne seulement
+  echo "$1" | grep -oE '^(GO|NO_GO)' | tail -1
+}
+
+INEXISTANT="/tmp/volume-qui-nexiste-pas-$$"
+
+# --- mode vagues ---------------------------------------------------------
+echo "=== 1. mode vagues — la racine suffit quand la matiere est purgee ==="
+S="$(TECDOC_REBUILD_MODE=vagues bash "$PORTE" / 2>&1)"; C=$?
+verifier "verdict GO" "GO" "$(verdict "$S")"
+verifier "code de sortie 0" 0 "$C"
+verifier "le seuil affiche est celui des vagues" 1 "$(echo "$S" | grep -c 'seuil minimal ....... 20 Go')"
+verifier "aucune exigence de volume dedie" 0 "$(echo "$S" | grep -c 'volume non dedie')"
+verifier "la cible de provisionnement n'est pas mentionnee" 0 \
+  "$(echo "$S" | grep -c 'cible provisionnement')"
+
+echo
+echo "=== 2. mode vagues — reste une VRAIE porte ==="
+S="$(TECDOC_REBUILD_MODE=vagues TECDOC_REBUILD_VAGUE_MIN_GO=999999 bash "$PORTE" / 2>&1)"; C=$?
+verifier "verdict NO_GO sous le seuil" "NO_GO" "$(verdict "$S")"
+verifier "code de sortie 1" 1 "$C"
+verifier "le manque est chiffre" 1 "$(echo "$S" | grep -c 'il manque')"
+
+S="$(TECDOC_REBUILD_MODE=vagues bash "$PORTE" "$INEXISTANT" 2>&1)"; C=$?
+verifier "chemin inexistant -> NO_GO" "NO_GO" "$(verdict "$S")"
+verifier "chemin inexistant -> sortie 1" 1 "$C"
+
+# --- anti-regression du mode materialise ---------------------------------
+echo
+echo "=== 3. mode materialise — refus INCHANGE sur volume non dedie ==="
+S="$(bash "$PORTE" / 2>&1)"; C=$?
+verifier "verdict NO_GO (defaut = materialise)" "NO_GO" "$(verdict "$S")"
+verifier "motif : volume non dedie" 1 "$(echo "$S" | grep -c 'NO_GO — volume non dedie')"
+verifier "code de sortie 1" 1 "$C"
+
+echo
+echo "=== 4. mode materialise — refus INCHANGE sur point de montage absent ==="
+S="$(bash "$PORTE" "$INEXISTANT" 2>&1)"; C=$?
+verifier "verdict NO_GO" "NO_GO" "$(verdict "$S")"
+verifier "motif : aucun volume dedie" 1 "$(echo "$S" | grep -c 'NO_GO — aucun volume dedie')"
+verifier "renvoie vers la section Provisionnement" 1 "$(echo "$S" | grep -c 'Provisionnement')"
+
+echo
+echo "=== 5. mode materialise — seuils NON desserres ==="
+verifier "seuil minimal reste 210 Go" 1 "$(grep -c 'TECDOC_REBUILD_MIN_GO:-210' "$PORTE")"
+verifier "cible reste 250 Go" 1 "$(grep -c 'TECDOC_REBUILD_CIBLE_GO:-250' "$PORTE")"
+# Meme cible, deux modes, deux verdicts : c'est la preuve que l'exigence de volume
+# dedie appartient au mode materialise et n'a pas ete supprimee globalement.
+M="$(bash "$PORTE" / 2>&1)"
+V="$(TECDOC_REBUILD_MODE=vagues bash "$PORTE" / 2>&1)"
+verifier "meme cible : materialise refuse" "NO_GO" "$(verdict "$M")"
+verifier "meme cible : vagues accepte"     "GO"    "$(verdict "$V")"
+verifier "le refus « volume non dedie » n'existe QUE en materialise" "1 0" \
+  "$(echo "$M" | grep -c 'volume non dedie') $(echo "$V" | grep -c 'volume non dedie')"
+verifier "materialise reste le mode par defaut" 1 \
+  "$(grep -c 'TECDOC_REBUILD_MODE:-materialise' "$PORTE")"
+
+# --- garde-fou de saisie -------------------------------------------------
+echo
+echo "=== 6. un mode inconnu est refuse, pas interprete ==="
+S="$(TECDOC_REBUILD_MODE=nimporte bash "$PORTE" / 2>&1)"; C=$?
+verifier "code de sortie 2" 2 "$C"
+verifier "aucun verdict rendu" "" "$(verdict "$S")"
+verifier "les modes valides sont nommes" 1 "$(echo "$S" | grep -c 'materialise | vagues')"
+
+echo
+printf '=== %s assertions · %s OK · %s KO ===\n' "$((OK + KO))" "$OK" "$KO"
+[ "$KO" -eq 0 ] || exit 1

--- a/scripts/tecdoc_replay.py
+++ b/scripts/tecdoc_replay.py
@@ -421,8 +421,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.json:
         import json
+        # `crc32` et `version_perimetre` ne sont pas decoratifs : ce sont les deux
+        # entrees, avec la table et le DLNR, du `batch_id`. Sans eux dans la preuve,
+        # le registre affirme une identite de lot que personne ne peut recalculer —
+        # or une preuve qu'on ne peut pas refaire n'en est pas une.
         print(json.dumps({"dlnr": lot.dlnr, "table": lot.table,
                           "batch_id": lot.batch_id, "fichier": lot.fichier,
+                          "crc32": shard["crc32"],
+                          "version_perimetre": perimetre.version,
                           "emis": lot.emis, "charges": lot.charges,
                           "dedoublonnes": lot.dedoublonnes, "rejets": lot.rejets},
                          ensure_ascii=False, sort_keys=True))

--- a/scripts/tecdoc_replay_wave.py
+++ b/scripts/tecdoc_replay_wave.py
@@ -195,6 +195,11 @@ def main(argv: list[str] | None = None) -> int:
                 "dlnr": dlnr,
                 "fichier": resultat["fichier"],
                 "batch_id": resultat["batch_id"],
+                # Les deux entrees qui, avec la table et le DLNR, PRODUISENT le
+                # batch_id. Les consigner rend l'identite du lot recalculable par un
+                # tiers ; sans elles le registre demande qu'on le croie sur parole.
+                "source": {"crc32": resultat["crc32"],
+                           "version_perimetre": resultat["version_perimetre"]},
                 "comptabilite": {"rows_emitted": resultat["emis"],
                                  "rows_loaded": resultat["charges"],
                                  "rows_deduplicated": resultat["dedoublonnes"],

--- a/scripts/tecdoc_replay_wave.py
+++ b/scripts/tecdoc_replay_wave.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Rejeu TecDoc par vagues — empreinte disque bornee, preuve conservee.
+
+POURQUOI DES VAGUES
+-------------------
+Materialiser les 110 DLNR simultanement demanderait ~250 Go. Or l'invariant a
+demontrer — `PROD actuelle ⊆ REBUILD source-truth`, sans perte de ligne ni derive
+d'identite — se verifie DLNR par DLNR. On rejoue donc un fournisseur, on le
+reconcilie, on scelle la preuve, **puis on jette la matiere**. Le pic disque devient
+celui du plus gros DLNR seul, pas leur somme.
+
+Ce qui est conserve n'est pas la donnee : c'est le REGISTRE DE PREUVE. Il porte, par
+DLNR, la comptabilite complete, l'empreinte du contenu charge et le verdict de
+reconciliation. Il est scelle : une preuve qu'on peut reecrire n'en est pas une.
+
+CE QUE CE SCRIPT DEMONTRE, ET RIEN DE PLUS
+------------------------------------------
+Au niveau RAW (`tecdoc_raw.t400`) : aucune ligne source n'est perdue, la PROD est
+incluse dans le rejeu, les registres d'identite ne bougent pas, les 9 ensembles figes
+sont intacts. C'est exactement la ou la perte de mars 2026 s'est produite.
+
+Il ne demontre RIEN sur la projection `source_linkages` : aucun projecteur verifie
+n'existe a ce jour (les projecteurs historiques sont en quarantaine, dont celui qui a
+pollue `pieces_relation_type` de ~219 M lignes fantomes). Ce sera un chantier separe.
+Annoncer ici une preuve de projection serait le vert-mais-faux que ce pipeline combat.
+
+FAIL-CLOSED
+-----------
+Toute anomalie arrete la vague, **sans purger le DLNR fautif** : sa matiere reste en
+base pour le diagnostic. Un DLNR n'est purge que lorsque sa preuve est ecrite.
+
+Codes de sortie
+  0 vague conforme · 3 illisible · 5 comptabilite · 6 identite
+  7 conservation · 8 inclusion rompue · 9 purge non confirmee
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tecdoc_identity_guard import IdentiteViolee
+from tecdoc_preservation import ConservationRompue
+from tecdoc_replay_controls import (controle_conservation, controle_identite,
+                                    controle_reconciliation)
+from tecdoc_seal import calculer as sceller
+
+ICI = Path(__file__).resolve().parent
+
+#: Empreinte du contenu charge pour un lot. Survit a la purge : c'est elle qui rend
+#: la preuve verifiable une fois la matiere jetee, et qui permet de constater qu'un
+#: second rejeu produit exactement le meme contenu.
+REQUETE_EMPREINTE = """
+    SELECT count(*), min(_source_row_no), max(_source_row_no),
+           md5(string_agg(_source_row_no || ':' || _raw_hash, ',' ORDER BY _source_row_no))
+    FROM tecdoc_raw.t400 WHERE _batch_id = %s"""
+
+
+class VagueInterrompue(RuntimeError):
+    """Anomalie fatale. La matiere du DLNR en cause est CONSERVEE pour diagnostic."""
+
+
+def _psy():
+    import psycopg2
+    return psycopg2
+
+
+def rejouer_dlnr(*, dlnr: int, scope_file: str, cible_dsn: str, workdir: Path,
+                 archive: str | None) -> dict:
+    """Appelle le chemin canonique. Son code de sortie fait foi, jamais sa sortie texte."""
+    cmd = [sys.executable, str(ICI / "tecdoc_replay.py"),
+           "--scope-mode", "historical", "--scope-file", scope_file,
+           "--dlnr", str(dlnr), "--table", "400",
+           "--cible-dsn", cible_dsn, "--workdir", str(workdir), "--json"]
+    if archive:
+        cmd += ["--archive", archive]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise VagueInterrompue(
+            f"DLNR {dlnr} : chargement refuse (code {r.returncode}).\n"
+            f"{(r.stderr or '').strip()[-800:]}")
+    return json.loads(r.stdout)
+
+
+def empreinte_lot(cible_dsn: str, batch_id: str) -> dict:
+    with _psy().connect(cible_dsn) as conn, conn.cursor() as cur:
+        cur.execute(REQUETE_EMPREINTE, (batch_id,))
+        n, bmin, bmax, md5 = cur.fetchone()
+    return {"lignes": n, "borne_min": bmin, "borne_max": bmax, "empreinte_md5": md5}
+
+
+def purger_lot(cible_dsn: str, batch_id: str) -> None:
+    """Retire la matiere du lot de la base JETABLE, puis VERIFIE qu'elle est partie.
+
+    `VACUUM` simple (jamais FULL) rend l'espace reutilisable par le DLNR suivant : la
+    table se stabilise au niveau du plus gros fournisseur, pas de leur somme.
+    """
+    conn = _psy().connect(cible_dsn)
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM tecdoc_raw.t400 WHERE _batch_id = %s", (batch_id,))
+            cur.execute("SELECT count(*) FROM tecdoc_raw.t400 WHERE _batch_id = %s",
+                        (batch_id,))
+            reste = cur.fetchone()[0]
+            if reste:
+                raise VagueInterrompue(
+                    f"purge non confirmee : {reste} ligne(s) subsistent pour {batch_id}.")
+            cur.execute("VACUUM (ANALYZE) tecdoc_raw.t400")
+    finally:
+        conn.close()
+
+
+def charger_registre(chemin: Path) -> dict:
+    if chemin.exists():
+        return json.loads(chemin.read_text(encoding="utf-8"))
+    return {"objet": "Registre de preuve du rejeu TecDoc par vagues.",
+            "invariant": "PROD actuelle ⊆ REBUILD source-truth, sans perte de ligne "
+                         "ni derive d'identite.",
+            "portee": "RAW (tecdoc_raw.t400) uniquement. Aucune preuve de projection.",
+            "entrees": []}
+
+
+def ecrire_registre(chemin: Path, registre: dict) -> None:
+    registre.pop("seal", None)
+    registre["seal"] = {"algorithm": "sha256",
+                        "canonicalization": "sort_keys, UTF-8, separateurs (',',':'), "
+                                            "bloc seal exclu.",
+                        "sha256": sceller(registre)}
+    chemin.parent.mkdir(parents=True, exist_ok=True)
+    chemin.write_text(json.dumps(registre, ensure_ascii=False, indent=2, sort_keys=True)
+                      + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--lot", type=int, required=True, help="index du lot dans le plan")
+    ap.add_argument("--plan", default=str(ICI / "tecdoc-replay" / "plan-lots.json"))
+    ap.add_argument("--scope-file", required=True)
+    ap.add_argument("--cible-dsn", required=True, help="base JETABLE du rebuild")
+    ap.add_argument("--reference-dsn", required=True, help="base de reference, LUE seule")
+    ap.add_argument("--manifeste", required=True, help="manifeste de conservation scelle")
+    ap.add_argument("--workdir", required=True)
+    ap.add_argument("--registre", required=True, help="registre de preuve (JSON scelle)")
+    ap.add_argument("--archive", default=None)
+    ap.add_argument("--conserver", action="store_true",
+                    help="ne pas purger apres preuve — reserve au diagnostic, "
+                         "fait exploser l'empreinte disque.")
+    args = ap.parse_args(argv)
+
+    try:
+        plan = json.loads(Path(args.plan).read_text(encoding="utf-8"))
+        lot = plan["lots"][args.lot]
+    except (OSError, json.JSONDecodeError, IndexError, KeyError) as e:
+        print(f"PLAN ILLISIBLE : {e}", file=sys.stderr)
+        return 3
+
+    registre_path = Path(args.registre)
+    registre = charger_registre(registre_path)
+    deja = {e["dlnr"]: e for e in registre["entrees"]}
+    workdir = Path(args.workdir)
+
+    print(f"=== {lot['nom']} — {lot['nombre']} DLNR, "
+          f"{lot['lignes_source_attendues']:,} lignes source attendues ===")
+    if lot.get("divergents_inclus"):
+        print(f"    divergents : {', '.join(lot['divergents_inclus'])}")
+
+    traites = 0
+    try:
+        for dlnr in lot["dlnr"]:
+            if dlnr in deja:
+                print(f"  · DLNR {dlnr} : deja prouve, ignore (registre)")
+                continue
+
+            resultat = rejouer_dlnr(dlnr=dlnr, scope_file=args.scope_file,
+                                    cible_dsn=args.cible_dsn, workdir=workdir,
+                                    archive=args.archive)
+            emp = empreinte_lot(args.cible_dsn, resultat["batch_id"])
+
+            rec = controle_reconciliation(reference_dsn=args.reference_dsn,
+                                          rejeu_dsn=args.cible_dsn, dlnr=dlnr)
+            if not rec["inclusion_respectee"]:
+                raise VagueInterrompue(
+                    f"DLNR {dlnr} : INCLUSION ROMPUE — la reference sert des lignes que "
+                    f"le rejeu ne reproduit pas, ou en contredit le contenu.\n"
+                    f"{json.dumps(rec, ensure_ascii=False, indent=2)}")
+
+            identite = controle_identite(reference_dsn=args.reference_dsn,
+                                         rejeu_dsn=args.cible_dsn, dlnr=dlnr)
+
+            registre["entrees"].append({
+                "dlnr": dlnr,
+                "fichier": resultat["fichier"],
+                "batch_id": resultat["batch_id"],
+                "comptabilite": {"rows_emitted": resultat["emis"],
+                                 "rows_loaded": resultat["charges"],
+                                 "rows_deduplicated": resultat["dedoublonnes"],
+                                 "rows_rejected": resultat["rejets"]},
+                "empreinte_du_charge": emp,
+                "reconciliation": rec,
+                "identite": [str(r) for r in identite],
+            })
+            ecrire_registre(registre_path, registre)   # preuve ecrite AVANT la purge
+
+            if args.conserver:
+                print(f"  ✓ DLNR {dlnr} : {resultat['charges']:,} lignes — matiere conservee")
+            else:
+                purger_lot(args.cible_dsn, resultat["batch_id"])
+                print(f"  ✓ DLNR {dlnr} : {resultat['charges']:,} lignes prouvees "
+                      f"(md5 {emp['empreinte_md5'][:12]}…) puis purgees")
+            traites += 1
+
+        print()
+        print("=== controle de conservation (9 ensembles figes) ===")
+        n = controle_conservation(manifeste_path=args.manifeste,
+                                  reference_dsn=args.reference_dsn)
+        print(f"  ✓ {n} ensembles intacts")
+        registre["conservation"] = {"ensembles_verifies": n, "lot": lot["nom"]}
+        ecrire_registre(registre_path, registre)
+
+    except VagueInterrompue as e:
+        print(f"\nVAGUE INTERROMPUE\n{e}", file=sys.stderr)
+        print("La matiere du DLNR en cause est CONSERVEE pour diagnostic.", file=sys.stderr)
+        return 8
+    except IdentiteViolee as e:
+        print(f"\nIDENTITE VIOLEE\n{e}", file=sys.stderr)
+        return 6
+    except ConservationRompue as e:
+        print(f"\nCONSERVATION ROMPUE\n{e}", file=sys.stderr)
+        return 7
+    except Exception as e:  # noqa: BLE001 — on nomme la cause, on ne la ravale pas
+        print(f"\nECHEC : {type(e).__name__}: {e}", file=sys.stderr)
+        return 3
+
+    print()
+    print(f"LOT CONFORME — {traites} DLNR prouves, registre scelle "
+          f"{registre['seal']['sha256'][:16]}…")
+    print(f"  {registre_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-tecdoc-replay.sh
+++ b/scripts/test-tecdoc-replay.sh
@@ -155,6 +155,13 @@ docker exec "$CONTENEUR" psql -U postgres -d reference -q \
 cas "ensemble applicatif modifie refuse" 7 \
   python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
     --manifeste tecdoc-replay/manifeste-synthetique.json --controles conservation
+# Restaurer la reference : une injection destructive qui ne se defait pas contamine
+# tous les cas suivants, et son echec serait mis au compte du mauvais composant.
+docker exec "$CONTENEUR" psql -U postgres -d reference -q \
+  -c "INSERT INTO public.auto_type(type_id_i) VALUES (60000) ON CONFLICT DO NOTHING" >/dev/null
+cas "reference restauree : conservation a nouveau intacte" 0 \
+  python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
+    --manifeste tecdoc-replay/manifeste-synthetique.json --controles conservation
 
 echo
 echo "-- Injection 6 : inclusion PROD ⊆ REBUILD rompue --"
@@ -173,6 +180,40 @@ cas "contenu servi contredisant le rejeu refuse (CONFLICT)" 8 \
   python3 tecdoc_replay_controls.py --reference-dsn "$REF" --rejeu-dsn "$BANC" \
     --dlnr "$DLNR_TEST" --controles reconciliation
 
+echo
+echo "-- Vagues : la preuve survit a la purge, l'echec conserve la matiere --"
+docker exec "$CONTENEUR" psql -U postgres -d banc -q -c 'DELETE FROM tecdoc_raw.t400' >/dev/null
+docker exec "$CONTENEUR" psql -U postgres -d reference -q -c 'DELETE FROM tecdoc_raw.t400' >/dev/null
+rm -f "$TMP"/400.*.csv "$TMP"/400.*.meta "$TMP/registre.json"
+cas "vague nominale (LOT 0) puis purge" 0 \
+  python3 tecdoc_replay_wave.py --lot 0 --plan tecdoc-replay/plan-lots.json \
+    --scope-file "$SCOPE" --cible-dsn "$BANC" --reference-dsn "$REF" \
+    --manifeste tecdoc-replay/manifeste-synthetique.json \
+    --workdir "$TMP" --registre "$TMP/registre.json" --archive "$ARCHIVE"
+egal "matiere purgee apres preuve" "0" "$(sql banc 'select count(*) from tecdoc_raw.t400')"
+egal "preuve conservee dans le registre" "13057" \
+  "$(python3 -c "import json;print(json.load(open('$TMP/registre.json'))['entrees'][0]['comptabilite']['rows_loaded'])" 2>/dev/null)"
+egal "registre scelle" "64" \
+  "$(python3 -c "import json;print(len(json.load(open('$TMP/registre.json'))['seal']['sha256']))" 2>/dev/null)"
+cas "relance du meme lot : idempotente" 0 \
+  python3 tecdoc_replay_wave.py --lot 0 --plan tecdoc-replay/plan-lots.json \
+    --scope-file "$SCOPE" --cible-dsn "$BANC" --reference-dsn "$REF" \
+    --manifeste tecdoc-replay/manifeste-synthetique.json \
+    --workdir "$TMP" --registre "$TMP/registre.json" --archive "$ARCHIVE"
+
+# La reference sert une ligne que le rejeu ne reproduit pas : inclusion rompue.
+rm -f "$TMP/registre2.json" "$TMP"/400.*.csv "$TMP"/400.*.meta
+docker exec "$CONTENEUR" psql -U postgres -d reference -q \
+  -c "INSERT INTO tecdoc_raw.t400(col_2,_source_row_no,_raw_hash) VALUES ('$DLNR_TEST',999999,'servie_mais_absente_du_rejeu')" >/dev/null
+cas "inclusion rompue : vague arretee" 8 \
+  python3 tecdoc_replay_wave.py --lot 0 --plan tecdoc-replay/plan-lots.json \
+    --scope-file "$SCOPE" --cible-dsn "$BANC" --reference-dsn "$REF" \
+    --manifeste tecdoc-replay/manifeste-synthetique.json \
+    --workdir "$TMP" --registre "$TMP/registre2.json" --archive "$ARCHIVE"
+egal "matiere CONSERVEE pour diagnostic sur echec" "13057" \
+  "$(sql banc 'select count(*) from tecdoc_raw.t400')"
+
+echo
 echo
 echo "=== $ok assertions vertes, $ko rouges ==="
 [ "$ko" -eq 0 ] || exit 1

--- a/scripts/test-tecdoc-replay.sh
+++ b/scripts/test-tecdoc-replay.sh
@@ -195,6 +195,73 @@ egal "preuve conservee dans le registre" "13057" \
   "$(python3 -c "import json;print(json.load(open('$TMP/registre.json'))['entrees'][0]['comptabilite']['rows_loaded'])" 2>/dev/null)"
 egal "registre scelle" "64" \
   "$(python3 -c "import json;print(len(json.load(open('$TMP/registre.json'))['seal']['sha256']))" 2>/dev/null)"
+
+# Une preuve incomplete est une preuve qu'on ne peut pas refaire. Les 13 champs
+# ci-dessous sont le contrat du registre : chacun doit etre present ET non nul.
+egal "les 13 champs du contrat de preuve sont presents" "13/13" \
+  "$(python3 - "$TMP/registre.json" <<'PYCHK'
+import json, sys
+e = json.load(open(sys.argv[1]))["entrees"][0]
+r = e.get("reconciliation", {})
+champs = {
+    "dlnr":               e.get("dlnr"),
+    "batch_id":           e.get("batch_id"),
+    "source shard":       e.get("fichier"),
+    "scope hash":         e.get("source", {}).get("version_perimetre"),
+    "CRC32 source":       e.get("source", {}).get("crc32"),
+    "rows_emitted":       e.get("comptabilite", {}).get("rows_emitted"),
+    "rows_loaded":        e.get("comptabilite", {}).get("rows_loaded"),
+    "rows_deduplicated":  e.get("comptabilite", {}).get("rows_deduplicated"),
+    "rows_rejected":      e.get("comptabilite", {}).get("rows_rejected"),
+    "empreinte charge":   (e.get("empreinte_du_charge") or {}).get("empreinte_md5"),
+    "reconciliation":     r or None,
+    "inclusion":          r.get("inclusion_respectee"),
+    "conflits":           r.get("conflits"),
+}
+presents = sum(1 for v in champs.values() if v is not None)
+manquants = [k for k, v in champs.items() if v is None]
+print(f"{presents}/{len(champs)}" + (" manquants: " + ",".join(manquants) if manquants else ""))
+PYCHK
+)"
+# La reference est VIDEE par la fixture juste avant ce cas : les 13 057 lignes du
+# rejeu n'ont donc aucun equivalent en PROD et sont toutes NEW_FROM_SOURCE. Les voir
+# TOUTES en quarantaine est le comportement correct, pas un defaut — attendre 0 ici
+# reviendrait a exiger que le delta source soit active d'office.
+#
+# On n'assert donc pas un nombre mais la PARTITION : tout ce que le rejeu produit est
+# soit deja identique en PROD (`identites_conservees`), soit en quarantaine. Aucune
+# troisieme categorie, silencieusement activable, ne doit exister.
+egal "quarantaine : partition exacte, rien d'activable en silence" "13057 partition couverture" \
+  "$(python3 - "$TMP/registre.json" <<'PYCHK'
+import json, sys
+r = json.load(open(sys.argv[1]))["entrees"][0]["reconciliation"]
+q = r["candidats_en_quarantaine"]
+somme = r["absentes_de_prod"] + r["conflits"] + r["indecidables"]
+couvert = r["identites_conservees"] + q
+print(q,
+      "partition" if q == somme else f"FUITE({q}!={somme})",
+      "couverture" if couvert == r["lignes_source_attendues"] else
+      f"TROU({couvert}!={r['lignes_source_attendues']})")
+PYCHK
+)"
+
+# Le sceau doit etre un vrai sceau : recalcule sur le contenu il concorde, recalcule
+# apres avoir change UNE valeur il diverge. Sans cette seconde moitie, le sceau
+# n'atteste que de lui-meme.
+egal "sceau : concorde sur le contenu, diverge sur une valeur alteree" "concorde diverge" \
+  "$(python3 - "$TMP/registre.json" <<'PYCHK'
+import importlib.util as u, json, sys
+spec = u.spec_from_file_location("w", "tecdoc_replay_wave.py")
+m = u.module_from_spec(spec); spec.loader.exec_module(m)
+d = json.load(open(sys.argv[1]))
+scelle = d["seal"]["sha256"]
+sans = {k: v for k, v in d.items() if k != "seal"}
+a = "concorde" if m.sceller(sans) == scelle else "DIVERGE"
+sans["entrees"][0]["comptabilite"]["rows_loaded"] += 1      # une seule valeur
+b = "diverge" if m.sceller(sans) != scelle else "CONCORDE"
+print(a, b)
+PYCHK
+)"
 cas "relance du meme lot : idempotente" 0 \
   python3 tecdoc_replay_wave.py --lot 0 --plan tecdoc-replay/plan-lots.json \
     --scope-file "$SCOPE" --cible-dsn "$BANC" --reference-dsn "$REF" \

--- a/scripts/test-tourner-secret-db.sh
+++ b/scripts/test-tourner-secret-db.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Banc hermetique pour tourner-secret-db.py.
+#
+# L'API Supabase est remplacee par un double qui applique VRAIMENT le changement
+# sur un PostgreSQL jetable. On verifie donc la mecanique complete — ordre des
+# etapes, codes de sortie, ecriture du .env, non-divulgation du secret — sans
+# jamais toucher a une base reelle.
+set -uo pipefail
+
+ICI="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTENEUR="banc-rotation-secret"
+PORT=55451
+TRAVAIL="$(mktemp -d)"
+OK=0
+KO=0
+
+verifier() { # libelle, attendu, obtenu
+  if [ "$2" = "$3" ]; then
+    printf '  \033[32mOK\033[0m   %s\n' "$1"; OK=$((OK + 1))
+  else
+    printf '  \033[31mKO\033[0m   %s — attendu «%s», obtenu «%s»\n' "$1" "$2" "$3"; KO=$((KO + 1))
+  fi
+}
+
+nettoyer() { docker rm -f "$CONTENEUR" >/dev/null 2>&1; rm -rf "$TRAVAIL"; }
+trap nettoyer EXIT
+
+echo "=== PostgreSQL jetable ==="
+docker rm -f "$CONTENEUR" >/dev/null 2>&1
+docker run -d --name "$CONTENEUR" -e POSTGRES_PASSWORD=depart \
+  -p "127.0.0.1:$PORT:5432" --tmpfs /var/lib/postgresql/data:rw,size=256m \
+  postgres:17-alpine >/dev/null
+for _ in $(seq 1 40); do
+  docker exec "$CONTENEUR" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1
+done
+docker exec "$CONTENEUR" pg_isready -U postgres >/dev/null 2>&1 \
+  || { echo "  le conteneur n'a pas demarre"; exit 1; }
+echo "  pret sur 127.0.0.1:$PORT"
+echo
+
+# Double de l'API : applique le changement comme le ferait Supabase.
+cat > "$TRAVAIL/faux_api.py" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("outil", sys.argv[1])
+outil = importlib.util.module_from_spec(spec); spec.loader.exec_module(outil)
+
+CODE = int(sys.argv[2])          # code HTTP a simuler
+PORT = int(sys.argv[3])
+
+def faux(projet, secret, jeton):
+    if CODE != 200:
+        return CODE, '{"message":"simule"}'
+    import psycopg2
+    from psycopg2 import sql
+    c = psycopg2.connect(host="127.0.0.1", port=PORT, user="postgres",
+                         password="depart", dbname="postgres")
+    c.autocommit = True
+    with c.cursor() as cur:
+        cur.execute(sql.SQL("ALTER USER postgres WITH PASSWORD {}").format(sql.Literal(secret)))
+    c.close()
+    return 200, "{}"
+
+outil.appeler_api = faux
+sys.exit(outil.main(sys.argv[4:]))
+PY
+
+lancer() { # code-http, arguments...
+  local code="$1"; shift
+  python3 "$TRAVAIL/faux_api.py" "$ICI/tourner-secret-db.py" "$code" "$PORT" \
+    --projet banc --hote 127.0.0.1 --port "$PORT" --utilisateur postgres "$@"
+}
+
+# --- 1. cas nominal ------------------------------------------------------
+echo "=== 1. rotation complete ==="
+printf 'AUTRE=garde\nSUPABASE_DB_PASSWORD=depart\nENCORE=garde\n' > "$TRAVAIL/reference.env"
+cp "$TRAVAIL/reference.env" "$TRAVAIL/cible.env"
+SORTIE="$(SUPABASE_ACCESS_TOKEN=factice lancer 200 \
+  --reference "$TRAVAIL/reference.env" --env "$TRAVAIL/cible.env" \
+  --coffre "$TRAVAIL/coffre.txt" 2>&1)"; CODE=$?
+echo "$SORTIE" | sed 's/^/    /'
+verifier "code de sortie 0" 0 "$CODE"
+verifier "verdict ROTATED" 1 "$(echo "$SORTIE" | grep -c '^ROTATED$')"
+verifier "nouveau secret accepte" 1 "$(echo "$SORTIE" | grep -c 'nouveau secret  : ACCEPTE')"
+verifier "ancien secret refuse en 28P01" 1 "$(echo "$SORTIE" | grep -c 'ancien secret   : REFUSE (28P01)')"
+
+NEUF="$(cat "$TRAVAIL/coffre.txt")"
+verifier "le coffre est en 0600" 600 "$(stat -c '%a' "$TRAVAIL/coffre.txt")"
+verifier "le .env porte la valeur du coffre" "SUPABASE_DB_PASSWORD=$NEUF" \
+  "$(grep '^SUPABASE_DB_PASSWORD=' "$TRAVAIL/cible.env")"
+verifier "les autres lignes sont intactes" 2 "$(grep -c '=garde$' "$TRAVAIL/cible.env")"
+verifier "une sauvegarde a ete deposee" 1 \
+  "$(find "$TRAVAIL" -name 'cible.env.avant-rotation-*' | wc -l)"
+verifier "la sauvegarde porte l'ancienne valeur" 1 \
+  "$(grep -hc '^SUPABASE_DB_PASSWORD=depart$' "$TRAVAIL"/cible.env.avant-rotation-* )"
+# Le point central : le secret ne doit apparaitre nulle part dans la sortie.
+verifier "le secret n'est jamais affiche" 0 "$(echo "$SORTIE" | grep -cF "$NEUF")"
+# Trois empreintes doivent sortir : celle de l'ancien, celle du neuf au moment de
+# la mise a l'abri, celle relue dans le .env. Elles sont la seule forme sous laquelle
+# une valeur de secret a le droit d'apparaitre.
+verifier "trois empreintes de 12 signes hexadecimaux" 3 \
+  "$(echo "$SORTIE" | grep -oE '\b[0-9a-f]{12}\b' | wc -l)"
+verifier "l'empreinte relue est celle du secret engendre" 2 \
+  "$(echo "$SORTIE" | grep -oE '\b[0-9a-f]{12}\b' | sort | uniq -c | awk '$1==2{print $1}')"
+
+# --- 2. l'identifiant de reference n'ouvre pas la base --------------------
+echo
+echo "=== 2. etat de depart inexploitable (attendu : 2, aucun changement) ==="
+printf 'SUPABASE_DB_PASSWORD=faux\n' > "$TRAVAIL/mauvais.env"
+cp "$TRAVAIL/cible.env" "$TRAVAIL/cible2.env"
+SORTIE="$(SUPABASE_ACCESS_TOKEN=factice lancer 200 \
+  --reference "$TRAVAIL/mauvais.env" --env "$TRAVAIL/cible2.env" \
+  --coffre "$TRAVAIL/coffre2.txt" 2>&1)"; CODE=$?
+verifier "code de sortie 2" 2 "$CODE"
+verifier "aucun coffre ecrit" 0 "$([ -f "$TRAVAIL/coffre2.txt" ] && echo 1 || echo 0)"
+verifier "le .env n'a pas bouge" 0 "$(diff -q "$TRAVAIL/cible.env" "$TRAVAIL/cible2.env" >/dev/null && echo 0 || echo 1)"
+verifier "un refus d'auth n'est pas confondu avec une panne" 1 \
+  "$(echo "$SORTIE" | grep -c '28P01')"
+
+# --- 3. l'API refuse -----------------------------------------------------
+echo
+echo "=== 3. l'API refuse l'appel (attendu : 6, .env intact) ==="
+printf 'SUPABASE_DB_PASSWORD=%s\n' "$NEUF" > "$TRAVAIL/reference3.env"
+cp "$TRAVAIL/cible.env" "$TRAVAIL/cible3.env"
+SORTIE="$(SUPABASE_ACCESS_TOKEN=factice lancer 403 \
+  --reference "$TRAVAIL/reference3.env" --env "$TRAVAIL/cible3.env" \
+  --coffre "$TRAVAIL/coffre3.txt" 2>&1)"; CODE=$?
+verifier "code de sortie 6" 6 "$CODE"
+verifier "le .env n'a pas bouge" 0 "$(diff -q "$TRAVAIL/cible.env" "$TRAVAIL/cible3.env" >/dev/null && echo 0 || echo 1)"
+verifier "le secret engendre est conserve, pas perdu" 1 \
+  "$([ -s "$TRAVAIL/coffre3.txt" ] && echo 1 || echo 0)"
+verifier "l'appel a bien ete tente avant d'abandonner" 1 \
+  "$(echo "$SORTIE" | grep -c 'HTTP 403')"
+
+# --- 4. le .env cible n'a pas la cle -------------------------------------
+echo
+echo "=== 4. cle absente du .env cible (refus d'ecrire a l'aveugle) ==="
+printf 'RIEN=ici\n' > "$TRAVAIL/vide.env"
+SORTIE="$(SUPABASE_ACCESS_TOKEN=factice lancer 200 \
+  --reference "$TRAVAIL/reference3.env" --env "$TRAVAIL/vide.env" \
+  --coffre "$TRAVAIL/coffre4.txt" 2>&1)"; CODE=$?
+verifier "sortie non nulle" 1 "$([ "$CODE" -ne 0 ] && echo 1 || echo 0)"
+verifier "aucune ligne ajoutee a l'aveugle" 0 \
+  "$(grep -c '^SUPABASE_DB_PASSWORD=' "$TRAVAIL/vide.env")"
+
+# --- 5. non-regression : aucun pointeur en dur ---------------------------
+echo
+echo "=== 5. le script ne contient aucun pointeur ==="
+verifier "aucune reference de projet, de depot ni de secret" 0 \
+  "$(grep -cE 'cxpojprg|sbp_|automecanik|\.env\.bak' "$ICI/tourner-secret-db.py")"
+
+echo
+printf '=== %s assertions · %s OK · %s KO ===\n' "$((OK + KO))" "$OK" "$KO"
+[ "$KO" -eq 0 ] || exit 1

--- a/scripts/test-tourner-secret-db.sh
+++ b/scripts/test-tourner-secret-db.sh
@@ -170,20 +170,23 @@ done
 verifier "le .env n'a pas bouge" 0 \
   "$(diff -q "$TRAVAIL/cible.env" "$TRAVAIL/cible4b.env" >/dev/null && echo 0 || echo 1)"
 
-# --- 4c. jeton vide : diagnostic explicite du piege du collage -----------
+# --- 4c. aucun jeton, aucun terminal pour le saisir ----------------------
 echo
-echo "=== 4c. jeton vide (le piege de read sans /dev/tty) ==="
+echo "=== 4c. pas de jeton et pas de terminal (usage non interactif) ==="
+# `< /dev/null` est indispensable : sans lui, le script ouvrirait une saisie
+# masquee et le banc resterait suspendu a attendre une frappe.
 SORTIE="$(SUPABASE_ACCESS_TOKEN="" lancer 200 \
   --reference "$TRAVAIL/reference3.env" --env "$TRAVAIL/cible4b.env" \
-  --coffre "$TRAVAIL/coffre4c.txt" 2>&1)"; CODE=$?
+  --coffre "$TRAVAIL/coffre4c.txt" < /dev/null 2>&1)"; CODE=$?
 verifier "code de sortie 3" 3 "$CODE"
-# Deux choses distinctes doivent sortir : la commande corrigee, et la RAISON.
-# Donner la commande sans la raison ferait recopier un incantatoire.
-verifier "la commande corrigee est donnee" 1 \
-  "$(echo "$SORTIE" | grep -c 'read -rsp .* < /dev/tty')"
-verifier "la raison du /dev/tty est expliquee" 1 \
-  "$(echo "$SORTIE" | grep -c "n'est pas decoratif")"
+verifier "la voie non interactive est nommee" 1 \
+  "$(echo "$SORTIE" | grep -c 'SUPABASE_ACCESS_TOKEN')"
 verifier "aucun secret engendre" 0 "$([ -f "$TRAVAIL/coffre4c.txt" ] && echo 1 || echo 0)"
+verifier "le .env n'a pas bouge" 0 \
+  "$(diff -q "$TRAVAIL/cible.env" "$TRAVAIL/cible4b.env" >/dev/null && echo 0 || echo 1)"
+# Le banc ne doit plus renvoyer vers la voie en deux temps : c'est elle qui echouait.
+verifier "plus aucun renvoi vers read/export" 0 \
+  "$(echo "$SORTIE" | grep -cE 'read -rsp|export ')"
 
 # --- 5. non-regression : aucun pointeur en dur ---------------------------
 echo

--- a/scripts/test-tourner-secret-db.sh
+++ b/scripts/test-tourner-secret-db.sh
@@ -44,8 +44,12 @@ import importlib.util, sys
 spec = importlib.util.spec_from_file_location("outil", sys.argv[1])
 outil = importlib.util.module_from_spec(spec); spec.loader.exec_module(outil)
 
-CODE = int(sys.argv[2])          # code HTTP a simuler
+CODE = int(sys.argv[2])          # code HTTP simule pour le PATCH
 PORT = int(sys.argv[3])
+CODE_JETON = int(sys.argv[4])    # code HTTP simule pour le preflight GET
+
+def faux_jeton(projet, jeton):
+    return CODE_JETON, '{"id":"simule"}' if CODE_JETON == 200 else '{"message":"simule"}'
 
 def faux(projet, secret, jeton):
     if CODE != 200:
@@ -61,12 +65,19 @@ def faux(projet, secret, jeton):
     return 200, "{}"
 
 outil.appeler_api = faux
-sys.exit(outil.main(sys.argv[4:]))
+outil.verifier_jeton = faux_jeton
+sys.exit(outil.main(sys.argv[5:]))
 PY
 
-lancer() { # code-http, arguments...
+lancer() { # code-http-PATCH, arguments...
   local code="$1"; shift
-  python3 "$TRAVAIL/faux_api.py" "$ICI/tourner-secret-db.py" "$code" "$PORT" \
+  python3 "$TRAVAIL/faux_api.py" "$ICI/tourner-secret-db.py" "$code" "$PORT" 200 \
+    --projet banc --hote 127.0.0.1 --port "$PORT" --utilisateur postgres "$@"
+}
+
+lancer_jeton() { # code-http-preflight, arguments...
+  local code="$1"; shift
+  python3 "$TRAVAIL/faux_api.py" "$ICI/tourner-secret-db.py" 200 "$PORT" "$code" \
     --projet banc --hote 127.0.0.1 --port "$PORT" --utilisateur postgres "$@"
 }
 
@@ -141,6 +152,38 @@ SORTIE="$(SUPABASE_ACCESS_TOKEN=factice lancer 200 \
 verifier "sortie non nulle" 1 "$([ "$CODE" -ne 0 ] && echo 1 || echo 0)"
 verifier "aucune ligne ajoutee a l'aveugle" 0 \
   "$(grep -c '^SUPABASE_DB_PASSWORD=' "$TRAVAIL/vide.env")"
+
+# --- 4b. le jeton n'ouvre pas le projet ----------------------------------
+echo
+echo "=== 4b. preflight du jeton (attendu : 6, RIEN engendre) ==="
+cp "$TRAVAIL/cible.env" "$TRAVAIL/cible4b.env"
+for HTTP in 401 403 404; do
+  SORTIE="$(SUPABASE_ACCESS_TOKEN=factice lancer_jeton "$HTTP" \
+    --reference "$TRAVAIL/reference3.env" --env "$TRAVAIL/cible4b.env" \
+    --coffre "$TRAVAIL/coffre4b.txt" 2>&1)"; CODE=$?
+  verifier "HTTP $HTTP -> code de sortie 6" 6 "$CODE"
+  verifier "HTTP $HTTP -> aucun secret engendre" 0 \
+    "$([ -f "$TRAVAIL/coffre4b.txt" ] && echo 1 || echo 0)"
+  verifier "HTTP $HTTP -> arret avant l'etat de depart" 0 \
+    "$(echo "$SORTIE" | grep -c '1/5')"
+done
+verifier "le .env n'a pas bouge" 0 \
+  "$(diff -q "$TRAVAIL/cible.env" "$TRAVAIL/cible4b.env" >/dev/null && echo 0 || echo 1)"
+
+# --- 4c. jeton vide : diagnostic explicite du piege du collage -----------
+echo
+echo "=== 4c. jeton vide (le piege de read sans /dev/tty) ==="
+SORTIE="$(SUPABASE_ACCESS_TOKEN="" lancer 200 \
+  --reference "$TRAVAIL/reference3.env" --env "$TRAVAIL/cible4b.env" \
+  --coffre "$TRAVAIL/coffre4c.txt" 2>&1)"; CODE=$?
+verifier "code de sortie 3" 3 "$CODE"
+# Deux choses distinctes doivent sortir : la commande corrigee, et la RAISON.
+# Donner la commande sans la raison ferait recopier un incantatoire.
+verifier "la commande corrigee est donnee" 1 \
+  "$(echo "$SORTIE" | grep -c 'read -rsp .* < /dev/tty')"
+verifier "la raison du /dev/tty est expliquee" 1 \
+  "$(echo "$SORTIE" | grep -c "n'est pas decoratif")"
+verifier "aucun secret engendre" 0 "$([ -f "$TRAVAIL/coffre4c.txt" ] && echo 1 || echo 0)"
 
 # --- 5. non-regression : aucun pointeur en dur ---------------------------
 echo

--- a/scripts/test-tourner-secret-db.sh
+++ b/scripts/test-tourner-secret-db.sh
@@ -188,6 +188,27 @@ verifier "le .env n'a pas bouge" 0 \
 verifier "plus aucun renvoi vers read/export" 0 \
   "$(echo "$SORTIE" | grep -cE 'read -rsp|export ')"
 
+# --- 4d. toute requete HTTP doit s'annoncer ------------------------------
+# Sans User-Agent explicite, `urllib` est banni par le pare-feu applicatif devant
+# l'API : 403 « error code: 1010 » identique pour un jeton valide et un jeton bidon,
+# donc un diagnostic qui accuse le jeton a tort. C'est arrive ; cette assertion
+# empeche qu'une requete ajoutee plus tard rejoue l'incident.
+echo
+echo "=== 4d. couverture du User-Agent sur toutes les requetes ==="
+LU="$(python3 - "$ICI/tourner-secret-db.py" <<'PYCHK'
+import re, sys
+t = open(sys.argv[1]).read()
+print(len(re.findall(r'urllib\.request\.Request\(', t)),
+      len(re.findall(r'"User-Agent": AGENT', t)))
+PYCHK
+)"
+verifier "chaque requete porte le User-Agent" "$(echo "$LU" | cut -d' ' -f1)" \
+  "$(echo "$LU" | cut -d' ' -f2)"
+verifier "au moins une requete existe" 1 \
+  "$([ "$(echo "$LU" | cut -d' ' -f1)" -ge 1 ] && echo 1 || echo 0)"
+verifier "une reponse non-JSON est imputee au pare-feu, pas au jeton" 1 \
+  "$(grep -c "AVANT l'API" "$ICI/tourner-secret-db.py")"
+
 # --- 5. non-regression : aucun pointeur en dur ---------------------------
 echo
 echo "=== 5. le script ne contient aucun pointeur ==="

--- a/scripts/tourner-secret-db.py
+++ b/scripts/tourner-secret-db.py
@@ -122,14 +122,21 @@ def obtenir_jeton() -> str | None:
 
 
 def verifier_jeton(projet: str, jeton: str) -> tuple[int, str]:
-    """Preflight : le jeton ouvre-t-il ce projet ? Appel en lecture seule.
+    """Preflight : le jeton porte-t-il la bonne permission ? Appel en lecture seule.
 
     Sans lui, un jeton absent ou errone n'est decouvert qu'a l'etape 4, apres qu'un
     secret a ete engendre et depose — du bruit a nettoyer pour rien. Echouer ici
     coute un aller-retour et ne laisse aucune trace.
+
+    Le point interroge n'est PAS choisi au hasard. `GET /v1/projects/{ref}` releve de
+    la permission « Project Settings », alors que le changement de mot de passe releve
+    de « Database Config » : un jeton correctement restreint a la tache aurait ete
+    refuse par le preflight lui-meme. On interroge donc la config Postgres, qui releve
+    de « Database Config » en lecture — impliquee par la lecture-ecriture qu'exige
+    l'operation. Une garde doit eprouver la meme permission que ce qu'elle precede.
     """
     requete = urllib.request.Request(
-        f"https://api.supabase.com/v1/projects/{projet}",
+        f"https://api.supabase.com/v1/projects/{projet}/config/database/postgres",
         headers={"Authorization": f"Bearer {jeton}"},
         method="GET",
     )
@@ -226,15 +233,15 @@ def main(argv: list[str] | None = None) -> int:
 
     print("=== 0/5 — le jeton ouvre-t-il ce projet ? ===")
     code, corps = verifier_jeton(args.projet, jeton)
-    print(f"  GET /v1/projects/{args.projet} -> HTTP {code}")
+    print(f"  GET /v1/projects/{args.projet}/config/database/postgres -> HTTP {code}")
     if code != 200:
         # Un 403 ne discrimine pas : il couvre le jeton malforme rejete en amont
         # (le corps porte alors un « error code » de la couche de filtrage) et le
         # jeton valide sans droit sur ce projet. Nommer une seule cause avec
         # assurance enverrait chercher au mauvais endroit.
         indice = {401: "jeton invalide, expire, ou saisi a vide",
-                  403: "jeton malforme rejete en amont, OU valide mais sans droit "
-                       "sur ce projet — voir la reponse ci-dessous",
+                  403: "jeton malforme rejete en amont, OU sans la permission "
+                       "« Database Config » sur ce projet — voir la reponse",
                   404: "reference de projet inconnue de ce compte",
                   0: "l'appel n'a pas abouti"}.get(code, "refus de l'API")
         print(f"  {indice}", file=sys.stderr)

--- a/scripts/tourner-secret-db.py
+++ b/scripts/tourner-secret-db.py
@@ -15,6 +15,8 @@ C'est la seule voie qui laisse le systeme coherent.
 
 ORDRE DES OPERATIONS — pense pour qu'aucune panne ne verrouille la base
 -----------------------------------------------------------------------
+  0. prouver que le jeton ouvre ce projet, en lecture seule — avant d'engendrer
+     quoi que ce soit, pour qu'un jeton absent ou errone ne laisse aucune trace
   1. prouver qu'un identifiant de reference ouvre bien la base (sinon on ne pourra
      rien prouver ensuite, et l'etat de depart est deja inconnu)
   2. engendrer le secret et l'ecrire IMMEDIATEMENT dans un fichier 0600 —
@@ -91,6 +93,27 @@ def essayer(secret: str, *, hote: str, port: int, utilisateur: str, base: str) -
         return False, f"PANNE:{type(e).__name__}"
 
 
+def verifier_jeton(projet: str, jeton: str) -> tuple[int, str]:
+    """Preflight : le jeton ouvre-t-il ce projet ? Appel en lecture seule.
+
+    Sans lui, un jeton absent ou errone n'est decouvert qu'a l'etape 4, apres qu'un
+    secret a ete engendre et depose — du bruit a nettoyer pour rien. Echouer ici
+    coute un aller-retour et ne laisse aucune trace.
+    """
+    requete = urllib.request.Request(
+        f"https://api.supabase.com/v1/projects/{projet}",
+        headers={"Authorization": f"Bearer {jeton}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(requete, timeout=60) as r:
+            return r.status, r.read().decode("utf-8", "replace")[:200]
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")[:200]
+    except Exception as e:  # noqa: BLE001
+        return 0, f"{type(e).__name__}: {e}"
+
+
 def appeler_api(projet: str, secret: str, jeton: str) -> tuple[int, str]:
     requete = urllib.request.Request(
         f"https://api.supabase.com/v1/projects/{projet}/database/password",
@@ -152,9 +175,17 @@ def main(argv: list[str] | None = None) -> int:
 
     jeton = os.environ.get(JETON, "").strip()
     if not jeton:
-        print(f"{JETON} absent de l'environnement.", file=sys.stderr)
-        print("Creer un jeton sur https://supabase.com/dashboard/account/tokens", file=sys.stderr)
-        print(f"puis : read -rs {JETON} && export {JETON}", file=sys.stderr)
+        print(f"{JETON} absent (ou vide) dans l'environnement.", file=sys.stderr)
+        print(file=sys.stderr)
+        print("Creer un jeton sur https://supabase.com/dashboard/account/tokens, puis :",
+              file=sys.stderr)
+        print(f'  read -rsp "Jeton : " {JETON} < /dev/tty && export {JETON} && echo',
+              file=sys.stderr)
+        print(file=sys.stderr)
+        print("Le `< /dev/tty` n'est pas decoratif : sans lui, `read` lit l'entree", file=sys.stderr)
+        print("standard, et si la commande a ete collee avec les lignes suivantes,", file=sys.stderr)
+        print("il avale la ligne d'apres au lieu d'attendre la frappe — la variable", file=sys.stderr)
+        print("est alors exportee vide.", file=sys.stderr)
         return 3
 
     cfg = dict(hote=args.hote, port=args.port, utilisateur=args.utilisateur, base=args.base)
@@ -165,6 +196,26 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{CLE} introuvable dans {args.reference}", file=sys.stderr)
         return 3
 
+    print("=== 0/5 — le jeton ouvre-t-il ce projet ? ===")
+    code, corps = verifier_jeton(args.projet, jeton)
+    print(f"  GET /v1/projects/{args.projet} -> HTTP {code}")
+    if code != 200:
+        # Un 403 ne discrimine pas : il couvre le jeton malforme rejete en amont
+        # (le corps porte alors un « error code » de la couche de filtrage) et le
+        # jeton valide sans droit sur ce projet. Nommer une seule cause avec
+        # assurance enverrait chercher au mauvais endroit.
+        indice = {401: "jeton invalide, expire, ou saisi a vide",
+                  403: "jeton malforme rejete en amont, OU valide mais sans droit "
+                       "sur ce projet — voir la reponse ci-dessous",
+                  404: "reference de projet inconnue de ce compte",
+                  0: "l'appel n'a pas abouti"}.get(code, "refus de l'API")
+        print(f"  {indice}", file=sys.stderr)
+        print(f"  reponse : {corps}", file=sys.stderr)
+        print("\n  Rien n'a ete engendre ni modifie.", file=sys.stderr)
+        return 6
+    print("  jeton accepte sur ce projet")
+
+    print()
     print("=== 1/5 — etat de depart ===")
     ok, detail = essayer(ancien, **cfg)
     print(f"  identifiant de reference ({empreinte(ancien)}) : "

--- a/scripts/tourner-secret-db.py
+++ b/scripts/tourner-secret-db.py
@@ -54,6 +54,12 @@ from pathlib import Path
 
 CLE = "SUPABASE_DB_PASSWORD"
 JETON = "SUPABASE_ACCESS_TOKEN"
+#: Sans User-Agent explicite, `urllib` s'annonce « Python-urllib/3.x » — signature
+#: bannie par le pare-feu applicatif devant l'API, qui repond 403 « error code: 1010 ».
+#: La requete n'atteint alors JAMAIS l'API : le meme 403 sort pour un jeton valide et
+#: pour un jeton bidon, ce qui fait accuser le jeton a tort. Mesure a l'appui : avec
+#: cet en-tete, un jeton faux rend « 401 JWT could not be decoded » — donc l'API repond.
+AGENT = "massdoc-rotation-secret/1.0"
 #: Alphabet volontairement alphanumerique. Un `.env` n'a pas de regle de citation
 #: universelle et une URL de connexion encore moins : un caractere special mal
 #: echappe reproduit exactement le defaut qu'on vient de diagnostiquer.
@@ -137,7 +143,7 @@ def verifier_jeton(projet: str, jeton: str) -> tuple[int, str]:
     """
     requete = urllib.request.Request(
         f"https://api.supabase.com/v1/projects/{projet}/config/database/postgres",
-        headers={"Authorization": f"Bearer {jeton}"},
+        headers={"Authorization": f"Bearer {jeton}", "User-Agent": AGENT},
         method="GET",
     )
     try:
@@ -153,7 +159,8 @@ def appeler_api(projet: str, secret: str, jeton: str) -> tuple[int, str]:
     requete = urllib.request.Request(
         f"https://api.supabase.com/v1/projects/{projet}/database/password",
         data=json.dumps({"password": secret}).encode("utf-8"),
-        headers={"Authorization": f"Bearer {jeton}", "Content-Type": "application/json"},
+        headers={"Authorization": f"Bearer {jeton}", "Content-Type": "application/json",
+                 "User-Agent": AGENT},
         method="PATCH",
     )
     try:
@@ -235,15 +242,19 @@ def main(argv: list[str] | None = None) -> int:
     code, corps = verifier_jeton(args.projet, jeton)
     print(f"  GET /v1/projects/{args.projet}/config/database/postgres -> HTTP {code}")
     if code != 200:
-        # Un 403 ne discrimine pas : il couvre le jeton malforme rejete en amont
-        # (le corps porte alors un « error code » de la couche de filtrage) et le
-        # jeton valide sans droit sur ce projet. Nommer une seule cause avec
-        # assurance enverrait chercher au mauvais endroit.
-        indice = {401: "jeton invalide, expire, ou saisi a vide",
-                  403: "jeton malforme rejete en amont, OU sans la permission "
-                       "« Database Config » sur ce projet — voir la reponse",
-                  404: "reference de projet inconnue de ce compte",
-                  0: "l'appel n'a pas abouti"}.get(code, "refus de l'API")
+        # Distinguer « l'API a refuse » de « on n'a jamais atteint l'API ». Une
+        # reponse qui n'est pas du JSON ne vient pas de l'API mais du pare-feu
+        # applicatif devant elle : accuser le jeton dans ce cas envoie chercher au
+        # mauvais endroit — c'est arrive.
+        if not corps.lstrip().startswith("{"):
+            indice = ("reponse non-JSON : la requete a ete arretee AVANT l'API, par "
+                      "le pare-feu applicatif. Le jeton n'est pas en cause.")
+        else:
+            indice = {401: "jeton invalide, expire, ou saisi a vide",
+                      403: "jeton sans la permission « Database Config » "
+                           "(lecture-ecriture) sur ce projet",
+                      404: "reference de projet inconnue de ce compte",
+                      0: "l'appel n'a pas abouti"}.get(code, "refus de l'API")
         print(f"  {indice}", file=sys.stderr)
         print(f"  reponse : {corps}", file=sys.stderr)
         print("\n  Rien n'a ete engendre ni modifie.", file=sys.stderr)

--- a/scripts/tourner-secret-db.py
+++ b/scripts/tourner-secret-db.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tourne le mot de passe de la base d'un projet Supabase, par le chemin supporte.
+
+POURQUOI L'API PLUTOT QU'UN `ALTER USER`
+-----------------------------------------
+Le mot de passe de la base existe a DEUX endroits : le role PostgreSQL, et
+l'identifiant que le pooler (Supavisor) conserve cote plan de controle pour ouvrir
+ses connexions amont. Un `ALTER USER` emis en direct ne change que le premier : le
+pooler garde l'ancien et cesse de fonctionner. Sur une base qui sert du trafic, cela
+coupe le site.
+
+`PATCH /v1/projects/{ref}/database/password` est l'operation qu'appelle le bouton
+« Reset database password » du tableau de bord : elle change les deux ensemble.
+C'est la seule voie qui laisse le systeme coherent.
+
+ORDRE DES OPERATIONS — pense pour qu'aucune panne ne verrouille la base
+-----------------------------------------------------------------------
+  1. prouver qu'un identifiant de reference ouvre bien la base (sinon on ne pourra
+     rien prouver ensuite, et l'etat de depart est deja inconnu)
+  2. engendrer le secret et l'ecrire IMMEDIATEMENT dans un fichier 0600 —
+     avant tout changement, pour qu'un plantage ne puisse pas le perdre
+  3. appeler l'API
+  4. verifier : le nouveau ouvre la base ET l'ancien est refuse (28P01)
+  5. seulement alors, mettre a jour le .env, avec sauvegarde horodatee
+Rien n'est ecrit dans le .env tant que la base n'a pas confirme.
+
+Le secret n'est ni affiche, ni journalise, ni passe en argv. Seules des empreintes
+SHA-256 tronquees apparaissent. Le jeton d'API est lu dans l'environnement.
+
+Codes de sortie
+  0 rotation prouvee             4 le changement n'a pas pris
+  2 etat de depart inexploitable  5 l'ancien identifiant est encore accepte
+  3 erreur d'entree/sortie        6 l'API a refuse l'appel
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import secrets
+import string
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+CLE = "SUPABASE_DB_PASSWORD"
+JETON = "SUPABASE_ACCESS_TOKEN"
+#: Alphabet volontairement alphanumerique. Un `.env` n'a pas de regle de citation
+#: universelle et une URL de connexion encore moins : un caractere special mal
+#: echappe reproduit exactement le defaut qu'on vient de diagnostiquer.
+ALPHABET = string.ascii_letters + string.digits
+
+
+def empreinte(v: str) -> str:
+    return hashlib.sha256(v.strip().encode()).hexdigest()[:12]
+
+
+def engendrer(n: int) -> str:
+    return "".join(secrets.choice(ALPHABET) for _ in range(n))
+
+
+def lire_secret(chemin: Path) -> str | None:
+    """Extrait la valeur de SUPABASE_DB_PASSWORD d'un fichier de type .env."""
+    if not chemin.is_file():
+        return None
+    for ligne in chemin.read_text(encoding="utf-8", errors="replace").splitlines():
+        if ligne.startswith(f"{CLE}="):
+            return ligne.split("=", 1)[1].strip()
+    return None
+
+
+def essayer(secret: str, *, hote: str, port: int, utilisateur: str, base: str) -> tuple[bool, str]:
+    """Tente une connexion. Distingue un refus d'authentification d'une panne reseau :
+    confondre les deux ferait passer une coupure pour une rotation reussie."""
+    import psycopg2
+    try:
+        psycopg2.connect(host=hote, port=port, user=utilisateur, password=secret,
+                         dbname=base, connect_timeout=20).close()
+        return True, "OK"
+    except psycopg2.OperationalError as e:
+        texte = str(e).strip().replace("\n", " ")
+        if "password authentication failed" in texte:
+            return False, "28P01"
+        return False, f"PANNE:{texte[:70]}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"PANNE:{type(e).__name__}"
+
+
+def appeler_api(projet: str, secret: str, jeton: str) -> tuple[int, str]:
+    requete = urllib.request.Request(
+        f"https://api.supabase.com/v1/projects/{projet}/database/password",
+        data=json.dumps({"password": secret}).encode("utf-8"),
+        headers={"Authorization": f"Bearer {jeton}", "Content-Type": "application/json"},
+        method="PATCH",
+    )
+    try:
+        with urllib.request.urlopen(requete, timeout=120) as r:
+            return r.status, r.read().decode("utf-8", "replace")[:200]
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")[:200]
+    except Exception as e:  # noqa: BLE001
+        return 0, f"{type(e).__name__}: {e}"
+
+
+def ecrire_env(env: Path, valeur: str) -> Path:
+    """Remplace la ligne du secret, atomiquement, apres sauvegarde horodatee."""
+    contenu = env.read_text(encoding="utf-8", errors="replace")
+    sauvegarde = env.with_name(f"{env.name}.avant-rotation-{time.strftime('%Y%m%d_%H%M%S')}")
+    sauvegarde.write_text(contenu, encoding="utf-8")
+    sauvegarde.chmod(0o600)
+
+    lignes, vu = [], False
+    for ligne in contenu.splitlines(keepends=True):
+        if ligne.startswith(f"{CLE}="):
+            lignes.append(f"{CLE}={valeur}\n")
+            vu = True
+        else:
+            lignes.append(ligne)
+    if not vu:
+        raise RuntimeError(f"{CLE} absent de {env} — refus d'ajouter une ligne a l'aveugle")
+
+    fd, provisoire = tempfile.mkstemp(dir=str(env.parent), prefix=".env.")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write("".join(lignes))
+    os.chmod(provisoire, env.stat().st_mode & 0o777)
+    os.replace(provisoire, env)
+    return sauvegarde
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--projet", required=True, help="reference du projet Supabase")
+    ap.add_argument("--hote", required=True, help="hote de verification (pooler)")
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument("--utilisateur", required=True, help="ex. postgres.<ref> pour le pooler")
+    ap.add_argument("--base", default="postgres")
+    ap.add_argument("--reference", required=True,
+                    help="fichier .env portant l'identifiant ACTUELLEMENT valide "
+                         "(celui qu'on veut invalider)")
+    ap.add_argument("--env", required=True, help="fichier .env a mettre a jour")
+    ap.add_argument("--coffre", required=True,
+                    help="fichier 0600 ou deposer le nouveau secret (hors depot)")
+    ap.add_argument("--longueur", type=int, default=40)
+    ap.add_argument("--attente", type=int, default=90,
+                    help="secondes d'attente max pour la propagation")
+    args = ap.parse_args(argv)
+
+    jeton = os.environ.get(JETON, "").strip()
+    if not jeton:
+        print(f"{JETON} absent de l'environnement.", file=sys.stderr)
+        print("Creer un jeton sur https://supabase.com/dashboard/account/tokens", file=sys.stderr)
+        print(f"puis : read -rs {JETON} && export {JETON}", file=sys.stderr)
+        return 3
+
+    cfg = dict(hote=args.hote, port=args.port, utilisateur=args.utilisateur, base=args.base)
+    env, coffre = Path(args.env), Path(args.coffre)
+
+    ancien = lire_secret(Path(args.reference))
+    if ancien is None:
+        print(f"{CLE} introuvable dans {args.reference}", file=sys.stderr)
+        return 3
+
+    print("=== 1/5 — etat de depart ===")
+    ok, detail = essayer(ancien, **cfg)
+    print(f"  identifiant de reference ({empreinte(ancien)}) : "
+          f"{'ACCEPTE' if ok else 'REFUSE'} ({detail})")
+    if not ok:
+        print("\n  Il n'ouvre pas la base : on ne pourra pas prouver qu'il cesse de",
+              file=sys.stderr)
+        print("  fonctionner. Fournir via --reference un identifiant valide.", file=sys.stderr)
+        return 2
+
+    print()
+    print("=== 2/5 — generation et mise a l'abri (avant tout changement) ===")
+    neuf = engendrer(args.longueur)
+    coffre.write_text(neuf + "\n", encoding="utf-8")
+    coffre.chmod(0o600)
+    print(f"  secret de {args.longueur} caracteres, empreinte {empreinte(neuf)}")
+    print(f"  depose dans {coffre} (0600) — jamais affiche")
+
+    print()
+    print("=== 3/5 — appel de l'API supportee ===")
+    code, corps = appeler_api(args.projet, neuf, jeton)
+    print(f"  PATCH /v1/projects/{args.projet}/database/password -> HTTP {code}")
+    if code != 200:
+        print(f"  reponse : {corps}", file=sys.stderr)
+        print(f"\n  Aucun changement applique. Le secret engendre reste dans {coffre} ;",
+              file=sys.stderr)
+        print("  le supprimer s'il ne sert pas.", file=sys.stderr)
+        return 6
+
+    print()
+    print(f"=== 4/5 — verification (jusqu'a {args.attente}s de propagation) ===")
+    limite = time.time() + args.attente
+    while True:
+        ok_neuf, d_neuf = essayer(neuf, **cfg)
+        if ok_neuf or time.time() > limite:
+            break
+        time.sleep(5)
+    ok_ancien, d_ancien = essayer(ancien, **cfg)
+    print(f"  nouveau secret  : {'ACCEPTE' if ok_neuf else 'REFUSE'} ({d_neuf})")
+    print(f"  ancien secret   : {'ACCEPTE' if ok_ancien else 'REFUSE'} ({d_ancien})")
+    if not ok_neuf:
+        print("\n  L'API a repondu 200 mais le nouveau secret n'ouvre pas la base.",
+              file=sys.stderr)
+        print(f"  Ne rien conclure : il est dans {coffre}. Reessayer la verification",
+              file=sys.stderr)
+        print("  avant de toucher au .env.", file=sys.stderr)
+        return 4
+    if ok_ancien:
+        print("\n  L'ancien identifiant ouvre ENCORE la base — rotation non effective.",
+              file=sys.stderr)
+        return 5
+
+    print()
+    print("=== 5/5 — mise a jour du .env ===")
+    sauvegarde = ecrire_env(env, neuf)
+    print(f"  {env} mis a jour · sauvegarde : {sauvegarde.name}")
+    relu = lire_secret(env)
+    if relu != neuf:
+        print("  ecriture incoherente — verifier le fichier a la main", file=sys.stderr)
+        return 3
+    print(f"  relecture conforme (empreinte {empreinte(relu)})")
+
+    print()
+    print("ROTATED")
+    print()
+    print("Reste a faire, dans cet ordre :")
+    print(f"  1. reporter la valeur de {coffre} dans le secret CI")
+    print("  2. redemarrer les services qui ont l'ancien identifiant en memoire")
+    print(f"  3. supprimer {args.reference} et {coffre} une fois la valeur reportee")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tourner-secret-db.py
+++ b/scripts/tourner-secret-db.py
@@ -27,7 +27,9 @@ ORDRE DES OPERATIONS — pense pour qu'aucune panne ne verrouille la base
 Rien n'est ecrit dans le .env tant que la base n'a pas confirme.
 
 Le secret n'est ni affiche, ni journalise, ni passe en argv. Seules des empreintes
-SHA-256 tronquees apparaissent. Le jeton d'API est lu dans l'environnement.
+SHA-256 tronquees apparaissent. Le jeton d'API est demande au terminal (saisie
+masquee via /dev/tty) ou, en usage non interactif, lu dans SUPABASE_ACCESS_TOKEN —
+jamais dans un fichier de configuration, jamais en argv.
 
 Codes de sortie
   0 rotation prouvee             4 le changement n'a pas pris
@@ -91,6 +93,32 @@ def essayer(secret: str, *, hote: str, port: int, utilisateur: str, base: str) -
         return False, f"PANNE:{texte[:70]}"
     except Exception as e:  # noqa: BLE001
         return False, f"PANNE:{type(e).__name__}"
+
+
+def obtenir_jeton() -> str | None:
+    """Recupere le jeton d'API : variable d'environnement, sinon saisie au terminal.
+
+    La saisie directe existe parce que la voie en deux temps
+    (`read … && export …` puis la commande) echoue silencieusement : `read` lit
+    l'entree standard, donc un collage multi-lignes lui fait avaler la ligne
+    suivante au lieu d'attendre la frappe, et la variable part vide. Demander
+    ici supprime l'etat de shell a porter entre deux commandes — donc la classe
+    d'erreur entiere.
+
+    `getpass` ouvre `/dev/tty` : la saisie est masquee et ne passe ni par argv,
+    ni par l'historique, ni par l'environnement d'un autre processus.
+    """
+    depuis_env = os.environ.get(JETON, "").strip()
+    if depuis_env:
+        return depuis_env
+    if not sys.stdin.isatty():
+        return None
+    import getpass
+    try:
+        return getpass.getpass("Jeton Supabase (saisie masquee, rien ne s'affiche) : ").strip() or None
+    except (EOFError, KeyboardInterrupt):
+        print(file=sys.stderr)
+        return None
 
 
 def verifier_jeton(projet: str, jeton: str) -> tuple[int, str]:
@@ -173,19 +201,19 @@ def main(argv: list[str] | None = None) -> int:
                     help="secondes d'attente max pour la propagation")
     args = ap.parse_args(argv)
 
-    jeton = os.environ.get(JETON, "").strip()
+    jeton = obtenir_jeton()
     if not jeton:
-        print(f"{JETON} absent (ou vide) dans l'environnement.", file=sys.stderr)
+        print("Aucun jeton d'API.", file=sys.stderr)
         print(file=sys.stderr)
-        print("Creer un jeton sur https://supabase.com/dashboard/account/tokens, puis :",
-              file=sys.stderr)
-        print(f'  read -rsp "Jeton : " {JETON} < /dev/tty && export {JETON} && echo',
-              file=sys.stderr)
+        if sys.stdin.isatty():
+            print("La saisie a ete annulee ou laissee vide. Relancer la commande :", file=sys.stderr)
+            print("le jeton est demande directement, rien a exporter au prealable.", file=sys.stderr)
+        else:
+            print(f"Pas de terminal pour la saisie — fournir {JETON} dans", file=sys.stderr)
+            print("l'environnement (usage non interactif).", file=sys.stderr)
         print(file=sys.stderr)
-        print("Le `< /dev/tty` n'est pas decoratif : sans lui, `read` lit l'entree", file=sys.stderr)
-        print("standard, et si la commande a ete collee avec les lignes suivantes,", file=sys.stderr)
-        print("il avale la ligne d'apres au lieu d'attendre la frappe — la variable", file=sys.stderr)
-        print("est alors exportee vide.", file=sys.stderr)
+        print("Creer un jeton sur https://supabase.com/dashboard/account/tokens",
+              file=sys.stderr)
         return 3
 
     cfg = dict(hote=args.hote, port=args.port, utilisateur=args.utilisateur, base=args.base)

--- a/scripts/verifier-rotation-secret.py
+++ b/scripts/verifier-rotation-secret.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Verifie mecaniquement qu'une rotation du mot de passe PostgreSQL a bien eu lieu.
+
+Une rotation n'est pas prouvee parce qu'on l'a faite : elle est prouvee quand
+l'ANCIEN secret est refuse ET que le NOUVEAU fonctionne. Ce script etablit les deux,
+sans jamais afficher, journaliser ni ecrire la moindre valeur.
+
+Ce qu'il fait
+  1. lit le secret ACTIF depuis backend/.env
+  2. lit le secret PUBLIE depuis l'historique git (blob du commit fautif)
+  3. compare leurs empreintes SHA-256 tronquees      -> rotation faite ou non
+  4. ouvre une connexion avec le secret ACTIF        -> doit REUSSIR
+  5. ouvre une connexion avec le secret PUBLIE       -> doit ECHOUER en 28P01
+  6. inventorie les copies locales portant l'ancien secret, sans les supprimer
+
+Aucune valeur ne transite par argv, par l'environnement d'un sous-processus, ni par
+la sortie. Les empreintes affichees sont tronquees a 12 hexa : elles identifient sans
+permettre de reconstituer.
+
+Codes de sortie
+  0  ROTATED         ancien refuse, nouveau valide
+  1  ROTATION_FAIL   l'ancien secret est ENCORE accepte — le pire cas
+  2  BLOCKED_BY_SECRET_ROTATION   actif == publie, rien n'a change
+  3  INDETERMINE     une verification n'a pas pu etre menee (dit, jamais suppose)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+RACINE = Path(__file__).resolve().parent.parent
+CLE = "SUPABASE_DB_PASSWORD"
+
+#: La reference du blob ou le litteral a ete publie est fournie a l'EXECUTION, jamais
+#: ecrite ici. Ce depot est public : y inscrire « le mot de passe est dans tel commit,
+#: tel fichier » en ferait un panneau indicateur. L'operateur la connait, le depot non.
+
+
+def empreinte(valeur: str) -> str:
+    return hashlib.sha256(valeur.strip().encode()).hexdigest()[:12]
+
+
+def secret_actif(env: Path) -> str:
+    if not env.is_file():
+        raise RuntimeError(
+            f"{env} introuvable. Le fichier .env n'est pas suivi par Git : depuis un "
+            "worktree, passer --env /opt/automecanik/app/backend/.env")
+    for ligne in env.read_text(encoding="utf-8", errors="replace").splitlines():
+        if ligne.startswith(f"{CLE}="):
+            return ligne.split("=", 1)[1].strip()
+    raise RuntimeError(f"{CLE} absent de {env}")
+
+
+def secret_publie(commit: str, chemin: str) -> str:
+    import re
+    blob = subprocess.run(["git", "show", f"{commit}:{chemin}"],
+                          cwd=RACINE, capture_output=True, text=True)
+    if blob.returncode != 0:
+        raise RuntimeError(f"blob {commit}:{chemin} illisible — "
+                           "historique tronque ou depot incomplet")
+    trouves = re.findall(r"['\"]password['\"]\s*:\s*['\"]([^'\"]+)['\"]", blob.stdout)
+    if not trouves:
+        raise RuntimeError("aucun litteral de mot de passe dans le blob de reference")
+    return trouves[0]
+
+
+def tenter_connexion(secret: str, *, hote: str, port: int, utilisateur: str,
+                     base: str) -> tuple[bool, str]:
+    """Ouvre une connexion et la referme. Rend (succes, classe d'erreur).
+
+    Le secret est passe par le parametre `password` de psycopg2 : il ne figure ni
+    dans argv, ni dans l'environnement, ni dans un fichier temporaire.
+    """
+    import psycopg2
+    try:
+        conn = psycopg2.connect(host=hote, port=port, user=utilisateur,
+                                password=secret, dbname=base, connect_timeout=15)
+        conn.close()
+        return True, "OK"
+    except psycopg2.OperationalError as e:
+        code = getattr(e, "pgcode", None) or ""
+        texte = str(e).lower()
+        if code == "28P01" or "authentication failed" in texte or "mot de passe" in texte:
+            return False, "28P01"
+        return False, f"AUTRE:{type(e).__name__}"
+    except Exception as e:  # noqa: BLE001 — on nomme, on ne suppose pas
+        return False, f"AUTRE:{type(e).__name__}"
+
+
+def copies_locales(cible: str, racine: Path) -> list[Path]:
+    """Fichiers hors Git portant l'empreinte donnee. Inventaire seul, aucune suppression."""
+    import re as _re
+    trouves: set[Path] = set()
+    for motif in ("backend/.env*", ".env*", "backend/*.bak", "backend/*.backup"):
+        for f in racine.glob(motif):
+            if not f.is_file():
+                continue
+            try:
+                contenu = f.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for ligne in contenu.splitlines():
+                nom, sep, val = ligne.partition("=")
+                if not sep or nom.strip() not in (CLE, "DATABASE_URL"):
+                    continue
+                val = val.strip().strip("\"'")
+                if nom.strip() == "DATABASE_URL":
+                    m = _re.search(r"://[^:]+:([^@]+)@", val)
+                    val = m.group(1) if m else ""
+                if val and empreinte(val) == cible:
+                    trouves.add(f)
+                    break
+    return sorted(trouves)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--hote", default="aws-0-eu-west-3.pooler.supabase.com")
+    ap.add_argument("--port", type=int, default=6543)
+    ap.add_argument("--utilisateur", default="postgres.cxpojprgwgubzjyqzmoq")
+    ap.add_argument("--base", default="postgres")
+    ap.add_argument("--commit", required=True,
+                    help="commit ou le litteral a ete publie (reference forensique, "
+                         "fournie par l'operateur — jamais figee dans le depot)")
+    ap.add_argument("--chemin", required=True,
+                    help="chemin du fichier dans ce commit")
+    ap.add_argument("--env", default=str(RACINE / "backend" / ".env"),
+                    help="fichier .env portant le secret actif (jamais suivi par Git)")
+    ap.add_argument("--sans-connexion", action="store_true",
+                    help="comparaison d'empreintes seule, aucune tentative de connexion")
+    args = ap.parse_args(argv)
+
+    try:
+        env = Path(args.env)
+        actif, publie = secret_actif(env), secret_publie(args.commit, args.chemin)
+    except Exception as e:  # noqa: BLE001
+        print(f"INDETERMINE : {e}", file=sys.stderr)
+        return 3
+
+    e_actif, e_publie = empreinte(actif), empreinte(publie)
+    print("=== Empreintes SHA-256 tronquees (aucune valeur affichee) ===")
+    print(f"  secret actif  ({CLE}) : {e_actif}")
+    print(f"  secret publie ({args.commit})     : {e_publie}")
+
+    if e_actif == e_publie:
+        print()
+        print("  Le secret actif EST celui publie publiquement.")
+        print("  La verification negative est sans objet : il n'y a pas d'« ancien » secret.")
+        print()
+        print("BLOCKED_BY_SECRET_ROTATION")
+        return 2
+
+    print("  -> les empreintes different : une rotation a eu lieu.")
+
+    if args.sans_connexion:
+        print()
+        print("INDETERMINE : rotation constatee par empreinte, connexions non testees "
+              "(--sans-connexion). Une rotation non eprouvee n'est pas une rotation prouvee.")
+        return 3
+
+    print()
+    print(f"=== Verification par connexion ({args.hote}:{args.port}) ===")
+    ok_neuf, detail_neuf = tenter_connexion(actif, hote=args.hote, port=args.port,
+                                            utilisateur=args.utilisateur, base=args.base)
+    print(f"  nouveau secret : {'ACCEPTE' if ok_neuf else 'REFUSE'} ({detail_neuf})")
+    ok_vieux, detail_vieux = tenter_connexion(publie, hote=args.hote, port=args.port,
+                                              utilisateur=args.utilisateur, base=args.base)
+    print(f"  ancien secret  : {'ACCEPTE' if ok_vieux else 'REFUSE'} ({detail_vieux})")
+
+    print()
+    if ok_vieux:
+        print("  L'identifiant publie publiquement ouvre TOUJOURS la base.")
+        print("ROTATION_FAIL")
+        return 1
+    if not ok_neuf:
+        print("  Le secret actif n'ouvre pas la base : configuration incoherente, ou")
+        print("  indisponibilite reseau. Ne pas conclure a une rotation reussie.")
+        print("INDETERMINE")
+        return 3
+    if detail_vieux != "28P01":
+        print(f"  L'ancien secret echoue, mais pas sur un refus d'authentification "
+              f"({detail_vieux}). Un echec reseau ressemble a un refus — il ne le prouve pas.")
+        print("INDETERMINE")
+        return 3
+
+    restes = copies_locales(e_publie, env.parent.parent)
+    print("=== Copies locales portant l'ancien secret (inventaire, aucune suppression) ===")
+    if restes:
+        for f in restes:
+            print(f"  · {f}")
+        print("  Ces fichiers peuvent maintenant etre supprimes sans risque : la valeur")
+        print("  qu'ils portent n'ouvre plus rien.")
+    else:
+        print("  aucune")
+
+    print()
+    print("ROTATED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Correction : les 250 Go venaient de moi, pas des données

La première version de cette PR exigeait un volume dédié de 250 Go et concluait `NO_GO`. Ce chiffre découlait d'une hypothèse que je n'avais pas soumise : **matérialiser les 110 DLNR simultanément** dans une seule instance.

L'invariant à démontrer — `PROD ⊆ REBUILD`, sans perte de ligne ni dérive d'identité — se vérifie **DLNR par DLNR**. On rejoue, on réconcilie, on scelle la preuve, **puis on jette la matière**. Le pic devient celui du plus gros fournisseur seul.

**Mesure réelle** (rejeu HIDRIA, PG 17 jetable) : `2 654 208` octets pour `13 057` lignes, index compris → **203 o/ligne**.

```
pic en base (FEBI, 17,4 M lignes — cas dimensionnant) ... 3,3 Go
+ CSV de parsing (transitoire) ......................... 1,5 Go
PIC ESTIMÉ ............................................ ~5 Go
libre sur / aujourd'hui ............................... 39 Go   → GO
```

**Le bloqueur capacité disparaît.** Pas de volume, pas de dépense. Les 250 Go ne redeviennent nécessaires que si l'on veut *conserver* un rebuild matérialisé.

## La preuve est le livrable

Puisque la matière est jetée, chaque DLNR laisse une entrée dans un **registre scellé** :

```json
{ "dlnr": 4523, "batch_id": "5df6aa47…",
  "comptabilite":        { "rows_emitted": 13057, "rows_loaded": 13057, "rows_rejected": {} },
  "empreinte_du_charge": { "lignes": 13057, "empreinte_md5": "0f46f853577f…" },
  "reconciliation":      { "identites_conservees": 13057, "conflits": 0,
                           "inclusion_respectee": true } }
```

Falsifier une seule valeur fait diverger le sceau — vérifié. Une preuve qu'on peut réécrire n'en est pas une.

## Fail-closed

Un DLNR n'est purgé que **lorsque sa preuve est écrite**. Toute anomalie arrête la vague **sans purger** le DLNR fautif : sa matière reste pour le diagnostic.

| Situation | Code | Effet |
|---|---:|---|
| Comptabilité déséquilibrée | 5 | rollback du DLNR |
| Dérive d'identité | 6 | vague arrêtée |
| Conservation rompue | 7 | vague arrêtée |
| Inclusion `PROD ⊄ REBUILD` | 8 | arrêtée, **matière conservée** |
| Purge non confirmée | 9 | vague arrêtée |

**Banc : 32 assertions, 0 rouge** — vague nominale + purge, relance idempotente, inclusion rompue, conservation de la matière sur échec. Un défaut du banc corrigé au passage : l'injection 5 dégradait la base de référence sans la restaurer, contaminant les cas suivants.

## Vérificateur de rotation

`verifier-rotation-secret.py` établit qu'une rotation a **réellement** eu lieu : ancien identifiant refusé en `28P01` **et** nouveau accepté.

- Aucune valeur affichée, journalisée ni passée en `argv` — seules des empreintes SHA-256 tronquées.
- Le distinguo **refus d'authentification / panne réseau** est éprouvé sur un secret délibérément faux, *avant* d'en avoir besoin : une coupure réseau ressemble à un refus sans en être un → `INDETERMINE`, jamais `ROTATED`.
- La référence du blob publié est fournie **à l'exécution**, pas inscrite dans le dépôt : l'y figer, dans un dépôt public, en ferait un panneau indicateur.

## Portée assumée

**RAW (`tecdoc_raw.t400`) uniquement** — là où la perte de mars 2026 s'est produite. Rien n'est démontré sur la projection `source_linkages` : aucun projecteur vérifié n'existe, les projecteurs historiques restent en quarantaine (dont celui qui a pollué `pieces_relation_type` de ~219 M lignes fantômes). Chantier séparé.

## Ce que la PR ne fait pas

- **Rejeu complet non lancé** — seul LOT 0 (1 DLNR, 13 k lignes) a servi à éprouver la mécanique.
- Aucun `DROP`, `TRUNCATE`, `VACUUM FULL`, resize. Aucune donnée supprimée.
- Le document ne consigne **aucun état de secret** : ce dépôt est public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)