### PR TITLE
fix(turbo): débloquer `npm run dev`, qui ne démarrait plus du tout

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,13 @@
 {
     "$schema": "https://turbo.build/schema.json",
     "globalDependencies": ["packages/typescript-config/*.json"],
+    // 11 paquets declarent un script `dev`, tous persistent:true (backend,
+    // frontend, et 9 watchers de paquets). Le plafond par defaut de turbo est
+    // 10, et il refuse de demarrer des qu'il y a plus de taches persistantes
+    // que de slots : `npm run dev` echouait donc entierement. Turbo demande une
+    // valeur strictement superieure au nombre de taches persistantes — 12 laisse
+    // une marge d'un paquet avant de devoir y revenir.
+    "concurrency": "12",
     "tasks": {
       "dev": {
         "cache": false,


### PR DESCRIPTION
## Le défaut

`npm run dev` à la racine échouait **entièrement** :

```
x Invalid task configuration
`->   x You have 11 persistent tasks but `turbo` is configured for
      | concurrency of 10. Set `--concurrency` to at least 12 or configure
      | `"concurrency"` in `turbo.json`
```

11 paquets déclarent un script `dev` — `backend`, `frontend`, et 9 watchers de paquets — tous `persistent: true`. Le plafond par défaut de turbo est 10, et il refuse de démarrer dès qu'il y a plus de tâches persistantes que de créneaux. `concurrency` n'était pas défini dans `turbo.json`.

## Pourquoi ça comptait

La conséquence était silencieuse. La commande documentée dans `.claude/rules/deployment.md` ne démarrant pas, le runtime DEV se lançait depuis `backend/`. **Mesuré avant correction : 0 des 9 watchers de paquets ne tournait** (les 2 `tsc --watch` visibles étaient ceux du backend lui-même).

Modifier `@repo/registry`, `@repo/domain-commerce`, `@fafa/design-tokens` ou n'importe quel paquet partagé ne recompilait donc rien, et le backend continuait de servir leur `dist/` périmé — de quoi chercher un défaut dans le mauvais fichier.

## Pourquoi 12 et pas 11

Turbo exige une valeur **strictement supérieure** au nombre de tâches persistantes. 12 laisse la marge d'un paquet avant de devoir y revenir.

## Vérification — machine DEV, runtime relancé par la racine

Les 11 tâches démarrent :

```
@fafa/backend:dev:  @fafa/frontend:dev:  @fafa/design-tokens:dev:
@repo/cwv-taxonomy:dev:  @repo/database-types:dev:  @repo/domain-commerce:dev:
@repo/registry:dev:  @repo/seo-role-contracts:dev:  @repo/seo-roles:dev:
@repo/seo-types:dev:  @repo/seo-url-contract:dev:
```

Les 8 watchers `@repo/*` rendent tous `Found 0 errors. Watching for file changes`.

| Route | Résultat |
|---|---|
| `/health` | 200 · 4,6 ms |
| `/` | 200 · 272 Ko · *« Pièces auto neuves compatibles toutes marques »* |
| `/pieces/alternateur-4.html` | 200 · 415 ms |
| `/constructeurs/bmw-33.html` | 200 · 194 ms |

Deux erreurs backend subsistent au démarrage — `@open-policy-agent/opa-wasm` absent (jamais déclaré dans `backend/package.json`) et Meilisearch éteint sur DEV. Elles **préexistent** à ce changement, sont des lacunes d'environnement DEV, et le service se rabat en `fallbackDenyAll = true` — fail-closed. Hors périmètre de cette PR.

## Sûreté du commentaire JSONC

Turbo lit nativement le JSONC (`turbo dev --dry` passe, 27 tâches planifiées). Vérifié qu'aucun consommateur ne parse ce fichier en JSON strict :

- `scripts/check-workspace-mini-monorepo.sh` n'utilise que le **nom** de fichier (liste d'interdits) ;
- `.github/workflows/ci.yml` n'en prend qu'un `hashFiles` ;
- `lint-staged` ne cible que `backend/src/**/*.ts`.

Prettier signalait déjà ce fichier sur `HEAD` — aucune régression de format introduite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)