### PR TITLE
fix(throttler): un tier nommé plafonnait tout le site à 30 req/min/IP

### DIFF
--- a/.ast-grep/rules/backend-throttle-key-must-match-configured-tier.yml
+++ b/.ast-grep/rules/backend-throttle-key-must-match-configured-tier.yml
@@ -1,0 +1,38 @@
+id: backend-throttle-key-must-match-configured-tier
+language: typescript
+severity: error
+message: |
+  `@Throttle({ <clé>: … })` nomme un tier qui n'existe pas dans
+  `backend/src/config/throttler-tiers.config.ts` → l'override est
+  SILENCIEUSEMENT IGNORÉ (aucune erreur, aucun log, la route garde la
+  politique par défaut).
+
+  Mécanique : le guard résout l'override en lisant la métadonnée sous le NOM
+  du tier configuré — `this.reflector.getAllAndOverride(THROTTLER_LIMIT +
+  namedThrottler.name, …)` (@nestjs/throttler 6.5.0, throttler.guard.js:77) —
+  en bouclant sur `this.throttlers`. Une clé qui ne correspond à aucun tier
+  n'est jamais lue. En particulier `default` : il n'est attribué qu'à un
+  throttler déclaré SANS `name` (throttler.guard.js:44), ce qui n'est le cas
+  d'aucun des nôtres.
+
+  Incident 2026-09-09 : trois endpoints de télémétrie portaient
+  `@Throttle({ default: … })` (120/min, 60/min, 30/min annoncés). Preuve
+  runtime sur DEV:3000 — 20 POST en rafale sur /api/seo/cwv/beacon →
+  15× 202 puis 5× 429, soit le tier `short` (15/s), jamais les 120/min.
+
+  Clés valides : `short` · `medium` · `long` · `payment_callback`.
+  Ajouter un tier = modifier `THROTTLER_TIERS` **et** cette règle — et lire
+  d'abord l'invariant de portée : un tier nommé dans `forRoot` s'applique à
+  TOUTES les routes (régression #390 : le site entier plafonné à 30 req/min).
+files:
+  - backend/src/**/*.ts
+ignores:
+  - backend/src/**/*.spec.ts
+  - backend/src/**/*.test.ts
+  - backend/src/**/*.e2e-spec.ts
+rule:
+  pattern: '@Throttle({ $KEY: $$$ })'
+constraints:
+  KEY:
+    not:
+      regex: '^(short|medium|long|payment_callback)$'

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { LoggerModule } from 'nestjs-pino';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { loggerConfig } from './config/logger.config';
+import { THROTTLER_TIERS } from './config/throttler-tiers.config';
 import { RequestIdMiddleware } from './modules/mcp-validation/middleware/request-id.middleware';
 // import { ScheduleModule } from '@nestjs/schedule'; // ❌ DÉSACTIVÉ - Conflit de version avec @nestjs/common v10
 // import { BullModule } from '@nestjs/bullmq'; // ❌ DÉSACTIVÉ - Conflit de version avec @nestjs/common v10
@@ -97,34 +98,9 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
     LoggerModule.forRoot(loggerConfig),
     // 🛡️ RATE LIMITING - Protection anti-spam/DDoS
     ThrottlerModule.forRoot({
-      throttlers: [
-        {
-          name: 'short',
-          ttl: 1000, // 1 seconde
-          limit: 15, // 15 req/sec max par IP
-        },
-        {
-          name: 'medium',
-          ttl: 60000, // 1 minute
-          limit: 100, // 100 req/min par IP
-        },
-        {
-          name: 'long',
-          ttl: 3600000, // 1 heure
-          limit: 2000, // 2000 req/heure par IP
-        },
-        {
-          // ADR-043 Sprint 1 ticket #6 — payment callbacks (STRIDE 01-paiement
-          // critique #2). Apply via @Throttle({ payment_callback: {...} }) on
-          // /api/paybox/callback + /api/payments/callback/cyberplus. Gateway IPN
-          // sends ~1-2 callbacks per transaction → 30/min/IP is generous for
-          // legitimate flow, tight for crypto-compute DoS. On 429, gateways
-          // retry idempotently (HMAC signature dedups).
-          name: 'payment_callback',
-          ttl: 60000, // 1 minute
-          limit: 30,
-        },
-      ],
+      // Tiers + invariant de portée : src/config/throttler-tiers.config.ts
+      // (un tier nommé ici s'applique à TOUTES les routes — cf. régression #390).
+      throttlers: THROTTLER_TIERS,
       // 🛡️ Skip internal calls (Remix SSR + Docker containers + Admin users)
       skipIf: (context) => {
         const request = context.switchToHttp().getRequest();

--- a/backend/src/config/throttler-tiers.config.test.ts
+++ b/backend/src/config/throttler-tiers.config.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Contrat des tiers de rate-limiting — preuve sur un vrai Nest booté.
+ *
+ * Régression couverte (incident 2026-09-09, introduite par #390 le 2026-05-08) :
+ * un throttler NOMMÉ dans `ThrottlerModule.forRoot` s'applique à **toutes** les
+ * routes — @nestjs/throttler 6.5.0, `throttler.guard.js:66` boucle sur
+ * `this.throttlers` dans `canActivate()`, sans aucune notion de portée. Le tier
+ * `payment_callback` (30/min), pensé pour resserrer les 2 callbacks passerelle,
+ * a donc plafonné le SITE ENTIER à 30 req/min/IP pendant 4 mois.
+ *
+ * Preuve terrain avant correctif (DEV:3000, cadence 5/s sur le handler catch-all
+ * `remix.controller.ts:160 @All('{*path}')`, IP fictive) : 1er 429 à la **31e**
+ * requête alors que `medium` affichait encore 69/100 et `short` 10/15.
+ *
+ * Le test lit les en-têtes `X-RateLimit-Limit-*` : ce sont les valeurs que le
+ * guard a réellement résolues (`throttler.guard.js:135`, après `resolveValue` des
+ * overrides de route), pas une relecture de la config. Précédent de boot Nest réel
+ * sans dépendance externe : `modules/analytics/landing-attribution-cutover.nest.test.ts`.
+ */
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { ThrottlerModule, Throttle } from '@nestjs/throttler';
+import request from 'supertest';
+
+import { CloudflareThrottlerGuard } from '../common/guards/cloudflare-throttler.guard';
+import { THROTTLER_TIERS } from './throttler-tiers.config';
+
+/** Route ordinaire : modélise le catch-all SSR et toute route sans @Throttle. */
+@Controller()
+class PlainController {
+  @Get('plain')
+  plain(): { ok: true } {
+    return { ok: true };
+  }
+}
+
+/**
+ * Route qui déclare explicitement le tier `payment_callback`.
+ * Modélise `payments/controllers/{paybox-,payment-}callback.controller.ts`, qui
+ * portent déjà `@Throttle({ payment_callback: { limit: 30, ttl: 60000 } })` et
+ * restent intouchés (zone STOP owner — `.claude/rules/payments.md`).
+ */
+@Controller()
+class ScopedController {
+  @Throttle({ payment_callback: { limit: 30, ttl: 60000 } })
+  @Get('scoped')
+  scoped(): { ok: true } {
+    return { ok: true };
+  }
+}
+
+describe('THROTTLER_TIERS — portée des tiers nommés', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ThrottlerModule.forRoot({ throttlers: THROTTLER_TIERS })],
+      controllers: [PlainController, ScopedController],
+      providers: [{ provide: APP_GUARD, useClass: CloudflareThrottlerGuard }],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  const limitsOf = async (path: string, ip: string) => {
+    const res = await request(app.getHttpServer())
+      .get(path)
+      .set('Cf-Connecting-Ip', ip)
+      .expect(200);
+    const num = (h: string) => Number(res.headers[h.toLowerCase()]);
+    return {
+      short: num('X-RateLimit-Limit-short'),
+      medium: num('X-RateLimit-Limit-medium'),
+      long: num('X-RateLimit-Limit-long'),
+      paymentCallback: num('X-RateLimit-Limit-payment_callback'),
+    };
+  };
+
+  it('aucun tier de portée route ne resserre une route ordinaire sous `medium`', async () => {
+    const limits = await limitsOf('/plain', '198.51.100.11');
+
+    // Le défaut exact de #390 : payment_callback=30 < medium=100 sur une route
+    // qui n'a jamais demandé ce tier ⇒ plafond réel du site à 30/min.
+    expect(limits.medium).toBe(100);
+    expect(limits.paymentCallback).toBeGreaterThanOrEqual(limits.medium);
+  });
+
+  it('les 2 fenêtres de rafale et horaire restent inchangées', async () => {
+    const limits = await limitsOf('/plain', '198.51.100.12');
+
+    expect(limits.short).toBe(15); // 15 req/s
+    expect(limits.long).toBe(2000); // 2000 req/h
+  });
+
+  it('une route qui déclare `payment_callback` obtient bien ses 30/min', async () => {
+    const limits = await limitsOf('/scoped', '198.51.100.13');
+
+    // Protection paiement préservée (ADR-043 Sprint 1 ticket #6) : la valeur
+    // opérante est posée PAR LA ROUTE. Si le tier disparaissait de forRoot,
+    // l'override deviendrait inerte et cette assertion tomberait.
+    expect(limits.paymentCallback).toBe(30);
+  });
+});

--- a/backend/src/config/throttler-tiers.config.ts
+++ b/backend/src/config/throttler-tiers.config.ts
@@ -1,0 +1,63 @@
+import { type ThrottlerOptions } from '@nestjs/throttler';
+
+/**
+ * Tiers de rate-limiting appliqués à CHAQUE route de l'application.
+ *
+ * ⚠️ Invariant de portée — à lire avant d'ajouter un tier.
+ * Un throttler nommé ici s'applique à **toutes** les routes : @nestjs/throttler
+ * 6.5.0 boucle sur `this.throttlers` dans `canActivate()` sans notion de portée
+ * (`throttler.guard.js:66`). Le nom d'un tier ne le restreint à rien. Le tier le
+ * plus strict devient donc le plafond réel du site entier.
+ *
+ * Corollaire : un tier destiné à une poignée de routes doit rester
+ * **non-contraignant globalement**, et sa valeur opérante être posée PAR LA ROUTE
+ * via `@Throttle({ <nom du tier>: { limit, ttl } })`.
+ *
+ * Le bucket est par (contrôleur, handler, tier, IP) — `generateKey()` =
+ * `sha256(Classe-Handler-tier-IP)` (`throttler.guard.js:148-151`). Conséquence :
+ * chaque `/api/*` a son propre budget, mais TOUT le SSR (pages, `*.data`,
+ * `/__manifest`) partage un seul bucket, servi par l'unique handler catch-all
+ * `remix.controller.ts:160 @All('{*path}')`.
+ */
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+/** Fenêtre de rafale — absorbe le parallélisme d'un chargement de page. */
+const SHORT: ThrottlerOptions = { name: 'short', ttl: SECOND, limit: 15 };
+
+/** Politique par défaut par minute — c'est elle qui borne la navigation. */
+const MEDIUM: ThrottlerOptions = { name: 'medium', ttl: MINUTE, limit: 100 };
+
+/** Plafond horaire — vise les sources automatisées, pas la navigation humaine. */
+const LONG: ThrottlerOptions = { name: 'long', ttl: HOUR, limit: 2000 };
+
+/**
+ * Tier de portée route pour les callbacks passerelle (ADR-043 Sprint 1
+ * ticket #6, STRIDE 01-paiement critique #2). Sa valeur opérante — 30/min/IP —
+ * est déclarée par les 2 routes concernées, dans `payments/controllers/`.
+ *
+ * Sa valeur ICI est délibérément alignée sur `MEDIUM` : globalement inerte.
+ * Historique : introduit à `limit: 30` par #390 (2026-05-08), ce tier a plafonné
+ * le site entier à 30 req/min/IP jusqu'au 2026-09-09 — 1er 429 mesuré à la 31e
+ * requête sur le catch-all alors que `medium` affichait encore 69/100 restants.
+ *
+ * Le tier doit rester déclaré : les deux `@Throttle({ payment_callback: … })` le
+ * référencent par nom, et un override nommant un tier absent de cette liste est
+ * silencieusement ignoré (`throttler.guard.js:77` lit la métadonnée sous le nom
+ * du tier configuré). Garde mécanique :
+ * `.ast-grep/rules/backend-throttle-key-must-match-configured-tier.yml`.
+ */
+const PAYMENT_CALLBACK: ThrottlerOptions = {
+  name: 'payment_callback',
+  ttl: MEDIUM.ttl,
+  limit: MEDIUM.limit,
+};
+
+export const THROTTLER_TIERS: ThrottlerOptions[] = [
+  SHORT,
+  MEDIUM,
+  LONG,
+  PAYMENT_CALLBACK,
+];

--- a/backend/src/modules/analytics/controllers/landing-attribution.controller.ts
+++ b/backend/src/modules/analytics/controllers/landing-attribution.controller.ts
@@ -41,7 +41,6 @@ import {
   Post,
   Req,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { z } from 'zod';
 import { classifyLandingSource } from '../landing-source.classifier';
@@ -88,7 +87,13 @@ export class LandingAttributionController {
 
   @Post('landing')
   @HttpCode(202)
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  // Pas d'override de tier ici : la politique standard s'applique
+  // (15/s · 100/min · 2000/h par IP, bucket propre à ce handler —
+  // src/config/throttler-tiers.config.ts). Un `@Throttle({ default: … })`
+  // a vécu ici sans jamais s'appliquer : aucun tier ne s'appelle `default`,
+  // et le guard lit l'override sous le NOM du tier configuré
+  // (throttler.guard.js:77). Prouvé le 2026-09-09 : 20 POST en rafale →
+  // 15× 202 puis 5× 429, soit le tier `short`, pas la limite annoncée.
   landing(
     @Body() body: unknown,
     @Req() req: Request,

--- a/backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
@@ -14,7 +14,9 @@
  * Pattern mirror de `FunnelEventsController` :
  *   - @HttpCode(202) — beacon = fire-and-forget, jamais 4xx visible côté UA
  *   - Validation safeParse → 202 silencieux si malformé (ne pas casser le client)
- *   - Throttler @nestjs/throttler 120/min/IP (= ~5 metrics × 24 pages-views/min absolute max)
+ *   - Throttler @nestjs/throttler : politique standard, bucket propre à ce
+ *     handler (15/s · 100/min · 2000/h par IP). Le client émet jusqu'à 5
+ *     beacons par page vue (un par métrique — web-vitals.client.ts:336-340).
  */
 import {
   Body,
@@ -24,7 +26,6 @@ import {
   Logger,
   Post,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
 import {
   CwvBeaconClientPayloadSchema,
   classifyUserAgent,
@@ -41,7 +42,13 @@ export class CwvBeaconController {
 
   @Post('beacon')
   @HttpCode(202)
-  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  // Pas d'override de tier ici : la politique standard s'applique
+  // (15/s · 100/min · 2000/h par IP, bucket propre à ce handler —
+  // src/config/throttler-tiers.config.ts). Un `@Throttle({ default: … })`
+  // a vécu ici sans jamais s'appliquer : aucun tier ne s'appelle `default`,
+  // et le guard lit l'override sous le NOM du tier configuré
+  // (throttler.guard.js:77). Prouvé le 2026-09-09 : 20 POST en rafale →
+  // 15× 202 puis 5× 429, soit le tier `short`, pas la limite annoncée.
   async beacon(
     @Body() body: unknown,
     @Headers('user-agent') ua: string | undefined,

--- a/backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts
@@ -5,9 +5,10 @@
  *   POST /api/seo/runtime-event — capture hydration / longtask / nav-abort /
  *   chunk-load-error depuis frontend via `navigator.sendBeacon`.
  *
- * Pattern mirror `CwvBeaconController` (public, @HttpCode(202), Throttle).
+ * Pattern mirror `CwvBeaconController` (public, @HttpCode(202)).
  *
- * Anti-flood : 60/min/IP (vs 120 pour beacon CWV) — les runtime events sont
+ * Anti-flood : politique standard par handler (15/s · 100/min · 2000/h par IP)
+ * — cf. src/config/throttler-tiers.config.ts. Les runtime events sont
  * supposés rares ; sample throttling frontend max 5/session/event_type.
  */
 import {
@@ -18,7 +19,6 @@ import {
   Logger,
   Post,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
 import {
   classifyUserAgent,
   priorityTierFromSurface,
@@ -35,7 +35,13 @@ export class RuntimeEventsController {
 
   @Post('runtime-event')
   @HttpCode(202)
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  // Pas d'override de tier ici : la politique standard s'applique
+  // (15/s · 100/min · 2000/h par IP, bucket propre à ce handler —
+  // src/config/throttler-tiers.config.ts). Un `@Throttle({ default: … })`
+  // a vécu ici sans jamais s'appliquer : aucun tier ne s'appelle `default`,
+  // et le guard lit l'override sous le NOM du tier configuré
+  // (throttler.guard.js:77). Prouvé le 2026-09-09 : 20 POST en rafale →
+  // 15× 202 puis 5× 429, soit le tier `short`, pas la limite annoncée.
   async event(
     @Body() body: unknown,
     @Headers('user-agent') ua: string | undefined,


### PR DESCRIPTION
## Symptôme

Page « Trop de requêtes / Veuillez réessayer dans quelques instants » vue par des visiteurs réels, par intermittence. Diagnostiquée deux fois (2026-07-03, 2026-07-14) et classée « garde qui fonctionne, pas de correctif code » — les deux fois, la **composition** des 429 avait été mesurée, jamais le **tier** qui tranche.

## Cause racine

`ThrottlerModule.forRoot` applique **chaque throttler nommé à toutes les routes** : @nestjs/throttler 6.5.0 boucle sur `this.throttlers` dans `canActivate()` (`throttler.guard.js:66`), sans aucune notion de portée. Le nom d'un tier ne le restreint à rien.

Le tier `payment_callback` (30/min), introduit par #390 le 2026-05-08 pour *resserrer* les 2 callbacks passerelle, plafonnait donc **le site entier à 30 req/min/IP** depuis 4 mois.

Aggravant : le bucket est par (contrôleur, handler, tier, IP) — `generateKey()` = `sha256(Classe-Handler-tier-IP)` (`throttler.guard.js:148`) — et tout le SSR (pages, `*.data`, `/__manifest`) passe par l'unique handler catch-all `remix.controller.ts:160 @All('{*path}')`. Un seul budget de 30/min pour toute la navigation d'un visiteur, quand chaque `/api/*` a le sien.

## Preuve avant / après

DEV:3000, cadence 5/s (sous le tier `short` de 15/s), IP fictive, handler catch-all :

| | 1er 429 | état des autres tiers |
|---|---|---|
| avant | requête **31** | `medium` encore à 69/100, `short` à 10/15 |
| après | requête **101** | le plafond redevient `medium` |

En-têtes résolus par le guard sur une route ordinaire : `X-RateLimit-Limit-payment_callback` passe de `30` à `100`.

## Correctif

La valeur **globale** de `payment_callback` est alignée sur `medium` → inerte hors des routes qui le déclarent. Le tier **reste déclaré** : les deux `@Throttle({ payment_callback: … })` le référencent par nom, et un override nommant un tier absent est silencieusement ignoré. **Protection paiement inchangée à 30/min ; `payments/` n'est pas touché** (zone STOP owner).

Retire aussi 3 `@Throttle({ default: … })` morts (beacon CWV 120/min, runtime-event 60/min, attribution 30/min) : aucun tier ne s'appelle `default`, le guard lit l'override sous le nom du tier configuré (`throttler.guard.js:77`), ils n'ont donc jamais rien fait. Prouvé : 20 POST en rafale sur `/api/seo/cwv/beacon` → 15× 202 puis 5× 429, soit le tier `short`, jamais les 120/min annoncés. **Zéro delta runtime** — le code cesse simplement de mentir.

## Gardes ajoutés

- `backend/src/config/throttler-tiers.config.test.ts` — boote un vrai Nest et lit les en-têtes `X-RateLimit-Limit-*` réellement résolus. **Échoue sur l'état d'avant** (reçu 30, attendu >= 100) ; vérifie aussi que les 30/min paiement tiennent.
- `.ast-grep/rules/backend-throttle-key-must-match-configured-tier.yml` — attrape `default` **et** toute faute de frappe (`mediumm`), laisse passer les tiers réels.

## Vérifications

- `tsc --noEmit` : 0 · `eslint` (6 fichiers) : 0 · `ast-grep` nouvelle règle sur `backend/src` : 0
- `jest` ciblé : **118 tests / 12 suites verts** (analytics, seo-monitoring, seo-link-tracking, nouveau contrat)
- Preuve runtime bout-en-bout sur DEV:3000 ci-dessus

## Hors périmètre (volontairement)

`/img/*` est en `cf-cache-status: BYPASS` permanent parce que `config/caddy/Caddyfile:120` proxifie Supabase Storage en propageant son `Set-Cookie: __cf_bm` (cookie que le navigateur rejette de toute façon — mauvais domaine). 9 des 13 requêtes origine de l'accueil sont ces images jamais cachées. C'est un défaut de **cache/LCP/egress**, **sans effet sur ces 429** : ces requêtes partent vers Supabase et n'atteignent jamais le throttler NestJS. Le Caddyfile est un chemin protégé (`pretool-file-guard.sh:23`, `airlock.sh:516`) → correctif d'une ligne à appliquer par l'owner, hors de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)