### PR TITLE
ci(monitoring): donner aux scripts d'alerte le chemin de déploiement qui leur manquait

### DIFF
--- a/.github/workflows/deploy-monitoring-scripts.yml
+++ b/.github/workflows/deploy-monitoring-scripts.yml
@@ -1,0 +1,100 @@
+name: 📟 Deploy monitoring scripts
+
+# Les scripts de `scripts/monitoring/` tournent en cron sur la box 49.12.233.2
+# depuis `/usr/local/bin/`, une COPIE installée à la main (`scripts/monitoring/README.md`
+# §Installation prod). Conséquence : merger un correctif ne le déploie pas, et rien
+# ne signale la dérive — c'est un cas d'école de l'invariant 8 (« présent » ≠
+# « réellement servi »). Le 2026-09-07, les correctifs d'alerte du tunnel de paiement
+# (#1413) sont restés inertes pour cette seule raison.
+#
+# Ce workflow ferme le chemin manquant : le runner self-hosted TOURNE sur cette
+# machine et y dispose déjà de sudo (cf. `ci.yml` job `lighthouse`, qui installe
+# google-chrome par `sudo dpkg`). Il se contente de recopier les exécutables ;
+# il ne touche NI `/etc/default/*` (secrets, installés une fois à la main),
+# NI `/etc/cron.d/*` (planification, décision opérateur).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/monitoring/*.sh'
+  # Indispensable : le merge de CE workflow ne modifie aucun `scripts/monitoring/*.sh`,
+  # donc le filtre `paths` ci-dessus ne se déclenchera pas. Le premier déploiement —
+  # et toute resynchronisation après une dérive — passe par un run manuel.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-monitoring-scripts
+  cancel-in-progress: false
+
+jobs:
+  install:
+    name: 📟 Installer sur /usr/local/bin (49.12.233.2)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 5
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🔍 Contrôle syntaxique AVANT toute écriture
+        # Fail-closed : on n'écrase JAMAIS un script qui tourne par un script
+        # cassé. `bash -n` parse sans exécuter — les scripts de monitoring
+        # envoient des mails et interrogent la base, ils ne doivent jamais être
+        # lancés ici.
+        run: |
+          set -euo pipefail
+          failed=0
+          for f in scripts/monitoring/*.sh; do
+            if bash -n "$f"; then
+              echo "✅ $f"
+            else
+              echo "❌ $f — syntaxe invalide, rien ne sera installé"
+              failed=1
+            fi
+          done
+          [ "$failed" -eq 0 ]
+
+      - name: 📊 Dérive constatée avant installation
+        # Rend la dérive lisible dans le log : quelle version tournait vraiment.
+        run: |
+          set -euo pipefail
+          for f in scripts/monitoring/*.sh; do
+            name=$(basename "$f")
+            repo_sum=$(md5sum "$f" | cut -d' ' -f1)
+            if [ -f "/usr/local/bin/$name" ]; then
+              live_sum=$(md5sum "/usr/local/bin/$name" | cut -d' ' -f1)
+            else
+              live_sum="(absent)"
+            fi
+            if [ "$repo_sum" = "$live_sum" ]; then
+              echo "≡ $name déjà à jour ($repo_sum)"
+            else
+              echo "≠ $name  installé=$live_sum  repo=$repo_sum"
+            fi
+          done
+
+      - name: 📦 Installation
+        run: |
+          set -euo pipefail
+          for f in scripts/monitoring/*.sh; do
+            sudo install -m 755 "$f" /usr/local/bin/
+            echo "→ installé : /usr/local/bin/$(basename "$f")"
+          done
+
+      - name: ✅ Vérification post-installation
+        # Le job échoue si une copie ne correspond pas au repo — sans quoi
+        # « vert » ne prouverait rien.
+        run: |
+          set -euo pipefail
+          for f in scripts/monitoring/*.sh; do
+            name=$(basename "$f")
+            if [ "$(md5sum "$f" | cut -d' ' -f1)" != "$(md5sum "/usr/local/bin/$name" | cut -d' ' -f1)" ]; then
+              echo "❌ $name diffère encore après installation"
+              exit 1
+            fi
+            echo "✅ $name identique au repo"
+          done

--- a/scripts/monitoring/README.md
+++ b/scripts/monitoring/README.md
@@ -103,10 +103,23 @@ Optionnelles :
 
 ### Installation prod (host `49.12.233.2`)
 
+> **L'étape 1 est automatisée depuis 2026-09-09.** Tout merge sur `main` touchant
+> `scripts/monitoring/*.sh` déclenche [`deploy-monitoring-scripts.yml`](../../.github/workflows/deploy-monitoring-scripts.yml),
+> qui recopie les exécutables dans `/usr/local/bin/` depuis le runner self-hosted
+> (la même machine). Le workflow contrôle la syntaxe **avant** d'écrire et vérifie
+> l'empreinte **après** : il ne peut donc ni installer un script cassé, ni passer au
+> vert sans avoir réellement mis à jour la copie.
+>
+> Avant cette date, la copie était manuelle et **un merge ne déployait rien** — les
+> correctifs d'alerte de #1413 sont restés inertes pendant deux jours pour cette
+> seule raison.
+>
+> Les étapes 2 et 4 (secrets, planification) restent **manuelles et faites une fois** :
+> le workflow ne touche ni `/etc/default/*` ni `/etc/cron.d/*`.
+
 ```bash
-# 1. Le script est déjà dans le repo git (après CI deploy de main)
-#    Path canonique : /home/deploy/actions-runner/_work/.../scripts/monitoring/
-#    Copier vers path stable (hors workdir du runner qui peut être wipé) :
+# 1. (automatique) — équivalent manuel, pour un premier amorçage ou un dépannage.
+#    Sinon : Actions → « 📟 Deploy monitoring scripts » → Run workflow.
 RUNNER_REPO=/home/deploy/actions-runner/_work/nestjs-remix-monorepo/nestjs-remix-monorepo
 sudo install -m 755 "$RUNNER_REPO/scripts/monitoring/check-payment-tunnel.sh" /usr/local/bin/
 
@@ -245,7 +258,13 @@ Identiques à PREV-1 (les secrets Gmail sont partagés). Seuls les seuils change
 
 ### Installation prod (host `49.12.233.2`)
 
+> Même mécanique que PREV-1 : la copie de l'exécutable est **automatisée** par
+> [`deploy-monitoring-scripts.yml`](../../.github/workflows/deploy-monitoring-scripts.yml)
+> (le workflow traite tous les `scripts/monitoring/*.sh`). Le lien env et le cron
+> ci-dessous restent manuels et faits une fois.
+
 ```bash
+# (automatique) — équivalent manuel pour amorçage/dépannage
 RUNNER_REPO=/home/deploy/actions-runner/_work/nestjs-remix-monorepo/nestjs-remix-monorepo
 sudo install -m 755 "$RUNNER_REPO/scripts/monitoring/check-error-logs-5xx.sh" /usr/local/bin/
 


### PR DESCRIPTION
## Le défaut

Les deux scripts de `scripts/monitoring/` tournent en cron sur `49.12.233.2` depuis `/usr/local/bin/`, une **copie installée à la main** (`scripts/monitoring/README.md` §Installation prod). Merger un correctif ne déployait donc rien, et rien ne signalait la dérive.

Ce n'est pas théorique : les correctifs d'alerte du tunnel de paiement (#1413, mergés le 2026-09-07) sont restés **inertes deux jours** pour cette seule raison, pendant que le cron continuait d'exécuter l'ancienne version — celle qui produit les doubles alertes. Cas d'école de l'invariant 8 : « présent » n'est pas « réellement servi ».

Le problème touche **les deux** scripts (`check-payment-tunnel.sh`, `check-error-logs-5xx.sh`), pas un cas isolé.

## Ce que fait cette PR

Un workflow qui recopie les exécutables, rien de plus. Le chemin existait déjà à moitié : le runner self-hosted **tourne sur cette machine** et y dispose de sudo — `ci.yml` job `lighthouse` (`runs-on: [self-hosted, Linux, X64]`) y installe google-chrome par `sudo dpkg` depuis longtemps.

Déclenchement : push `main` touchant `scripts/monitoring/*.sh`, plus `workflow_dispatch`.

## Fail-closed par construction

| Garde | Effet |
|---|---|
| `bash -n` sur chaque script **avant** toute écriture | un seul script cassé annule l'installation complète — on n'écrase jamais un script qui tourne par un script invalide |
| empreintes md5 comparées **après** installation | le job échoue si une copie diffère encore, sans quoi « vert » ne prouverait rien |
| dérive journalisée avant écriture | le log dit quelle version tournait réellement |
| les scripts ne sont **jamais exécutés** ici | ils envoient des mails et interrogent la base |

Périmètre volontairement étroit : ni `/etc/default/*` (secrets) ni `/etc/cron.d/*` (planification) ne sont touchés. Ils restent installés une fois à la main.

## `workflow_dispatch` est nécessaire, pas décoratif

Le merge de cette PR ne modifie **aucun** `scripts/monitoring/*.sh` — le filtre `paths` ne se déclenchera donc pas. Le premier déploiement passe obligatoirement par un run manuel :

> Actions → **📟 Deploy monitoring scripts** → Run workflow

C'est ce run qui installera enfin les correctifs de #1413.

## L'arbitrage, explicitement

Cette PR donne à la CI un **droit d'écriture root sur `/usr/local/bin` de la machine PROD**. Le précédent existe (le job `lighthouse` y fait déjà du `sudo dpkg`) et le runner promeut déjà l'image `:production`, donc il contrôle bien plus que l'écriture d'un fichier. Mais le geste institue un canal permanent là où le précédent est un `apt` ponctuel — c'est la raison d'être de cette section : que la décision soit prise les yeux ouverts, pas subie.

## Vérification

Les 3 étapes rejouées localement avant livraison :

```
=== Contrôle syntaxique ===
✅ scripts/monitoring/check-error-logs-5xx.sh
✅ scripts/monitoring/check-payment-tunnel.sh
verdict: 0 (0 attendu)

=== Dérive constatée ===
≠ check-error-logs-5xx.sh  installé=(absent)  repo=bf8b6fb4e1596391727533ec91dee0ae
≠ check-payment-tunnel.sh  installé=(absent)  repo=ce1b9bddb8d38728e67c28299bb3cbfd

=== Preuve du fail-closed (script volontairement cassé) ===
✅ bash -n rejette bien le script cassé → aucune installation
```

**Couverture : partiellement vérifié.** L'étape `sudo install` et la vérification post-installation n'ont pas pu être rejouées ici — elles exigent sudo sur `49.12.233.2`, hors de portée depuis la machine DEV (SSH refusé). Elles seront exercées pour la première fois par le run manuel post-merge, et le job échoue si les empreintes ne concordent pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
