### PR TITLE
fix(dev): `turbo dev` SIGSEGV (bug amont 2.10.0) + la mort du superviseur devient bruyante

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -26,7 +26,7 @@ automatisé par [`scripts/ops/sync-dev-runtime.sh`](../../scripts/ops/sync-dev-r
 feature/agent se fait en **worktree** (`.claude/worktrees/`). Ne jamais y laisser une branche
 feature (sinon DEV:3000 sert du code périmé).
 
-**5 axes de dérive** vs `main` (le script garde 1-2, alerte sur 3-5 — jamais d'action destructive auto) :
+**6 axes de dérive** vs `main` (le script garde 1-2, alerte sur 3-6 — jamais d'action destructive auto) :
 
 1. **Git** : checkout sur main + ff-pull `origin/main`. (auto)
 2. **`.env`** : `backend/.env` doit avoir toutes les vars REQUIRED de `env-validation.ts`
@@ -40,6 +40,13 @@ feature (sinon DEV:3000 sert du code périmé).
    `MODULE_NOT_FOUND` (incident 2026-05-25 : `@repo/domain-commerce` + `@repo/cwv-taxonomy`).
    Détection `check_workspace_integrity()` ; install/build = action manuelle owner-gated
    (mutation `package-lock.json`, comme l'axe 4). (alerte)
+6. **Topologie runtime** : le superviseur du stack dev peut mourir en laissant ses tâches
+   persistantes vivantes, reparentées à PID 1 — `:3000` répond alors toujours `200` alors que plus
+   rien ne supervise (incident 2026-09-09 : `turbo dev` SIGSEGV, bug amont turbo 2.10.0 corrigé en
+   2.10.4). Détection `check_dev_runtime_topology()` : santé HTTP à chaque tick, racines orphelines
+   (PPID 1), stacks dev concurrents, dumps frais dans `/var/crash`. Sonde **placée avant les gardes
+   git** (un incident runtime est indépendant de l'état git) et **alert-only** — jamais `abort`, qui
+   couperait les axes de resync. Détail : `audit/turbo-dev-sigsegv-shutdown-2026-09-09.md`. (alerte)
 
 ## Mécanique du tag Docker `:preprod` (alias flottant)
 

--- a/audit/turbo-dev-sigsegv-shutdown-2026-09-09.md
+++ b/audit/turbo-dev-sigsegv-shutdown-2026-09-09.md
@@ -1,0 +1,184 @@
+# `turbo dev` SIGSEGV — bug amont turbo 2.10.0 au shutdown, et le silence local
+
+_2026-09-09 · machine DEV (`dev-automecanik`) · turbo 2.10.0 · Node v24.17.0 · 8 CPU · 15 GiB_
+
+## Résumé
+
+Deux défauts distincts, empilés :
+
+| Couche | Défaut | Statut |
+|---|---|---|
+| **1 — le crash** | Bug amont **turbo 2.10.0**, corrigé en **2.10.4** (upstream issue #13254 / PR #13256) | corrigé ici par bump de version |
+| **2 — le silence** | `sync-dev-runtime.sh` ne peut pas voir « superviseur mort, enfants vivants » *par construction* | corrigé ici par une 6e sonde |
+
+**`concurrency: "12"` (PR #1421) n'est PAS la cause** — preuve plus bas. C'est en revanche la
+**condition d'accès** : avant elle `turbo dev` refusait de démarrer (11 tâches persistantes > plafond
+par défaut 10), donc le bug amont était inatteignable sur ce repo.
+
+## Mesure AVANT
+
+Incident du 2026-09-09 09:01:41 (`turbo dev` démarré 08:52:56, mort à T+8 min 45 s) :
+
+```
+$ sudo grep -a "Sep  9 09:01" /var/log/kern.log
+traps: tokio-rt-worker[499388] general protection fault ip:7f9a37ed1d5e sp:7f9a34eb7030 error:0
+tokio-rt-worker[499393]: segfault at 7f0030bbc815 ip 00007f9a37ec2816 sp 00007f9a3449b0c0 error 4 in turbo[7f9a360a8000+1e31000]
+```
+
+Pas un OOM — `earlyoom` mesurait 66–74 % de mémoire **disponible** sur toute la fenêtre :
+
+```
+$ sudo grep -a earlyoom /var/log/syslog | grep "Sep  9 09:0"
+09:00:58 mem avail: 10346 of 15604 MiB (66.31%), swap free: 7441 of 8191 MiB (90.84%)
+09:01:58 mem avail: 11557 of 15604 MiB (74.06%), swap free: 7442 of 8191 MiB (90.85%)
+```
+
+Orphelins confirmés — les enfants ont survécu au superviseur, et `:3000` répondait toujours 200 :
+
+```
+$ ps -eo pid,ppid,etime,cmd | awk '$2==1'
+ 499482       1  13:38 npm run dev          <-- reparenté à PID 1
+$ curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/health
+200
+```
+
+### Localisation du fautif (sans gdb — non installé, non installé volontairement)
+
+Les deux IP tombent dans le segment exécutable de `turbo` (`ProcMaps` du dump apport) :
+
+```
+7f9a360a8000-7f9a37ed9000 r-xp 0010e000 ... /opt/automecanik/app/node_modules/@turbo/linux-64/bin/turbo
+offset fault 1 = 0x1e1a816     offset fault 2 = 0x1e29d5e
+```
+
+Désassemblage aux deux adresses (binaire `static-pie`, strippé — identification par **signature**,
+pas par symbole) :
+
+```
+$ objdump -d --start-address=0x1f37d30 --stop-address=0x1f37d90 <turbo>
+ 1f37d57: 41 80 7d 00 00   cmpb $0x0,0x0(%r13)
+ 1f37d5c: 74 01            je   0x1f37d5f
+ 1f37d5e: f4               hlt              <-- FAULT 2 : `hlt` en ring 3 => #GP
+```
+
+`hlt` est un **piège compilé volontairement** (89 occurrences dans une fenêtre de 256 Ko, chacune
+précédée d'un saut conditionnel). Le fault 1 déréférence `0x7f0030bbc815`, adresse qui ne
+correspond à **aucun mapping** du processus. Autrement dit : l'allocateur durci de la libc statique
+a détecté une corruption de tas et s'est arrêté net. Ni OOM, ni saut sauvage.
+
+## Cause racine — reproduite
+
+Le crash survient dans le **chemin d'arrêt** de turbo, pas en régime établi.
+
+```
+$ scripts/… 4 tâches persistantes, SIGTERM après 10 s
+  trial 1..6 : SIGSEGV 5/6
+$ … même chose avec SIGINT (Ctrl+C) : SIGSEGV 3/3
+```
+
+Balayage du nombre de tâches persistantes (SIGTERM, 3 essais chacun) :
+
+| tâches persistantes | 1 | 2 | 3 | 4 |
+|---|---|---|---|---|
+| crashes | 0/3 | 0/3 | **2/3** | **3/3** |
+
+Les adresses de fault reproduites retombent **sur les mêmes instructions** que l'incident
+(`0x1e1a81c` et `0x1e29d5e` vs `0x1e1a816` et `0x1e29d5e`).
+
+### `concurrency: "12"` est hors de cause — contrôle explicite
+
+Même test, `turbo.json` **sans aucune clé `concurrency`** (défaut turbo pur), 4 tâches :
+
+```
+CONTROL default-concurrency, 4 persistent tasks: crashes 3/3   exit codes: 135 139 139
+```
+
+Le crash se reproduit sans le réglage. PR #1421 ne l'introduit pas ; elle le rend seulement
+**atteignable**, en permettant à `turbo dev` de démarrer.
+
+### Correspondance amont
+
+- issue **vercel/turborepo#13254** — _« segfault after Ctrl-C on 2.10 (but not on 2.9.18) »_ (CLOSED)
+- PR **#13256** — _« Avoid non-reentrant libc calls in concurrent shutdown process scans »_,
+  MERGED 2026-07-06, un seul fichier `crates/turborepo-process/src/child/handle.rs`
+- régression introduite par PR **#13100** (MERGED 2026-06-17), livrée dans **v2.10.0**
+
+Première release contenant le correctif — vérifié par `git compare` sur les tags :
+
+```
+$ gh api repos/vercel/turborepo/compare/v2.10.3...bf2d8273  -> diverged   (correctif absent)
+$ gh api repos/vercel/turborepo/compare/v2.10.4...bf2d8273  -> behind     (correctif présent)
+```
+
+## Preuve APRÈS — A/B, même workspace, même arrêt, seul le binaire change
+
+```
+workspace: 4 persistent tasks, SIGTERM after 10s, 4 trials each
+turbo 2.10.0 (installed)           crashes=4/4   exit codes: 139 139 139 135
+turbo 2.10.12 (fixed, >=2.10.4)    crashes=0/4   exit codes: 0 0 0 0
+```
+
+## Couche 2 — pourquoi personne n'a rien vu
+
+`scripts/ops/sync-dev-runtime.sh` tourne en cron toutes les 10 min, mais :
+
+1. son unique appel à `$HEALTH_URL` vit dans l'étape 8, **atteignable seulement sur le chemin de
+   resync** — quand `HEAD == origin/main` (cas nominal) le script sortait sans rien sonder du runtime ;
+2. même ce health-check n'aurait rien vu : un superviseur mort avec enfants orphelins rend
+   **exactement le même 200** qu'un stack sain. Le seul signal qui les distingue est **topologique** ;
+3. les gardes branche (étape 1) et working-tree (étape 2) font `abort` **avant** tout le reste — au
+   moment de l'incident les deux étaient déclenchées, donc le cron n'a rien probé pendant des heures.
+
+D'où la 6e sonde, placée **avant** les gardes git, `alert`-only (jamais `abort` : un abort couperait
+les axes de resync qui gardent DEV:3000 frais).
+
+### Ce que la sonde vérifie, et pourquoi `/health` ne suffit pas
+
+| Contrôle | Ce qu'il attrape |
+|---|---|
+| (a) `/health`, 3 essais / 5 s | runtime réellement mort — sur **chaque** tick, pas seulement au resync. Debounce : nodemon coupe `:3000` quelques secondes à chaque rebuild |
+| (b) racine dev reparentée à **PID 1** | **la signature exacte de l'incident** — insensible à la cause (segfault, OOM, `kill -9`) |
+| (c) plusieurs racines `npm run dev` | deux arbres concurrents écrivant le même `backend/dist` (état observé après le crash) |
+| (d) dumps frais dans `/var/crash` | la machine écrit déjà des dumps apport ; **aucun script du repo ne lisait `/var/crash`** (vérifié) |
+
+(b) est le cœur : il ne peut **pas** être satisfait par `/health`.
+
+## Preuve APRÈS — la sonde
+
+Vrai positif sur un `:3000` réellement tombé (constaté indépendamment : rien en écoute) :
+
+```
+  ALERT> DEV:3000 ne répond pas après 3 essais (http://localhost:3000/health) — runtime DOWN
+  -> return=1  alerts=1
+```
+
+Détection d'un orphelin reproduisant la signature observée (`ppid=1`, `npm run dev`, cwd sous `APP_DIR`) :
+
+```
+  pid=625425 ppid=1 cwd=<APP_DIR> :: npm run dev
+  ALERT> superviseur dev MORT — 1 racine(s) orpheline(s) reparentée(s) à PID 1 (pids: 625425).
+  -> return=1  alerts=1
+```
+
+Le stack sain du repo, hors `APP_DIR` du test, n'est pas remonté : le filtrage par `cwd` fonctionne.
+
+## Limites assumées / non-vérifié
+
+- **Ce qui a déclenché l'arrêt à 09:01:41 n'est pas déterminé.** `Ctrl+C`, fermeture de terminal et
+  fin de tâche persistante mènent tous au même chemin. Aucune trace ne dit lequel. Je ne le déduis pas.
+- **Pourquoi ~8-9 min** dans les deux occurrences observées : non expliqué, non instrumenté.
+- Le core dump du 09:01:41 a été **écrasé par apport** à 09:16:44 (dédup par exécutable) ; l'analyse
+  ci-dessus vient de la copie extraite avant écrasement.
+- L'identification du code fautif est une **correspondance de signature** (idiome `hlt`, séquence
+  d'instructions), corroborée par la description de la PR amont — pas une résolution de symboles :
+  le binaire est strippé, `.dynsym` ne contient que l'entrée nulle, pas de DWARF.
+- Le canal structuré `report()` → `cron_report()` → `__cron_runs` de ce script **n'a jamais émis**
+  (`SUPABASE_URL` absent de l'environnement cron ; `/tmp/.cron_last_sync-dev-runtime` inexistant).
+  Non corrigé ici — hors périmètre, signalé.
+
+## Incident causé pendant l'enquête
+
+La première tentative de reproduction (churn sur 15 watchers `tsc`) a saturé la RAM ; `earlyoom` a
+tué le `tsc --build --watch` du stack réel à 09:16:21 (mémoire dispo 3,22 %), coupant DEV:3000
+environ 2 minutes. Service restauré, vérifié 9/9 × HTTP 200. Les reproductions suivantes ont tourné
+sous garde mémoire explicite, puis sur des tâches triviales sans `tsc`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "squawk-cli": "2.58.0",
-        "turbo": "^2.9.16",
+        "turbo": "^2.10.12",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -11054,9 +11054,9 @@
       "license": "MIT"
     },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.0.tgz",
-      "integrity": "sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.12.tgz",
+      "integrity": "sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==",
       "cpu": [
         "x64"
       ],
@@ -11068,9 +11068,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.0.tgz",
-      "integrity": "sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.12.tgz",
+      "integrity": "sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==",
       "cpu": [
         "arm64"
       ],
@@ -11082,9 +11082,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.0.tgz",
-      "integrity": "sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.12.tgz",
+      "integrity": "sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==",
       "cpu": [
         "x64"
       ],
@@ -11092,13 +11092,14 @@
       "license": "MIT",
       "optional": true,
       "os": [
+        "android",
         "linux"
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.0.tgz",
-      "integrity": "sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.12.tgz",
+      "integrity": "sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==",
       "cpu": [
         "arm64"
       ],
@@ -11106,13 +11107,14 @@
       "license": "MIT",
       "optional": true,
       "os": [
+        "android",
         "linux"
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.0.tgz",
-      "integrity": "sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.12.tgz",
+      "integrity": "sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==",
       "cpu": [
         "x64"
       ],
@@ -11124,9 +11126,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.0.tgz",
-      "integrity": "sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.12.tgz",
+      "integrity": "sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==",
       "cpu": [
         "arm64"
       ],
@@ -31582,21 +31584,21 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.0.tgz",
-      "integrity": "sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.12.tgz",
+      "integrity": "sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.10.0",
-        "@turbo/darwin-arm64": "2.10.0",
-        "@turbo/linux-64": "2.10.0",
-        "@turbo/linux-arm64": "2.10.0",
-        "@turbo/windows-64": "2.10.0",
-        "@turbo/windows-arm64": "2.10.0"
+        "@turbo/darwin-64": "2.10.12",
+        "@turbo/darwin-arm64": "2.10.12",
+        "@turbo/linux-64": "2.10.12",
+        "@turbo/linux-arm64": "2.10.12",
+        "@turbo/windows-64": "2.10.12",
+        "@turbo/windows-arm64": "2.10.12"
       }
     },
     "node_modules/tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "squawk-cli": "2.58.0",
-    "turbo": "^2.9.16",
+    "turbo": "^2.10.12",
     "typescript": "6.0.3"
   },
   "dependencies": {

--- a/scripts/ops/sync-dev-runtime.sh
+++ b/scripts/ops/sync-dev-runtime.sh
@@ -88,6 +88,106 @@ check_workspace_integrity() {
   return "$drift"
 }
 
+# ---------------------------------------------------------------------------
+# Sonde de topologie runtime — 6e axe de dérive.
+#
+# POURQUOI ELLE EXISTE : le 2026-09-09 09:01:41, `turbo dev` (superviseur du
+# stack DEV) est mort en SIGSEGV. Ses tâches persistantes ont survécu,
+# reparentées à PID 1, et `:3000` a continué de répondre 200. Résultat : plus
+# aucun superviseur, mais TOUS les signaux existants restaient au vert. La
+# cause du crash est un bug amont (turbo 2.10.0, cf. audit) — ce que cette
+# sonde corrige, c'est le SILENCE, qui lui est local.
+#
+# CE QU'ELLE AJOUTE que /health ne peut pas voir : /health interroge le
+# processus backend, pas la chaîne qui le supervise. Un superviseur mort avec
+# enfants orphelins rend exactement le même 200 qu'un stack sain. Le seul
+# signal qui distingue les deux est TOPOLOGIQUE (qui est le parent), pas HTTP.
+#
+# POURQUOI AVANT LES GARDES GIT (1 et 2) : la mort du superviseur est un fait
+# runtime, sans rapport avec l'état git. Les gardes branche/working-tree font
+# `abort` ; placée après elles, la sonde ne verrait jamais un incident survenu
+# pendant qu'une branche feature ou un fichier modifié traîne dans le checkout.
+# C'est précisément l'état du 2026-09-09 (branche feature + turbo.json modifié)
+# : le cron abortait à l'étape 1 et n'a rien probé pendant ~10 h.
+#
+# ALERT-ONLY, JAMAIS `abort` : un abort ici stopperait les axes de resync git
+# qui gardent DEV:3000 frais — on transformerait un incident d'observabilité en
+# panne de synchronisation.
+check_dev_runtime_topology() {
+  local drift=0 stamp="/tmp/.${LOG_TAG}-topology-stamp"
+
+  # (a) Santé HTTP à CHAQUE tick. L'unique appel à $HEALTH_URL du script vit
+  #     dans l'étape 8, atteignable seulement sur le chemin de resync : quand
+  #     HEAD == origin/main (le cas nominal) le script sortait sans avoir rien
+  #     probé du runtime.
+  #     Debounce volontaire (3 essais / 5 s) : nodemon coupe :3000 quelques
+  #     secondes à chaque rebuild tsc. Sans ça le cron alerterait sur une
+  #     fenêtre de redémarrage normale, et une alerte qui crie faux finit
+  #     ignorée — exactement le mode de panne qu'on cherche à supprimer.
+  local up=0 i
+  for i in 1 2 3; do
+    if curl -sf --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then up=1; break; fi
+    [ "$i" -lt 3 ] && sleep 5
+  done
+  if [ "$up" != "1" ]; then
+    alert "DEV:3000 ne répond pas après 3 essais ($HEALTH_URL) — runtime DOWN"
+    drift=1
+  fi
+
+  # (b) Superviseur mort, enfants orphelins. Signature exacte de l'incident :
+  #     une racine de stack dev reparentée à PID 1. Dans un stack sain la
+  #     racine a un parent shell/tmux/VS Code, jamais init. On restreint au
+  #     cwd du repo pour ne pas compter un autre projet de la machine.
+  local orphans=() pid ppid cwd cmd
+  while read -r pid ppid cmd; do
+    [ "$ppid" = "1" ] || continue
+    case "$cmd" in *"npm run dev"*|*"turbo dev"*) ;; *) continue ;; esac
+    cwd=$(readlink -f "/proc/$pid/cwd" 2>/dev/null) || continue
+    case "$cwd" in "$APP_DIR"*) orphans+=("$pid") ;; esac
+  done < <(ps -eo pid=,ppid=,args= 2>/dev/null)
+  if [ "${#orphans[@]}" -gt 0 ]; then
+    alert "superviseur dev MORT — ${#orphans[@]} racine(s) orpheline(s) reparentée(s) à PID 1 (pids: ${orphans[*]}). Le stack tourne sans superviseur : /health reste vert mais plus rien ne surveille les watchers. Cf. turbo 2.10.0 SIGSEGV au shutdown."
+    drift=1
+  fi
+
+  # (c) Stacks dev concurrents. Après le crash du 2026-09-09, deux arbres
+  #     `npm run dev` tournaient en parallèle sur le même backend/dist : deux
+  #     tsc écrivant le même dist, deux nodemon le surveillant. État instable
+  #     qu'aucun signal existant ne rendait visible.
+  local all_roots
+  all_roots=$(pgrep -c -f '^npm run dev$' 2>/dev/null || true)
+  if [ "${all_roots:-0}" -gt 1 ]; then
+    alert "stacks dev CONCURRENTS : $all_roots racines \`npm run dev\` simultanées — elles se disputent backend/dist (tsc + nodemon en double). Une seule doit tourner."
+    drift=1
+  fi
+
+  # (d) Crash dumps frais imputables au repo. La machine écrit déjà des dumps
+  #     apport dans /var/crash ; personne ne les lit jamais (aucun script du
+  #     repo ne référence /var/crash — vérifié). On ne lit PAS le contenu des
+  #     dumps (pas de privilège requis) : uniquement nom + mtime.
+  if [ -d /var/crash ]; then
+    local newdumps
+    if [ -f "$stamp" ]; then
+      newdumps=$(find /var/crash -maxdepth 1 -name '*.crash' -newer "$stamp" 2>/dev/null \
+                 | grep -E 'automecanik|turbo|node' || true)
+    else
+      newdumps=$(find /var/crash -maxdepth 1 -name '*.crash' -mmin -15 2>/dev/null \
+                 | grep -E 'automecanik|turbo|node' || true)
+    fi
+    if [ -n "$newdumps" ]; then
+      alert "crash dump(s) frais dans /var/crash : $(echo "$newdumps" | tr '\n' ' ')— un process du stack a crashé (SIGSEGV/SIGBUS). Inspecter avec: grep -a '^Signal\|^ProcCmdline' <fichier>"
+      drift=1
+    fi
+  fi
+  touch "$stamp" 2>/dev/null || true
+
+  return "$drift"
+}
+
+# 0. Sonde de topologie runtime (6e axe) — AVANT les gardes git, alert-only.
+#    Voir l'en-tête de check_dev_runtime_topology pour le « pourquoi avant ».
+check_dev_runtime_topology || true
+
 # 1. Garde branche : le checkout runtime DOIT rester sur main (features = worktrees).
 branch=$(git rev-parse --abbrev-ref HEAD)
 [ "$branch" = "main" ] || abort "checkout sur '$branch' (pas main) — resync refusée (cf. convention worktree)"


### PR DESCRIPTION
## Le symptôme

Le 2026-09-09 09:01:41, `turbo dev` est mort en **SIGSEGV**. Ses tâches persistantes ont survécu,
**reparentées à PID 1**, et `:3000` a continué de répondre `200`. Plus aucun superviseur — et tous
les signaux existants au vert. C'est l'incident silencieux.

Deux défauts empilés, traités séparément.

---

## 1 — Le crash : bug amont turbo 2.10.0

### Mesure AVANT

```
$ sudo grep -a "Sep  9 09:01" /var/log/kern.log
traps: tokio-rt-worker[499388] general protection fault ip:7f9a37ed1d5e sp:7f9a34eb7030 error:0
tokio-rt-worker[499393]: segfault at 7f0030bbc815 ip 00007f9a37ec2816 sp ... in turbo[7f9a360a8000+1e31000]
```

**Pas un OOM** — `earlyoom` mesurait 66–74 % de mémoire *disponible* sur toute la fenêtre :

```
09:00:58 mem avail: 10346 of 15604 MiB (66.31%)
09:01:58 mem avail: 11557 of 15604 MiB (74.06%)
```

Orphelins + `/health` vert *simultanément* :

```
$ ps -eo pid,ppid,etime,cmd | awk '$2==1'
 499482       1  13:38 npm run dev
$ curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/health
200
```

Sans gdb (non installé), désassemblage aux deux offsets — le fault 2 est **littéralement un piège
compilé** :

```
 1f37d57: cmpb $0x0,0x0(%r13)
 1f37d5c: je   0x1f37d5f
 1f37d5e: f4   hlt          <-- `hlt` en ring 3 => #GP
```

Le fault 1 déréférence `0x7f0030bbc815`, qui ne correspond à **aucun mapping** du processus.
L'allocateur durci a détecté une corruption de tas et s'est arrêté net.

### Cause racine — le chemin d'ARRÊT, reproduit

| test | résultat |
|---|---|
| 4 tâches persistantes + SIGTERM | **SIGSEGV 5/6** |
| 4 tâches persistantes + SIGINT (Ctrl+C) | **SIGSEGV 3/3** |

Seuil sur le nombre de tâches persistantes (SIGTERM, 3 essais) :

| tâches | 1 | 2 | 3 | 4 |
|---|---|---|---|---|
| crashes | 0/3 | 0/3 | **2/3** | **3/3** |

Les adresses reproduites retombent **sur les mêmes instructions** que l'incident.

### `concurrency: "12"` (PR #1421) n'est pas la cause — contrôle explicite

Même test, `turbo.json` **sans aucune clé `concurrency`** :

```
CONTROL default-concurrency, 4 persistent tasks: crashes 3/3   exit codes: 135 139 139
```

Le crash se reproduit sans le réglage. #1421 ne l'introduit pas ; elle le rend **atteignable**, en
permettant à `turbo dev` de démarrer (11 tâches persistantes > plafond par défaut 10). Ni régression
de #1421, ni exonération gratuite : les deux affirmations sont mesurées.

### Amont

- issue **vercel/turborepo#13254** — « segfault after Ctrl-C on 2.10 (but not on 2.9.18) »
- PR **#13256** — « Avoid non-reentrant libc calls in concurrent shutdown process scans »
- régression via PR **#13100**, livrée dans **v2.10.0** (la version installée)

Première release corrigée, vérifiée par compare de tags :

```
compare/v2.10.3...bf2d8273 -> diverged   (absent)
compare/v2.10.4...bf2d8273 -> behind     (présent)
```

### Preuve APRÈS — A/B, seul le binaire change

```
turbo 2.10.0 (installed)           crashes=4/4   exit codes: 139 139 139 135
turbo 2.10.12 (fixed, >=2.10.4)    crashes=0/4   exit codes: 0 0 0 0
```

→ `package.json` : `"turbo": "^2.9.16"` → `"^2.10.12"` (lockfile mis à jour en `--package-lock-only`).

---

## 2 — Le silence : le vrai défaut local

Il **survivrait au bump** : la prochaine mort de superviseur, quelle qu'en soit la cause, serait
tout aussi invisible.

`sync-dev-runtime.sh` ne pouvait pas la voir *par construction* :

1. son unique appel à `$HEALTH_URL` vit dans l'étape 8, **atteignable seulement sur le chemin de
   resync** — quand `HEAD == origin/main` (cas nominal) le script sortait sans rien sonder ;
2. même atteint, il n'aurait rien vu : un superviseur mort avec enfants orphelins rend **le même
   200** qu'un stack sain. Le seul signal qui les distingue est **topologique** ;
3. les gardes branche et working-tree font `abort` **avant** tout le reste — les deux étaient
   déclenchées pendant l'incident, donc le cron n'a rien probé pendant des heures.

### La 6e sonde

`check_dev_runtime_topology()`, modelée sur `check_workspace_integrity()` existante — **pas** de
nouveau script, pas d'unité systemd, pas de second cron.

| contrôle | ce qu'il attrape |
|---|---|
| `/health`, 3 essais / 5 s | runtime mort, sur **chaque** tick. Debounce contre les fenêtres de rebuild nodemon |
| racine dev reparentée à **PID 1** | **la signature exacte de l'incident**, insensible à la cause |
| plusieurs racines `npm run dev` | deux arbres concurrents sur le même `backend/dist` (état observé après le crash) |
| dumps frais dans `/var/crash` | la machine en écrit déjà ; **aucun script du repo ne les lisait** |

Deux choix structurels, tous deux délibérés :

- **placée avant les gardes git** — un incident runtime est indépendant de l'état git ; derrière
  les gardes, elle n'aurait rien vu le 2026-09-09 ;
- **`alert`-only, jamais `abort`** — un abort couperait les axes de resync qui gardent DEV:3000 frais,
  transformant un défaut d'observabilité en panne de synchronisation.

### Preuve APRÈS

Vrai positif sur un `:3000` réellement tombé (vérifié indépendamment : rien en écoute) :

```
ALERT> DEV:3000 ne répond pas après 3 essais (http://localhost:3000/health) — runtime DOWN
-> return=1  alerts=1
```

Détection d'un orphelin reproduisant la signature observée :

```
pid=625425 ppid=1 cwd=<APP_DIR> :: npm run dev
ALERT> superviseur dev MORT — 1 racine(s) orpheline(s) reparentée(s) à PID 1 (pids: 625425).
-> return=1  alerts=1
```

Le stack sain du repo, hors `APP_DIR` du test, **n'est pas remonté** — le filtrage par `cwd` marche.

---

## Non-vérifié, assumé

- **Ce qui a déclenché l'arrêt à 09:01:41 n'est pas déterminé.** Ctrl+C, fermeture de terminal et
  fin de tâche persistante mènent au même chemin ; aucune trace ne dit lequel. Je ne le déduis pas.
- **Pourquoi ~8-9 min** dans les deux occurrences : non expliqué, non instrumenté.
- L'identification du code fautif est une **correspondance de signature**, corroborée par la PR
  amont — pas une résolution de symboles (binaire strippé, pas de DWARF).
- Le canal structuré `report()` → `__cron_runs` de ce script **n'a jamais émis** (`SUPABASE_URL`
  absent de l'env cron). Signalé, **non corrigé ici** — hors périmètre.

## Incident causé pendant l'enquête

La première tentative de reproduction a saturé la RAM ; `earlyoom` a tué le `tsc --build --watch`
du stack réel à 09:16:21, coupant DEV:3000 ~2 min. Service restauré et vérifié (9/9 × HTTP 200).
Les reproductions suivantes ont tourné sous garde mémoire explicite, puis sur des tâches triviales.

Détail complet : `audit/turbo-dev-sigsegv-shutdown-2026-09-09.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)