### PR TITLE
fix(search): ne plus signaler en ERROR l'absence attendue de Meilisearch

### DIFF
--- a/audit/meilisearch-expected-off-log-requalification-2026-09-09.md
+++ b/audit/meilisearch-expected-off-log-requalification-2026-09-09.md
@@ -1,0 +1,97 @@
+# Meilisearch sur DEV : non-problème de service, vrai défaut de classification de log
+
+_2026-09-09 · machine DEV_
+
+## Verdict
+
+**Meilisearch éteint sur DEV est ATTENDU** — ce n'est pas une panne. Le défaut réel est que cette
+condition normale était signalée en **ERROR à chaque boot, deux fois**, par deux services distincts.
+
+## Mesure — pourquoi « attendu »
+
+Meilisearch n'est démarré par **aucun** compose de déploiement, **aucun** workflow CI, **aucun**
+Dockerfile. Il n'existe que dans un compose opt-in :
+
+```
+$ grep -il "meili" docker-compose.yml docker-compose.dev.yml \
+      docker-compose.preprod.yml docker-compose.prod.yml Dockerfile*
+(aucun résultat)
+$ grep -rl "meili" .github/workflows/
+(aucun résultat)
+$ grep -rln "meili" --include="docker-compose*.yml" .
+./docker-compose.meilisearch.yml      <-- opt-in, lancé à la main
+./docker-compose.vector.yml
+```
+
+Et aucune variable n'est renseignée sur DEV :
+
+```
+$ grep -oE '^[A-Z_]*MEILI[A-Z_]*' backend/.env | sort -u
+(aucun résultat)
+```
+
+Le code, lui, faisait comme si l'absence de configuration était une configuration :
+
+```ts
+host: this.configService.get('MEILISEARCH_HOST') || 'http://localhost:7700'
+```
+
+Ce défaut substitué **détruisait le seul signal** qui distingue « pas déployé sur cet
+environnement » de « déployé mais en panne ». Les deux cas convergeaient vers le même
+`localhost:7700` injoignable, donc vers la même branche d'échec, donc vers le même ERROR.
+
+## Mesure AVANT — le bruit, deux fois par boot
+
+```
+$ grep -aiE "Meilisearch" /tmp/dev-server.log | grep -i ERROR | tail -4
+@fafa/backend:dev: [08:53:02] ERROR: ❌ Erreur init Meilisearch:            (log-ingestion.service.ts:129)
+@fafa/backend:dev: [08:53:02] ❌ Failed to initialize Meilisearch           (meilisearch.service.ts:53)
+```
+
+Un ERROR récurrent pour une condition **normale et non actionnable** apprend à ignorer les ERROR.
+C'est le défaut : pas le service éteint.
+
+## Correction — cause racine, pas le niveau de log
+
+On ne baisse pas la sévérité : on **rétablit la distinction** que le défaut substitué effaçait.
+Lecture de `MEILISEARCH_HOST` **sans défaut** d'abord, pour décider de l'état, puis :
+
+| État | Comportement |
+|---|---|
+| `MEILISEARCH_HOST` **absent** | une ligne **WARN** déclarant la dégradation, sa portée et le remède ; init sautée |
+| `MEILISEARCH_HOST` **présent** mais injoignable | chemin inchangé → **ERROR** (vrai problème, vraie action) |
+
+Ce n'est **pas un repli silencieux** (canon `no-silent-fallback`) : la dégradation est déclarée,
+datée au boot, avec sa conséquence et sa commande de remise en service.
+
+## Preuve APRÈS — services patchés réellement instanciés
+
+```
+=== A. MEILISEARCH_HOST unset — DEV / CI / PREPROD / PROD (expected-off) ===
+  WARN  MEILISEARCH_HOST non défini → indexation/recherche Meilisearch DÉSACTIVÉE sur cet
+        environnement (dégradation assumée). Pour l'activer : `docker compose -f
+        docker-compose.meilisearch.yml up -d` puis renseigner MEILISEARCH_HOST.
+  WARN  MEILISEARCH_HOST non défini → indexation des access logs DÉSACTIVÉE sur cet
+        environnement (dégradation assumée). L'ingestion Loki/Caddy n'est pas affectée.
+
+=== B. MEILISEARCH_HOST set — un opérateur l'a délibérément configuré ===
+  LOG   🚀 Init MeilisearchService — initialisation des index en arrière-plan
+  LOG   🚀 Init LogIngestionService — config Meilisearch en arrière-plan
+```
+
+Zéro ERROR en A ; en B le chemin nominal est **intact**, donc un Meilisearch réellement configuré
+et en panne produit toujours un ERROR. `tsc --noEmit` passe.
+
+## Trouvés en chemin, NON corrigés ici (hors périmètre, signalés pour ne pas les perdre)
+
+1. **`GET /api/pieces/index` renvoie HTTP 200 sur échec.** La route appelle l'indexation
+   Meilisearch ; `pieces.controller.ts` attrape toute exception dans le handler et retourne un
+   objet, si bien que l'échec sort en `200` avec une `TypeError` brute :
+   `{"success":false,"error":"Cannot read properties of undefined (reading 'addDocuments')"}`.
+   Corriger le code HTTP demande de toucher le contrôleur — défaut distinct, PR distincte.
+2. **Contrat d'env incohérent** : `MEILISEARCH_MASTER_KEY` (1 lecteur, `search/`) vs
+   `MEILISEARCH_API_KEY` (plusieurs lecteurs, `seo-logs/`, `seo/`). Deux noms pour la même chose.
+3. **Identifiant par défaut en dur** : `|| 'masterKey123'` subsiste dans `meilisearch.service.ts`.
+   **Volontairement non modifié** : `docker-compose.meilisearch.yml` utilise la même valeur par
+   défaut (`MEILI_MASTER_KEY=${MEILISEARCH_MASTER_KEY:-masterKey123}`), donc la changer casserait
+   le chemin opt-in local. C'est une décision à part, pas un effet de bord de cette PR.

--- a/backend/src/modules/search/services/meilisearch.service.ts
+++ b/backend/src/modules/search/services/meilisearch.service.ts
@@ -15,20 +15,27 @@ interface SearchOptions {
 export class MeilisearchService implements OnModuleInit {
   private readonly logger = new Logger(MeilisearchService.name);
   private client: MeiliSearch;
+  /** Meilisearch est-il déclaré sur cet environnement ? (cf. constructeur) */
+  private readonly configured: boolean;
   private vehicleIndex: Index;
   private productIndex: Index;
 
   constructor(private readonly configService: ConfigService) {
+    // `MEILISEARCH_HOST` absent = Meilisearch n'est pas déployé sur CET
+    // environnement. Il n'est démarré par aucun compose de déploiement, aucun
+    // workflow CI et aucun Dockerfile : il n'existe que dans l'opt-in
+    // `docker-compose.meilisearch.yml`. On lit donc la valeur SANS défaut pour
+    // conserver ce signal — le substituer par `localhost:7700` rendait
+    // « pas déployé ici » indiscernable de « déployé mais en panne », et les
+    // deux finissaient en ERROR à chaque boot.
+    const host = this.configService.get<string>('MEILISEARCH_HOST');
+    this.configured = Boolean(host);
     const masterKey =
       this.configService.get('MEILISEARCH_MASTER_KEY') || 'masterKey123';
     this.client = new MeiliSearch({
-      host:
-        this.configService.get('MEILISEARCH_HOST') || 'http://localhost:7700',
+      host: host ?? 'http://localhost:7700',
       apiKey: masterKey,
     });
-    this.logger.debug(
-      `Meilisearch config: host=${this.configService.get('MEILISEARCH_HOST') || 'http://localhost:7700'}, apiKey=${masterKey ? '***' : 'undefined'}`,
-    );
   }
 
   /**
@@ -39,6 +46,16 @@ export class MeilisearchService implements OnModuleInit {
    * timeout, et bloque `app.listen()` → exit 124 sur /health.
    */
   onModuleInit(): void {
+    if (!this.configured) {
+      // Dégradation DÉCLARÉE, pas un repli silencieux : une ligne au boot qui
+      // dit l'état, la conséquence et le remède. Niveau warn — sur DEV et en CI
+      // c'est la configuration attendue, et un ERROR récurrent pour une
+      // condition normale apprend à ignorer les ERROR.
+      this.logger.warn(
+        'MEILISEARCH_HOST non défini → indexation/recherche Meilisearch DÉSACTIVÉE sur cet environnement (dégradation assumée). Pour l\'activer : `docker compose -f docker-compose.meilisearch.yml up -d` puis renseigner MEILISEARCH_HOST.',
+      );
+      return;
+    }
     this.logger.log(
       '🚀 Init MeilisearchService — initialisation des index en arrière-plan',
     );

--- a/backend/src/modules/seo/services/log-ingestion.service.ts
+++ b/backend/src/modules/seo/services/log-ingestion.service.ts
@@ -58,14 +58,18 @@ export class LogIngestionService implements OnModuleInit {
   private readonly meilisearch: MeiliSearch;
   private readonly lokiUrl: string;
   private readonly caddyLogPath: string;
+  /** Meilisearch est-il déclaré sur cet environnement ? (cf. constructeur) */
+  private readonly meilisearchConfigured: boolean;
 
   constructor(private readonly configService: ConfigService) {
-    // Meilisearch client
+    // Meilisearch client. Lecture SANS défaut d'abord : `MEILISEARCH_HOST`
+    // absent = Meilisearch n'est pas déployé sur cet environnement (aucun
+    // compose de déploiement / CI / Dockerfile ne le démarre). Garder ce signal
+    // est ce qui permet de ne pas confondre « pas déployé ici » et « en panne ».
+    const meiliHost = this.configService.get<string>('MEILISEARCH_HOST');
+    this.meilisearchConfigured = Boolean(meiliHost);
     this.meilisearch = new MeiliSearch({
-      host: this.configService.get<string>(
-        'MEILISEARCH_HOST',
-        'http://localhost:7700',
-      ),
+      host: meiliHost ?? 'http://localhost:7700',
       apiKey: this.configService.get<string>('MEILISEARCH_API_KEY', ''),
     });
 
@@ -89,6 +93,14 @@ export class LogIngestionService implements OnModuleInit {
    * `localhost:7700` qui bloque `app.listen()` → exit 124 sur /health.
    */
   onModuleInit(): void {
+    if (!this.meilisearchConfigured) {
+      // Même contrat que MeilisearchService : dégradation déclarée, une ligne,
+      // niveau warn. C'était le SECOND ERROR au boot pour la même cause.
+      this.logger.warn(
+        'MEILISEARCH_HOST non défini → indexation des access logs DÉSACTIVÉE sur cet environnement (dégradation assumée). L\'ingestion Loki/Caddy n\'est pas affectée.',
+      );
+      return;
+    }
     this.logger.log(
       '🚀 Init LogIngestionService — config Meilisearch en arrière-plan',
     );


### PR DESCRIPTION
## Verdict : non-problème de service, vrai défaut de classification

**Meilisearch éteint sur DEV est ATTENDU.** Le défaut est que cette condition normale sortait en
**ERROR à chaque boot, deux fois**, depuis deux services distincts.

## Mesure — pourquoi « attendu »

```
$ grep -il "meili" docker-compose.yml docker-compose.dev.yml \
      docker-compose.preprod.yml docker-compose.prod.yml Dockerfile*
(aucun résultat)
$ grep -rl "meili" .github/workflows/
(aucun résultat)
$ grep -rln "meili" --include="docker-compose*.yml" .
./docker-compose.meilisearch.yml      <-- opt-in, lancé à la main
$ grep -oE '^[A-Z_]*MEILI[A-Z_]*' backend/.env | sort -u
(aucun résultat)
```

Aucun compose de déploiement, aucun CI, aucun Dockerfile ne le démarre. Aucune variable renseignée.

## Mesure AVANT — le bruit

```
$ grep -aiE "Meilisearch" /tmp/dev-server.log | grep -i ERROR | tail -4
@fafa/backend:dev: [08:53:02] ERROR: ❌ Erreur init Meilisearch:       (log-ingestion.service.ts:129)
@fafa/backend:dev: [08:53:02] ❌ Failed to initialize Meilisearch      (meilisearch.service.ts:53)
```

## Cause racine — pas le niveau de log, un défaut substitué

```ts
host: this.configService.get('MEILISEARCH_HOST') || 'http://localhost:7700'
```

Ce défaut **détruisait le seul signal** distinguant « pas déployé sur cet environnement » de
« déployé mais en panne » : les deux convergeaient vers le même `localhost:7700` injoignable, donc
la même branche d'échec, donc le même ERROR. Un ERROR récurrent pour une condition **normale et
non actionnable** apprend à ignorer les ERROR — c'est ça, le défaut.

## Correction

Lire `MEILISEARCH_HOST` **sans défaut** d'abord, pour décider de l'état :

| État | Comportement |
|---|---|
| **absent** | une ligne **WARN** déclarant la dégradation, sa portée et le remède ; init sautée |
| **présent** mais injoignable | chemin **inchangé** → **ERROR** (vrai problème, vraie action) |

Pas un repli silencieux (canon `no-silent-fallback`) : la dégradation est **déclarée** au boot, avec
sa conséquence et sa commande de remise en service.

## Preuve APRÈS — services patchés réellement instanciés

```
=== A. MEILISEARCH_HOST unset — DEV / CI / PREPROD / PROD (expected-off) ===
  WARN  MEILISEARCH_HOST non défini → indexation/recherche Meilisearch DÉSACTIVÉE sur cet
        environnement (dégradation assumée). Pour l'activer : `docker compose -f
        docker-compose.meilisearch.yml up -d` puis renseigner MEILISEARCH_HOST.
  WARN  MEILISEARCH_HOST non défini → indexation des access logs DÉSACTIVÉE sur cet
        environnement (dégradation assumée). L'ingestion Loki/Caddy n'est pas affectée.

=== B. MEILISEARCH_HOST set — un opérateur l'a délibérément configuré ===
  LOG   🚀 Init MeilisearchService — initialisation des index en arrière-plan
  LOG   🚀 Init LogIngestionService — config Meilisearch en arrière-plan
```

Zéro ERROR en A ; en B le chemin nominal est **intact**. `tsc --noEmit` passe.

## Trouvés en chemin, NON corrigés ici (signalés pour ne pas les perdre)

1. **`GET /api/pieces/index` renvoie HTTP 200 sur échec** — `pieces.controller.ts` attrape toute
   exception dans le handler, donc l'échec sort en `200` avec une `TypeError` brute :
   `{"success":false,"error":"Cannot read properties of undefined (reading 'addDocuments')"}`.
   Corriger le code HTTP demande de toucher le contrôleur : défaut distinct, PR distincte.
2. **Contrat d'env incohérent** : `MEILISEARCH_MASTER_KEY` (1 lecteur) vs `MEILISEARCH_API_KEY`
   (plusieurs) nomment la même chose.
3. **`|| 'masterKey123'` laissé tel quel** — `docker-compose.meilisearch.yml` s'aligne sur la même
   valeur par défaut, le changer casserait le chemin opt-in local. Décision à part, pas un effet
   de bord de cette PR.

Détail : `audit/meilisearch-expected-off-log-requalification-2026-09-09.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)