### PR TITLE
fix(caddy): ne plus propager le Set-Cookie Supabase sur /img/* (BYPASS CDN permanent)

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -120,6 +120,10 @@ automecanik.com, www.automecanik.com {
         reverse_proxy https://cxpojprgwgubzjyqzmoq.supabase.co {
             header_up Host cxpojprgwgubzjyqzmoq.supabase.co
             header_down -Cache-Control
+            # Supabase renvoie `__cf_bm; Domain=supabase.co` — cookie que le
+            # navigateur rejette (mauvais domaine) et qui fait refuser le cache
+            # a Cloudflare : cf-cache-status BYPASS sur des images immutable 1 an.
+            header_down -Set-Cookie
         }
     }
 


### PR DESCRIPTION
## Symptôme

Toutes les images servies par `/img/*` sont en `cf-cache-status: BYPASS` — **jamais** mises en cache par Cloudflare, alors qu'elles portent `Cache-Control: public, max-age=31536000, immutable`. Chaque visiteur, à chaque page vue, va rechercher les mêmes images à l'origine.

Mesuré sur la page d'accueil PROD (Playwright, cache navigateur froid) : **9 des 13 requêtes atteignant l'origine sont ces images**.

## Cause

Le handler `@img_proxy` proxifie Supabase Storage et retire `Cache-Control`, mais **pas `Set-Cookie`**. La réponse repart donc avec :

```
set-cookie: __cf_bm=…; HttpOnly; SameSite=None; Secure; Path=/; Domain=supabase.co
```

C'est le cookie bot-management du Cloudflare **de Supabase**. Deux conséquences :

1. Le navigateur le **rejette** de toute façon — `Domain=supabase.co` ne correspond pas à `www.automecanik.com`. Il n'a donc aucune utilité fonctionnelle.
2. Cloudflare refuse de mettre en cache une réponse porteuse d'un `Set-Cookie` → `BYPASS` permanent.

## Preuve — A/B sur la MÊME image, en live sur PROD

| URL | Cache-Control | Set-Cookie | `cf-cache-status` |
|---|---|---|---|
| `/img/uploads/articles/familles-produits/Freinage.webp` | `immutable, 1 an` | oui (Supabase) | **BYPASS** — jamais caché |
| `/imgproxy/…/Freinage.webp` | `immutable, 1 an` | non | **MISS** — cacheable |

`/imgproxy/*` passe par le container imgproxy local, qui fait lui-même le fetch vers Supabase : le cookie ne traverse pas. Même politique de cache, comportement CDN opposé — le `Set-Cookie` est la seule variable.

Aucune Cache Rule Cloudflare n'est nécessaire : l'extension `.webp` est cacheable par défaut, ce que démontre justement le `MISS` de `/imgproxy/`. Ce changement n'entre donc pas dans le périmètre owner-gated de la PR C du cutover cache (`audit/cache-cutover-design-A-B-C-2026-07-14.md`), qui concerne le HTML.

## Ce que ça corrige

- Le document de conception du cutover cache pose déjà l'invariant : *« aucune réponse mise en cache ne doit contenir un `Set-Cookie` propagé »*. Cette surface non-HTML n'était pas couverte ; elle le devient.
- Charge origine et egress Supabase : les images cessent d'être rechargées à chaque visite.
- LCP : les images de familles produits de l'accueil deviennent servies par l'edge.

## Vérifications

- `caddy adapt --config … --adapter caddyfile` (image `caddy:2.11-alpine`, celle épinglée en prod) → **exit 0, zéro erreur**, et `"Set-Cookie"` présent dans le JSON compilé.
- Diff : 1 fichier, 4 lignes ajoutées, aucune autre directive touchée.
- Risque fonctionnel nul : le cookie supprimé est déjà rejeté par le navigateur (mauvais domaine).

## Vérification post-déploiement (après le tag qui l'embarque)

```bash
U="https://www.automecanik.com/img/uploads/articles/familles-produits/Freinage.webp"
curl -sI "$U" | grep -i -E 'cf-cache-status|set-cookie'   # attendu : MISS, plus aucun set-cookie
curl -sI "$U" | grep -i cf-cache-status                   # attendu : HIT
```

Tant que la réponse dit `BYPASS`, la correction n'est pas active.

## Déploiement

`deploy-prod.yml:211` copie `config/caddy/Caddyfile` sur la machine et redémarre le service `caddy` : ce changement part avec le prochain tag `v*`, sans intervention SSH.

## Rollback

Revert de la PR puis nouveau tag. Aucun effet de bord persistant : la directive ne touche qu'un en-tête de réponse, rien n'est écrit nulle part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)