### PR TITLE
fix(ops): durcir les permissions des `.env` et détecter la récidive (umask 0002)

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -40,6 +40,12 @@ feature (sinon DEV:3000 sert du code périmé).
    `MODULE_NOT_FOUND` (incident 2026-05-25 : `@repo/domain-commerce` + `@repo/cwv-taxonomy`).
    Détection `check_workspace_integrity()` ; install/build = action manuelle owner-gated
    (mutation `package-lock.json`, comme l'axe 4). (alerte)
+7. **Permissions des `.env`** : tout `.env*` non suivi par git doit être en `600`. L'umask de la
+   machine est `0002` (pam_umask + `login.defs UMASK 022` + `USERGROUPS_ENAB yes` + groupe primaire
+   `deploy`), donc un `chmod` seul ne tient pas — le 664 se recrée. Détection
+   `check_env_file_permissions()`, **alert-only et sans chmod automatique** (un correctif auto
+   masquerait ce qui recrée le 664 ; et le fichier de clés Paybox est en zone paiement, jamais
+   touché par ce script). Détail : `audit/env-file-permissions-2026-09-09.md`. (alerte)
 
 ## Mécanique du tag Docker `:preprod` (alias flottant)
 

--- a/audit/env-file-permissions-2026-09-09.md
+++ b/audit/env-file-permissions-2026-09-09.md
@@ -1,0 +1,145 @@
+# Fichiers `.env` en 664 — la cause n'est pas le mode, c'est l'umask
+
+_2026-09-09 · machine DEV_
+
+## Mesure AVANT
+
+Les **9** fichiers d'environnement porteurs de secrets (non suivis par git) étaient en `664`,
+c'est-à-dire lisibles par tout compte local :
+
+```
+MODE   GIT       PATH                                    KEYS
+664    untracked backend/.env                            119
+664    untracked backend/.env.backup-20251104-174224      34
+664    untracked backend/.env.paybox-test-keys             6
+664    untracked backend/.env.production                  34
+664    untracked backend/.env.supabase.timeout             4
+664    untracked backend/.env.test                        34
+664    untracked config/vector/.env.vector                 7
+664    untracked .env                                      3
+664    untracked .env.vps                                 27
+664    untracked frontend/.env                             6
+```
+
+Les fichiers **suivis** (`*.example`, `*.template`) sont aussi en 664 — c'est voulu, ils sont publics.
+
+### Sévérité réelle, mesurée et non extrapolée
+
+La chaîne de répertoires est traversable par tous :
+
+```
+drwxr-xr-x root:root      /opt
+drwxr-xr-x deploy:deploy  /opt/automecanik/app
+drwxrwxr-x deploy:deploy  /opt/automecanik/app/backend
+```
+
+Donc `664` expose bien réellement. **Mais** `deploy` est le seul compte humain, et le groupe
+`deploy` n'a aucun autre membre :
+
+```
+$ awk -F: '$3>=1000 && $3<65534 {print $1}' /etc/passwd   ->  deploy
+$ getent group deploy                                     ->  deploy:x:1001:      (liste vide)
+```
+
+Risque pratique aujourd'hui : **faible**. Risque réel : un futur compte de service, ou n'importe
+quel processus non privilégié compromis, lit des identifiants de production vivants.
+
+## Cause racine — pourquoi `chmod` seul ne suffit pas
+
+L'umask de la machine est `0002`, y compris sur les processus longs :
+
+```
+$ umask                                   -> 0002
+$ grep Umask /proc/<backend pid>/status   -> Umask: 0002
+```
+
+Il ne vient d'aucun fichier de login (`/etc/profile`, `~/.bashrc`, `~/.profile` : rien, seulement
+un `#umask 022` **commenté**). Il vient de PAM :
+
+```
+/etc/pam.d/common-session:26   session optional  pam_umask.so
+/etc/login.defs:151            UMASK           022
+/etc/login.defs:230            USERGROUPS_ENAB yes
+$ id -gn deploy                -> deploy          (groupe primaire = nom d'utilisateur)
+```
+
+Règle `pam_umask` : si l'utilisateur n'est pas root **et** que son groupe primaire porte son nom,
+les bits groupe de l'umask sont alignés sur ceux du propriétaire — `022` devient `002`. D'où
+`0666 & ~002 = 0664`, exactement le mode observé sur **tous** les fichiers.
+
+**Conséquence : un `chmod 600` est un correctif de symptôme.** Le prochain `cp`, la prochaine
+sauvegarde d'éditeur, le prochain script qui réécrit un `.env` recrée du 664.
+
+## Correction appliquée
+
+**1. Modes (fait, sur la machine)** — `chmod 600` sur les **8** fichiers hors zone paiement :
+
+```
+backend/.env  backend/.env.production  backend/.env.test  backend/.env.supabase.timeout
+backend/.env.backup-20251104-174224  config/vector/.env.vector  .env  .env.vps  frontend/.env
+```
+
+`backend/.env.paybox-test-keys` **délibérément laissé en 664** — zone paiement, accord owner requis
+(invariant 9). Mesuré, non modifié.
+
+Contrôle de non-régression : tout tourne sous `deploy`, propriétaire des fichiers, donc `600`
+n'enlève l'accès à personne. Vérifié :
+
+```
+$ node -e "fs.readFileSync('/opt/automecanik/app/backend/.env','utf8')"
+  read OK, 296 lines — 600 does NOT block the owner
+$ docker inspect (tous les conteneurs) | grep automecanik/app
+  aucun bind-mount du repo -> aucun autre uid n'a besoin de ces fichiers
+```
+
+**2. Récidive (fait, dans le dépôt)** — 7e axe `check_env_file_permissions()` dans
+`scripts/ops/sync-dev-runtime.sh` (cron 10 min), qui détecte tout `.env` non suivi dont le mode
+n'est pas `600`.
+
+Deux choix délibérés :
+
+- **Aucun `chmod` automatique.** Un correctif auto masquerait *ce qui* recrée du 664, donc la cause.
+  Et le script ne doit jamais toucher au fichier Paybox, même « pour améliorer ses droits ».
+- **Périmètre = fichiers non suivis par git uniquement.** Les `*.example` / `*.template` suivis
+  restent en 664 : les passer en 600 casserait l'arbre suivi pour rien.
+
+**3. Umask système — NON fait, décision owner.** Le seul levier correct est
+`/etc/login.defs:151 UMASK 022 -> 027` (la règle usergroups donnerait alors `007`). Rayon d'action :
+**tout ce que la machine écrit**, pas seulement les `.env` — arbre de build npm/turbo inclus.
+Disproportionné pour ce défaut, et hors périmètre. Le 7e axe couvre le besoin sans y toucher.
+
+## Preuve APRÈS
+
+Le garde, exécuté sur l'arbre réel après le `chmod`, ne signale **que** le fichier volontairement
+laissé :
+
+```
+ALERT> fichiers d'environnement trop permissifs (attendu 600) : backend/.env.paybox-test-keys:664
+       — corriger: chmod 600 <fichier>. Cause récurrente = umask 0002 (...).
+       NE PAS chmod backend/.env.paybox-test-keys sans accord owner (zone paiement).
+-> return=1  alerts=1
+```
+
+Contrôle — on desserre un fichier hors zone paiement, le garde l'attrape :
+
+```
+$ chmod 664 frontend/.env
+ALERT> ... : backend/.env.paybox-test-keys:664 frontend/.env:664
+$ chmod 600 frontend/.env     (restauré)
+```
+
+## Ce qui reste à l'owner
+
+1. **`chmod 600 backend/.env.paybox-test-keys`** — zone paiement, accord nominatif requis.
+2. **Supprimer `backend/.env.backup-20251104-174224`.** Copie de 2026-01-30 qui porte l'intégralité
+   des identifiants de paiement de production (noms de clés vérifiés, valeurs jamais affichées),
+   plus `SESSION_SECRET` et `SUPABASE_SERVICE_ROLE_KEY`. Un doublon périmé de secrets vivants n'a
+   pas de raison d'exister. Non supprimé ici : zone paiement, et le fichier est non suivi — aucune
+   récupération possible depuis git.
+
+## Trouvé en chemin — beaucoup plus grave, traité séparément
+
+`backend/.env.test.template` est **suivi par git, présent dans `origin/main`, dans un dépôt
+GitHub PUBLIC**, et contient **9 secrets byte-identiques à des valeurs vivantes** (comparaison
+SHA-256, valeurs jamais affichées). Le mode 664 est un défaut local ; **ceci est une publication**.
+Zone paiement, rotation = action owner. Aucune modification faite.

--- a/scripts/ops/sync-dev-runtime.sh
+++ b/scripts/ops/sync-dev-runtime.sh
@@ -88,6 +88,59 @@ check_workspace_integrity() {
   return "$drift"
 }
 
+# 7e axe de dérive — PERMISSIONS DES FICHIERS D'ENVIRONNEMENT.
+#
+# POURQUOI : tous les `.env*` porteurs de secrets étaient en 664 (lisibles par
+# tout compte local). Le `chmod 600` seul ne tient pas : l'umask de la machine
+# est 0002 et RECRÉE du 664 au prochain `cp`, à la prochaine sauvegarde d'éditeur,
+# au prochain script qui réécrit un `.env`. Chaîne mesurée :
+#   pam_umask (common-session) + /etc/login.defs UMASK 022 + USERGROUPS_ENAB yes
+#   + groupe primaire de `deploy` nommé `deploy`  =>  022 devient 002  =>  0664.
+# Corriger l'umask système (login.defs 022 -> 027) a un rayon d'action bien plus
+# large que les .env (tout ce que la box écrit) : c'est une décision owner. En
+# attendant, on DÉTECTE la récidive à chaque tick plutôt que de la subir.
+#
+# ALERT-ONLY, ET AUCUN `chmod` AUTOMATIQUE — délibéré :
+#   - un chmod auto masquerait ce qui recrée du 664, donc la cause ;
+#   - `backend/.env.paybox-test-keys` est en zone paiement (invariant 9 STOP) :
+#     ce script ne doit jamais y toucher, même pour "améliorer" ses droits.
+# Périmètre : uniquement les fichiers NON suivis par git (= ceux qui portent de
+# vrais secrets). Les `*.example` / `*.template` suivis restent en 664, c'est
+# voulu : ils sont publics.
+check_env_file_permissions() {
+  local drift=0 f mode
+  local files=(
+    backend/.env
+    backend/.env.production
+    backend/.env.test
+    backend/.env.supabase.timeout
+    backend/.env.backup-20251104-174224
+    backend/.env.paybox-test-keys
+    config/vector/.env.vector
+    frontend/.env
+    .env
+    .env.vps
+  )
+  local loose=()
+  for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    # Un fichier suivi par git n'est pas un porteur de secret : on l'ignore.
+    git ls-files --error-unmatch "$f" >/dev/null 2>&1 && continue
+    mode=$(stat -c '%a' "$f" 2>/dev/null) || continue
+    [ "$mode" = "600" ] && continue
+    loose+=("$f:$mode")
+  done
+  if [ "${#loose[@]}" -gt 0 ]; then
+    alert "fichiers d'environnement trop permissifs (attendu 600) : ${loose[*]} — corriger: chmod 600 <fichier>. Cause récurrente = umask 0002 (pam_umask + login.defs UMASK 022 + USERGROUPS_ENAB yes). NE PAS chmod backend/.env.paybox-test-keys sans accord owner (zone paiement)."
+    drift=1
+  fi
+  return "$drift"
+}
+
+# 0b. Permissions des fichiers d'environnement (7e axe) — avant les gardes git,
+#     alert-only : un secret lisible par tous ne dépend pas de l'état du dépôt.
+check_env_file_permissions || true
+
 # 1. Garde branche : le checkout runtime DOIT rester sur main (features = worktrees).
 branch=$(git rev-parse --abbrev-ref HEAD)
 [ "$branch" = "main" ] || abort "checkout sur '$branch' (pas main) — resync refusée (cf. convention worktree)"


### PR DESCRIPTION
## Mesure AVANT

Les **9** fichiers d'environnement porteurs de secrets (non suivis par git) étaient en `664` :

```
MODE   GIT       PATH                                    KEYS
664    untracked backend/.env                            119
664    untracked backend/.env.backup-20251104-174224      34
664    untracked backend/.env.paybox-test-keys             6
664    untracked backend/.env.production                  34
664    untracked backend/.env.test                        34
664    untracked .env.vps                                 27
664    untracked config/vector/.env.vector                 7
664    untracked frontend/.env                             6
664    untracked .env                                      3
```

### Sévérité réelle — mesurée, pas supposée

La chaîne de répertoires **est** traversable par tous, donc 664 expose réellement :

```
drwxr-xr-x root:root      /opt
drwxr-xr-x deploy:deploy  /opt/automecanik/app
drwxrwxr-x deploy:deploy  /opt/automecanik/app/backend
```

**Mais** `deploy` est le seul compte humain et le groupe `deploy` n'a aucun autre membre :

```
$ awk -F: '$3>=1000 && $3<65534 {print $1}' /etc/passwd  ->  deploy
$ getent group deploy                                    ->  deploy:x:1001:   (liste vide)
```

Risque pratique aujourd'hui **faible** ; risque réel : un futur compte de service, ou un processus
non privilégié compromis, lit des identifiants de production vivants.

## Cause racine — pas le mode, l'umask

```
$ umask                                   -> 0002
$ grep Umask /proc/<backend pid>/status   -> Umask: 0002     (aussi sur les process longs)
```

Il ne vient d'aucun fichier de login (`~/.profile` n'a qu'un `#umask 022` **commenté**), mais de PAM :

```
/etc/pam.d/common-session:26   session optional  pam_umask.so
/etc/login.defs:151            UMASK           022
/etc/login.defs:230            USERGROUPS_ENAB yes
$ id -gn deploy                -> deploy      (groupe primaire = nom d'utilisateur)
```

La règle usergroups aligne les bits groupe sur ceux du propriétaire : `022` → `002`, donc
`0666 & ~002 = 0664` — exactement le mode observé **partout**.

→ **`chmod 600` seul est un correctif de symptôme** : le prochain `cp`, la prochaine sauvegarde
d'éditeur, le prochain script qui réécrit un `.env` recrée du 664.

## Correction

**1. Modes (fait sur la machine)** — `chmod 600` sur les **8** fichiers hors zone paiement.
`backend/.env.paybox-test-keys` **délibérément laissé en 664** : zone paiement, accord owner requis
(invariant 9). Mesuré, non modifié.

Non-régression vérifiée — tout tourne sous `deploy`, propriétaire des fichiers :

```
$ node -e "fs.readFileSync('/opt/automecanik/app/backend/.env','utf8')"
  read OK, 296 lines — 600 does NOT block the owner
$ docker inspect (tous les conteneurs) | grep automecanik/app
  aucun bind-mount du repo -> aucun autre uid n'a besoin de ces fichiers
```

**2. Récidive (fait dans le dépôt)** — 7e axe `check_env_file_permissions()` dans
`scripts/ops/sync-dev-runtime.sh` (cron 10 min).

Deux choix délibérés :

- **Aucun `chmod` automatique** — il masquerait *ce qui* recrée le 664, donc la cause ; et le script
  ne doit jamais toucher au fichier Paybox, même « pour améliorer ses droits ».
- **Périmètre = fichiers non suivis par git** — les `*.example` / `*.template` suivis restent en 664,
  ils sont publics.

**3. Umask système — NON modifié, décision owner.** Le seul levier correct
(`login.defs UMASK 022 → 027`) impacte **tout ce que la machine écrit**, arbre de build npm/turbo
inclus. Disproportionné ici ; le 7e axe couvre le besoin sans y toucher.

## Preuve APRÈS

Après le `chmod`, le garde ne signale **que** le fichier volontairement laissé :

```
ALERT> fichiers d'environnement trop permissifs (attendu 600) : backend/.env.paybox-test-keys:664
       — corriger: chmod 600 <fichier>. Cause récurrente = umask 0002 (...).
       NE PAS chmod backend/.env.paybox-test-keys sans accord owner (zone paiement).
-> return=1  alerts=1
```

Contrôle — on desserre un fichier hors zone paiement, il l'attrape ; puis restauré :

```
$ chmod 664 frontend/.env
ALERT> ... : backend/.env.paybox-test-keys:664 frontend/.env:664
$ chmod 600 frontend/.env
```

## Reste à l'owner

1. **`chmod 600 backend/.env.paybox-test-keys`** — zone paiement, accord nominatif.
2. **Supprimer `backend/.env.backup-20251104-174224`** — copie de 2026-01-30 portant l'intégralité
   des identifiants de paiement de production (noms de clés vérifiés, valeurs jamais affichées),
   plus `SESSION_SECRET` et `SUPABASE_SERVICE_ROLE_KEY`. Non supprimé ici : zone paiement, et le
   fichier est non suivi — aucune récupération depuis git.

## Trouvé en chemin, bien plus grave — traité séparément

`backend/.env.test.template` est **suivi par git, dans `origin/main`, dépôt GitHub PUBLIC**, et
contient **9 secrets byte-identiques à des valeurs vivantes** (comparaison SHA-256, valeurs jamais
affichées). Le 664 est un défaut local ; **ceci est une publication**. Rotation = action owner.

> **Note de merge** : touche le même fichier que #1424 (6e axe) — à rebaser sur elle.

Détail : `audit/env-file-permissions-2026-09-09.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)