### PR TITLE
chore(registry): resync des projections L1+L3 (catch-up #1418 + #1422)

### DIFF
--- a/.claude/knowledge/REPO_MAP.md
+++ b/.claude/knowledge/REPO_MAP.md
@@ -3,7 +3,7 @@ title: Repository Map
 kind: registry-index
 generated_at: "1970-01-01T00:00:00.000Z"
 source: audit/registry/canonical.json
-source_sha256: 339b0135524be63cc61225ce3f0895dbc51cae076e11bb7f589708eb493daf38
+source_sha256: 40d2f9c2f8e6a3dace985293574fc8dcbc2461ddae3840656ed2a6380313a9a7
 schema_version: "1.0.0"
 do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-058 PR-F)
 ---
@@ -18,13 +18,13 @@ do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-
 
 | Layer | Count |
 |---|---|
-| Files (Layer 1) | 2837 |
+| Files (Layer 1) | 2839 |
 | DB tables (Layer 1) | 307 |
 | DB RPC (Layer 1) | 259 |
 | Dependencies (Layer 1) | 237 |
 | Runtime entrypoints (Layer 1) | 515 |
 
-Source sotFingerprint: `3e0506607356`.
+Source sotFingerprint: `60e8951e88c3`.
 
 ## Comment l'utiliser
 
@@ -132,10 +132,10 @@ Source sotFingerprint: `3e0506607356`.
 
 ### D13 — Config & System
 
-- **Files**: 190 (service=70, config=52, script=50, test=18)
+- **Files**: 192 (service=70, config=53, script=50, test=19)
 - **Runtime entrypoints**: 5
-- **Top owners**: @ak125 (190)
-- **Status**: LIVE=80, UNKNOWN=110
+- **Top owners**: @ak125 (192)
+- **Status**: LIVE=81, UNKNOWN=111
 
 ### D14 — Gamme Aggregates & V-Level
 

--- a/audit/db-usage-map.json
+++ b/audit/db-usage-map.json
@@ -17,7 +17,7 @@
     "dynamic_from_callsites": 897,
     "dynamic_rpc_callsites": 1,
     "migrations_scanned": 345,
-    "backend_files_scanned": 1377
+    "backend_files_scanned": 1379
   },
   "tables": {
     "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7": {

--- a/audit/module-boundaries.json
+++ b/audit/module-boundaries.json
@@ -53,7 +53,7 @@
         "backend/src/modules/analytics/services"
       ],
       "files_count": 8,
-      "loc_total": 1525,
+      "loc_total": 1530,
       "has_barrel": false
     },
     "api": {
@@ -91,7 +91,7 @@
         "backend/src/utils"
       ],
       "files_count": 35,
-      "loc_total": 6156,
+      "loc_total": 6132,
       "has_barrel": true
     },
     "blog": {
@@ -185,8 +185,8 @@
         "backend/src/modules/config/services",
         "backend/src/modules/config/validators"
       ],
-      "files_count": 96,
-      "loc_total": 23947,
+      "files_count": 98,
+      "loc_total": 24121,
       "has_barrel": true
     },
     "customers": {
@@ -804,7 +804,7 @@
         "backend/src/modules/seo-monitoring/services"
       ],
       "files_count": 38,
-      "loc_total": 7116,
+      "loc_total": 7129,
       "has_barrel": false
     },
     "seo-projection": {
@@ -1257,7 +1257,7 @@
     {
       "from": "backend-core",
       "to": "config",
-      "count": 8
+      "count": 9
     },
     {
       "from": "backend-core",
@@ -1587,6 +1587,11 @@
     {
       "from": "config",
       "to": "backend-core",
+      "count": 1
+    },
+    {
+      "from": "config",
+      "to": "common",
       "count": 1
     },
     {

--- a/audit/registry/canonical.json
+++ b/audit/registry/canonical.json
@@ -28045,6 +28045,7 @@
         "backend/src/common/guards/cloudflare-throttler.guard.ts",
         "backend/src/config/feature-flags.module.ts",
         "backend/src/config/logger.config.ts",
+        "backend/src/config/throttler-tiers.config.ts",
         "backend/src/config/write-guard.module.ts",
         "backend/src/controllers/analytics.controller.ts",
         "backend/src/database/database.module.ts",
@@ -28106,7 +28107,7 @@
         "backend/src/workers/worker.module.ts"
       ],
       "kind": "service",
-      "loc": 297,
+      "loc": 273,
       "owner": "__unassigned__",
       "path": "backend/src/app.module.ts",
       "risk": "low",
@@ -29723,7 +29724,8 @@
       "id": "backend/src/common/guards/cloudflare-throttler.guard.ts",
       "importedBy": [
         "backend/src/app.module.ts",
-        "backend/src/common/guards/cloudflare-throttler.guard.test.ts"
+        "backend/src/common/guards/cloudflare-throttler.guard.test.ts",
+        "backend/src/config/throttler-tiers.config.test.ts"
       ],
       "imports": [],
       "kind": "service",
@@ -32434,6 +32436,53 @@
       "loc": 37,
       "owner": "@ak125",
       "path": "backend/src/config/source-provenance.constants.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "LIVE"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual"
+      ],
+      "domain": "D13",
+      "id": "backend/src/config/throttler-tiers.config.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/common/guards/cloudflare-throttler.guard.ts",
+        "backend/src/config/throttler-tiers.config.ts"
+      ],
+      "kind": "test",
+      "loc": 110,
+      "owner": "@ak125",
+      "path": "backend/src/config/throttler-tiers.config.test.ts",
+      "risk": "medium",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "manual",
+        "reachability"
+      ],
+      "domain": "D13",
+      "id": "backend/src/config/throttler-tiers.config.ts",
+      "importedBy": [
+        "backend/src/app.module.ts",
+        "backend/src/config/throttler-tiers.config.test.ts"
+      ],
+      "imports": [],
+      "kind": "config",
+      "loc": 64,
+      "owner": "@ak125",
+      "path": "backend/src/config/throttler-tiers.config.ts",
       "risk": "medium",
       "runtime": false,
       "schemaVersion": "1.0.0",
@@ -38048,7 +38097,7 @@
         "backend/src/modules/analytics/landing-source.classifier.ts"
       ],
       "kind": "controller",
-      "loc": 157,
+      "loc": 162,
       "owner": "@ak125",
       "path": "backend/src/modules/analytics/controllers/landing-attribution.controller.ts",
       "risk": "medium",
@@ -52156,7 +52205,7 @@
         "backend/src/modules/seo-monitoring/services/cwv-beacon.service.ts"
       ],
       "kind": "controller",
-      "loc": 69,
+      "loc": 76,
       "owner": "@ak125/seo-team",
       "path": "backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts",
       "risk": "medium",
@@ -52259,7 +52308,7 @@
         "backend/src/modules/seo-monitoring/services/runtime-events.service.ts"
       ],
       "kind": "controller",
-      "loc": 70,
+      "loc": 76,
       "owner": "@ak125/seo-team",
       "path": "backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts",
       "risk": "medium",
@@ -98249,11 +98298,11 @@
       ".spec/00-canon/repository-registry/status-overrides.yaml": "6acccd32de6d9c15b47621ab22d9f2d3e34861ea8b6b1a3cd559f68a9fa32e02",
       "audit/registry/db.json": "c874feb59f5d00601c29a139560da9ecd2d63678eea0eddc4bb4fbd8d79672d1",
       "audit/registry/deps.json": "6f667991be593e37b2798c4ca0f0689d89c412731aa2bdf50000248da9f2c5bd",
-      "audit/registry/files.json": "2cde5d2ed3ec6a07c7d70e868d317a25255cf6688d3bc8f1bad062d4dd0d451e",
+      "audit/registry/files.json": "f92ed7e5f12fa525e51b6b73d1eca1bc30ef50778a8dfd0ea7aae6e1068c7f11",
       "audit/registry/rpc.json": "59d3bb0e2b79c240fb14ec32e3adab2b269fe5a69a3c721ab762128504f4f980",
       "audit/registry/runtime.json": "314a3bda98e2b9bb87a4b6a88a1efa131a3c12505d9e56b5f60eeebd23e5f70f"
     },
-    "sotFingerprint": "3e0506607356"
+    "sotFingerprint": "60e8951e88c3"
   },
   "runtime": [
     {

--- a/audit/registry/files.json
+++ b/audit/registry/files.json
@@ -716,6 +716,7 @@
         "backend/src/common/guards/cloudflare-throttler.guard.ts",
         "backend/src/config/feature-flags.module.ts",
         "backend/src/config/logger.config.ts",
+        "backend/src/config/throttler-tiers.config.ts",
         "backend/src/config/write-guard.module.ts",
         "backend/src/controllers/analytics.controller.ts",
         "backend/src/database/database.module.ts",
@@ -777,7 +778,7 @@
         "backend/src/workers/worker.module.ts"
       ],
       "kind": "service",
-      "loc": 297,
+      "loc": 273,
       "owner": "__unassigned__",
       "path": "backend/src/app.module.ts",
       "risk": "low",
@@ -2343,7 +2344,8 @@
       "id": "backend/src/common/guards/cloudflare-throttler.guard.ts",
       "importedBy": [
         "backend/src/app.module.ts",
-        "backend/src/common/guards/cloudflare-throttler.guard.test.ts"
+        "backend/src/common/guards/cloudflare-throttler.guard.test.ts",
+        "backend/src/config/throttler-tiers.config.test.ts"
       ],
       "imports": [],
       "kind": "service",
@@ -4957,6 +4959,51 @@
       "loc": 37,
       "owner": "__unassigned__",
       "path": "backend/src/config/source-provenance.constants.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "LIVE"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise"
+      ],
+      "domain": "UNKNOWN",
+      "id": "backend/src/config/throttler-tiers.config.test.ts",
+      "importedBy": [],
+      "imports": [
+        "backend/src/common/guards/cloudflare-throttler.guard.ts",
+        "backend/src/config/throttler-tiers.config.ts"
+      ],
+      "kind": "test",
+      "loc": 110,
+      "owner": "__unassigned__",
+      "path": "backend/src/config/throttler-tiers.config.test.ts",
+      "risk": "low",
+      "runtime": false,
+      "schemaVersion": "1.0.0",
+      "sourceConfidence": "medium",
+      "status": "UNKNOWN"
+    },
+    {
+      "deletePolicy": "FREE",
+      "derivedFrom": [
+        "depcruise",
+        "reachability"
+      ],
+      "domain": "UNKNOWN",
+      "id": "backend/src/config/throttler-tiers.config.ts",
+      "importedBy": [
+        "backend/src/app.module.ts",
+        "backend/src/config/throttler-tiers.config.test.ts"
+      ],
+      "imports": [],
+      "kind": "config",
+      "loc": 64,
+      "owner": "__unassigned__",
+      "path": "backend/src/config/throttler-tiers.config.ts",
       "risk": "low",
       "runtime": false,
       "schemaVersion": "1.0.0",
@@ -10387,7 +10434,7 @@
         "backend/src/modules/analytics/landing-source.classifier.ts"
       ],
       "kind": "controller",
-      "loc": 157,
+      "loc": 162,
       "owner": "__unassigned__",
       "path": "backend/src/modules/analytics/controllers/landing-attribution.controller.ts",
       "risk": "low",
@@ -24039,7 +24086,7 @@
         "backend/src/modules/seo-monitoring/services/cwv-beacon.service.ts"
       ],
       "kind": "controller",
-      "loc": 69,
+      "loc": 76,
       "owner": "__unassigned__",
       "path": "backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts",
       "risk": "low",
@@ -24138,7 +24185,7 @@
         "backend/src/modules/seo-monitoring/services/runtime-events.service.ts"
       ],
       "kind": "controller",
-      "loc": 70,
+      "loc": 76,
       "owner": "__unassigned__",
       "path": "backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts",
       "risk": "low",

--- a/audit/runtime-entrypoints.json
+++ b/audit/runtime-entrypoints.json
@@ -2791,6 +2791,7 @@
       ".github/workflows/spec-validation.yml",
       ".github/workflows/stale.yml",
       ".github/workflows/tecdoc-api-surface-guard.yml",
+      ".github/workflows/tecdoc-failclosed-guard.yml",
       ".github/workflows/validator-dev-safety-observe.yml",
       ".github/workflows/vault-canon-exists.yml",
       ".github/workflows/visual-gate.yml",
@@ -2891,7 +2892,7 @@
       "tests/registry/rpc-parser.test.ts"
     ]
   },
-  "runtime_files_count": 1503,
+  "runtime_files_count": 1504,
   "runtime_files": [
     ".claude/knowledge/REPO_MAP.md",
     ".dependency-cruiser.cjs",
@@ -2957,6 +2958,7 @@
     ".github/workflows/spec-validation.yml",
     ".github/workflows/stale.yml",
     ".github/workflows/tecdoc-api-surface-guard.yml",
+    ".github/workflows/tecdoc-failclosed-guard.yml",
     ".github/workflows/validator-dev-safety-observe.yml",
     ".github/workflows/vault-canon-exists.yml",
     ".github/workflows/visual-gate.yml",


### PR DESCRIPTION
## Ce que ça répare

Le gate `registry-fresh` (warn-only, Phase 1) signalait deux dérives cumulées :

- `.github/workflows/tecdoc-failclosed-guard.yml`, nouvel entrypoint runtime laissé par #1418 ;
- les 2 fichiers ajoutés par #1422 (`backend/src/config/throttler-tiers.config.ts` et son test), absents de `files.json` / `canonical.json`.

Ses deux steps en échec disaient exactement quoi faire : `npm run audit:inventory` puis `npm run registry:heal` (depuis Linux).

## Pourquoi régénérer depuis DEV aurait été un piège

Régénérer depuis le checkout `/opt/automecanik/app` produisait **744 lignes** de churn :

```
- "@repo/database-types"
+ "../../../packages/database-types/dist/index.d.ts"
```

`build-deep-inventory.js` passe par **dependency-cruiser** et retient `dep.resolved` : le specifier reste `@repo/*` quand le workspace n'est pas bâti, et devient un chemin `dist/` quand il l'est. Sur DEV les workspaces sont bâtis ; sur le runner CI non — `registry-fresh.yml` fait `npm ci` (`:96`) puis `audit:inventory` (`:186`) et `registry` (`:253`), **sans aucun step de build**. L'artefact commité ne porte d'ailleurs que la forme `@repo/*` (0 occurrence de `dist/index.d.ts`), et le gate passe sur `main`.

Committer la forme résolue n'aurait donc rien réparé — la CI aurait rediffé au prochain run — et aurait figé la résolution d'une seule machine dans une projection partagée. C'est le piège documenté par la mémoire `reference_registry_l1_files_builder_is_environment_sensitive`.

## Comment ces commits ont été produits

Clone isolé, `npm ci` **sans build** (aucun `prepare`/`postinstall` dans les 12 workspaces — vérifié), donc l'environnement exact du runner :

```
packages buildés après npm ci ? NON (attendu — comme la CI)
backend_files_scanned : 1379
GARDE churn dist/index.d.ts : 0
```

Les projections `audit/registry/*.json` sont passées par `npm run registry:heal`, seul chemin accepté par `scripts/registry/check-no-manual-edit-generated.sh` : ce garde exige à la fois la provenance (`npm_lifecycle_event` ~ `^registry:`) **et** la reproductibilité du hash. Une première tentative en `npm run registry` + `git add` séparé a été refusée par le hook — à raison.

## Diff

129 insertions / 26 suppressions, toutes traçables :

| Changement | Origine |
|---|---|
| `files_count` 96 → 98 | les 2 fichiers de #1422 |
| arête de module `config → common` | `throttler-tiers.config.test.ts` importe le guard |
| `loc` d'`app.module.ts` 297 → 273 | array de tiers extrait vers `config/` |
| entrypoint runtime ajouté | `tecdoc-failclosed-guard.yml` (#1418) |

À comparer aux 569/489 lignes qu'aurait produites une régénération depuis DEV.

## Vérification

- `git diff origin/main..HEAD -- audit/registry/ | grep -c 'dist/index\.d\.ts'` → **0**
- Working tree propre après les deux commits
- Aucun fichier hors `audit/` et `.claude/knowledge/REPO_MAP.md` touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)